### PR TITLE
fix: filter out TEST discoms from trade report

### DIFF
--- a/devkits/p2p-trading-interdiscom/deg-ledger-ui-kit/discom_trade_report.py
+++ b/devkits/p2p-trading-interdiscom/deg-ledger-ui-kit/discom_trade_report.py
@@ -153,6 +153,8 @@ def generate_report():
     for trade in all_trades:
         buyer_discom = trade.get("discomIdBuyer", "")
         seller_discom = trade.get("discomIdSeller", "")
+        if buyer_discom.startswith("TEST") or seller_discom.startswith("TEST"):
+            continue
         sort_key, display_day = _delivery_date_key(trade)
 
         # Buyer side


### PR DESCRIPTION
## Summary
- Skips trades where buyer or seller discom ID starts with "TEST" when generating the discom trade report
- Prevents test data from polluting production report output

## Test plan
- [x] Run `discom_trade_report.py` with trades containing TEST discom IDs and verify they are excluded
- [x] Confirm real trades still appear correctly in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)