### PR TITLE
Issue 155 improve inter-discom p2p sequence diagrams

### DIFF
--- a/docs/implementation-guides/v2/P2P_Trading/Inter_energy_retailer_P2P_trading_draft.md
+++ b/docs/implementation-guides/v2/P2P_Trading/Inter_energy_retailer_P2P_trading_draft.md
@@ -567,7 +567,9 @@ When a prosumer has multiple trades within the same delivery window, actual mete
 | T2 | 9:30 AM | 2–4 PM | 4 kWh | — | 3 kWh |
 | **Total** | — | — | 9 kWh | **8 kWh** | 8 kWh |
 
-*P1 contracted 9 kWh across two trades but only injected 8 kWh. T1 (earlier trade) gets full 5 kWh; T2 gets remaining 3 kWh. T2 buyer may claim shortfall penalty.*
+*P1 contracted 9 kWh across two trades but only injected 8 kWh. T1 (earlier trade) gets full 5 kWh; T2 gets remaining 3 kWh.*
+
+A more detailed multi-party, multi-epoch example is worked out in a table [here](https://docs.google.com/spreadsheets/d/1ZXdvUnLshdOmiaqJJQuONigPK_KnTZ3Pq8aiLWYClaA/edit?usp=sharing).
 
 ---
 


### PR DESCRIPTION
Closes #155 

Improve the sequence flows in [this inter-utility p2p trading guide](https://github.com/Beckn-One/DEG/blob/266c5bdd3cfc276c0665cbb9493e2057cfed4c54/docs/implementation-guides/v2/P2P_Trading/Inter_energy_retailer_P2P_trading_draft.md) which matches the collective revised understanding. Main changes and expandable screenshots are below:
- Trade exchange maintaining a ledger of (Discom A, Discom B, seller, buyer, Trade Time, Delivery Start/End,Trade Qty, allocated Actual pushed, allocated Actual pulled Qty)  Note that allocation is needed for multiple overlapping trades.
  <details><summary>Click to see details</summary>
  <img width="1089" height="314" alt="image" src="https://github.com/user-attachments/assets/cbd05bac-4d79-48ab-bbb2-99978e4484db" />
  </details>

- For overlapping trades, FIFO logic to allocate actual push to trades, and final trade quantity recognized as min(trade Qty, actual pushed Qty) or some other rules.
  <details><summary>Click to see details</summary>
  <img width="1177" height="520" alt="image" src="https://github.com/user-attachments/assets/9b86f412-1080-49ac-818e-992e404fff16" />
  </details>

- Improved flow of revenue from final p2p trades -> billing -> remittance of wheeling charges.
  <details><summary>Click to see details</summary>
  <img width="1007" height="246" alt="image" src="https://github.com/user-attachments/assets/28375ece-a48c-453f-bd00-b984f02d40b5" />
  </details>
