### PR TITLE
Fix subscriber schema URL in registry setup

### DIFF
--- a/docs/implementation-guides/v2/EV_Charging_V0.8-draft.md
+++ b/docs/implementation-guides/v2/EV_Charging_V0.8-draft.md
@@ -108,7 +108,7 @@ All NPs (BAPs, BPPs, CDS’es) **MUST** register as a user on dedi.global and cl
 
 #### 10.1.1.2 Step 2 :  Setting up a Registry
 
-Once the namespace is claimed, each NP **MUST** create a Beckn NP registry in the namespace to list their subscriber details. While creating the registry, the user **MUST** configure it with the [subscriber schema](https://gist.githubusercontent.com/nirmalnr/a6e5b17522169ecea4f3ccdd831af7e4/raw/b7cf8a47e6531ef22744b43e6305b8d8cc106e7b/beckn-subscriber-no-refs.schema.json). 
+Once the namespace is claimed, each NP **MUST** create a Beckn NP registry in the namespace to list their subscriber details. While creating the registry, the user **MUST** configure it with the [subscriber schema](https://gist.githubusercontent.com/nirmalnr/a6e5b17522169ecea4f3ccdd831af7e4/raw/7744f2542034db9675901b61b41c8228ea239074/beckn-subscriber-no-refs.schema.json). 
 
 #### 10.1.1.3 Step 3 :  Publishing subscriber details
 


### PR DESCRIPTION
Updated the subscriber schema URL in the registry setup instructions to replace location object with countries array.