### PR TITLE
Add .gitignore rules for OS artifacts, IDE config, env files, and Python cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,18 @@
 validator.sh
 api/l2.yaml
+
+# OS artifacts
+.DS_Store
+
+# IDE / Claude Code
+.claude/
+CLAUDE.md
+
+# Environment files
+.env
+*.env
+!example.env
+
+# Python
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

- Add `.DS_Store` to prevent macOS Finder metadata from being committed
- Add `.claude/` and `CLAUDE.md` to prevent Claude Code IDE config from being committed
- Add `.env`, `*.env` (with `!example.env` exception) to prevent secrets/credentials
- Add `__pycache__/` and `*.pyc` to prevent Python bytecode cache

No tracked files need removal — these patterns only existed on feature branches and were not yet on main.

## Changes

`.gitignore` additions:
```
# OS artifacts
.DS_Store

# IDE / Claude Code
.claude/
CLAUDE.md

# Environment files
.env
*.env
!example.env

# Python
__pycache__/
*.pyc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)