### PR TITLE
fix: Disabled Policy Rule P3b Still Active in Code

### DIFF
--- a/specification/policies/p2p-trading-interdiscom.rego
+++ b/specification/policies/p2p-trading-interdiscom.rego
@@ -68,6 +68,7 @@ import rego.v1
 #
 # Config:
 #   data.config.minDeliveryLeadHours  - minimum hours of lead time (default: 4)
+#   data.config.validateDeliverySlotDuration - enforce exactly 1 hour slot (default: false)
 
 default min_lead_hours := 4
 
@@ -76,6 +77,12 @@ min_lead_hours := to_number(data.config.minDeliveryLeadHours) if {
 }
 
 ns_per_hour := 1000 * 1000 * 1000 * 60 * 60
+
+default validate_delivery_slot_duration := false
+
+validate_delivery_slot_duration := true if {
+	data.config.validateDeliverySlotDuration == true
+}
 
 # Parse the trade timestamp from context
 trade_time := time.parse_rfc3339_ns(input.context.timestamp)
@@ -175,6 +182,8 @@ _order_violations contains msg if {
 
 # Rule 3 – Delivery window must be exactly 1 hour
 _order_violations contains msg if {
+	validate_delivery_slot_duration
+
 	item := input.message.order["beckn:orderItems"][i]
 	offer_attrs := item["beckn:acceptedOffer"]["beckn:offerAttributes"]
 
@@ -679,6 +688,8 @@ _publish_violations contains msg if {
 
 # Publish Rule 5b — Delivery window must be exactly 1 hour (mirrors O3)
 _publish_violations contains msg if {
+	validate_delivery_slot_duration
+
 	offer := input.message.catalogs[_]["beckn:offers"][j]
 	offer_attrs := offer["beckn:offerAttributes"]
 

--- a/specification/policies/p2p-trading-interdiscom_test.rego
+++ b/specification/policies/p2p-trading-interdiscom_test.rego
@@ -101,3 +101,67 @@ test_t1_mixed_buyer_utility_fail if {
 	contains(msg, "buyer utilityId")
 	contains(msg, "TEST_DISCOM_BUYER")
 }
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Delivery slot duration toggle (O3 / P3b)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_input_order_duration_two_hours := {
+	"context": {
+		"version": "2.0.0",
+		"action": "confirm",
+		"timestamp": "2024-10-04T10:00:00Z",
+		"domain": "beckn.one:deg:p2p-trading-interdiscom:2.0.0",
+	},
+	"message": {"order": {
+		"beckn:orderItems": [{
+			"beckn:acceptedOffer": {"beckn:offerAttributes": {
+				"deliveryWindow": {
+					"schema:startTime": "2024-10-04T14:00:00Z",
+					"schema:endTime": "2024-10-04T16:00:00Z",
+				},
+			}},
+		}],
+	}},
+}
+
+_input_publish_duration_half_hour := {
+	"context": {
+		"version": "2.0.0",
+		"action": "catalog_publish",
+		"timestamp": "2024-10-04T10:00:00Z",
+		"domain": "beckn.one:deg:p2p-trading-interdiscom:2.0.0",
+	},
+	"message": {
+		"catalogs": [{
+			"beckn:offers": [{
+				"beckn:offerAttributes": {
+					"deliveryWindow": {
+						"schema:startTime": "2024-10-04T10:00:00Z",
+						"schema:endTime": "2024-10-04T10:30:00Z",
+					},
+				},
+			}],
+		}],
+	},
+}
+
+test_delivery_slot_duration_disabled_by_default_order if {
+	not some msg in _order_violations with input as _input_order_duration_two_hours
+	contains(msg, "delivery window (")
+}
+
+test_delivery_slot_duration_disabled_by_default_publish if {
+	not some msg in _publish_violations with input as _input_publish_duration_half_hour
+	contains(msg, "delivery window (")
+}
+
+test_delivery_slot_duration_enabled_order if {
+	some msg in _order_violations with input as _input_order_duration_two_hours with data.config as {"validateDeliverySlotDuration": true}
+	contains(msg, "must be exactly 1 hour")
+}
+
+test_delivery_slot_duration_enabled_publish if {
+	some msg in _publish_violations with input as _input_publish_duration_half_hour with data.config as {"validateDeliverySlotDuration": true}
+	contains(msg, "must be exactly 1 hour")
+}


### PR DESCRIPTION
## Summary

This PR fixes the mismatch reported in [#249](https://github.com/beckn/DEG/issues/249), where delivery slot duration validation was marked as disabled in comments but still executed in policy code.

### What changed

- Added a configuration toggle in `specification/policies/p2p-trading-interdiscom.rego`:
  - `data.config.validateDeliverySlotDuration`
- Set default behavior to disabled:
  - `validateDeliverySlotDuration = false`
- Gated both duration rules behind this toggle:
  - Order-side duration check (O3 mirror)
  - Publish-side duration check (P3b mirror)

### Tests added

Updated `specification/policies/p2p-trading-interdiscom_test.rego` with regression tests to verify:

- non-1-hour order duration does **not** fail when config is unset/default
- non-1-hour publish duration does **not** fail when config is unset/default
- both checks **do fail** when `validateDeliverySlotDuration: true`

## Why this change

The policy comments explicitly state P3b is disabled, but the previous implementation still enforced exact 1-hour duration. This PR aligns runtime behavior with documented intent while preserving a safe path to re-enable strict validation via config.

## Backward compatibility

- **Default behavior changes:** exact 1-hour slot validation is now **off** unless explicitly enabled.
- To restore prior strict behavior, set:

```yaml
config:
  validateDeliverySlotDuration: true