### PR TITLE
fix(devkits-data-exchange):Change discover-request method from POST to GET

### DIFF
--- a/devkits/data-exchange/usecase1/postman/data-exchange-usecase1.BAP-DEG.postman_collection.json
+++ b/devkits/data-exchange/usecase1/postman/data-exchange-usecase1.BAP-DEG.postman_collection.json
@@ -76,7 +76,7 @@
         {
           "name": "discover-request",
           "request": {
-            "method": "POST",
+            "method": "GET",
             "header": [],
             "body": {
               "mode": "raw",

--- a/devkits/data-exchange/usecase2/postman/data-exchange-usecase2.BAP-DEG.postman_collection.json
+++ b/devkits/data-exchange/usecase2/postman/data-exchange-usecase2.BAP-DEG.postman_collection.json
@@ -76,7 +76,7 @@
         {
           "name": "discover-request",
           "request": {
-            "method": "POST",
+            "method": "GET",
             "header": [],
             "body": {
               "mode": "raw",


### PR DESCRIPTION
In the 2 postman requests the POST method was changed to GET as the response needs to be synchronous when running locally.