### PR TITLE
devkits/demand-flex: wire opapolicychecker and migrate to allowedNetworkIDs

### DIFF
--- a/devkits/demand-flex/README.md
+++ b/devkits/demand-flex/README.md
@@ -29,7 +29,9 @@ For the shared stack topology, prerequisites, Quick Start, transaction flow, hos
 
 ## Policy Enforcement
 
-Uses OPA (Open Policy Agent) via the `opapolicychecker` plugin. Current policy is loaded from the `becknv2-demand-flex` branch of this repo — replace the `location` URL in the config with a stable policy reference as network rules mature.
+Uses OPA (Open Policy Agent) via the `opapolicychecker` plugin. Policies are declared in [`config/opa-network-policies.yaml`](./config/opa-network-policies.yaml) and loaded from [`policies/demand_flex_network.rego`](./policies/demand_flex_network.rego) (a no-op placeholder that mirrors [`specification/policies/demand_flex_network.rego`](../../specification/policies/demand_flex_network.rego)). Both BAP and BPP use a single `default:` entry — every message evaluates against the same rules regardless of `context.networkId`. Add per-networkId entries to `opa-network-policies.yaml` as the demand-flex network matures.
+
+Signature/registry lookups currently target `nfh.global/testnet-deg` via the `allowedNetworkIDs` key on the `dediregistry` plugin. Subscriber IDs are placeholders (`bap.example.com` / `bpp.example.com`) with signing keys borrowed from the p2p-trading devkit, so arazzo flows will NACK on lookup until real subscribers are registered on testnet-deg.
 
 ## Related
 

--- a/devkits/demand-flex/config/local-demand-flex-bap.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bap.yaml
@@ -33,13 +33,18 @@ modules:
           config:
             url: https://api.dev.beckn.io/registry/dedi
             registryName: subscribers.beckn.one
-            allowedParentNamespaces: "IES,IES-DISCOMS"
+            # Placeholder until the demand-flex network is stood up on
+            # testnet-deg and arazzo flows stop NACKing on lookup.
+            allowedNetworkIDs: "nfh.global/testnet-deg"
             timeout: 10
         keyManager:
           id: simplekeymanager
           config:
-            # Reusing signing keys from p2p-trading devkit
-            networkParticipant: p2p-trading-sandbox1.com
+            # Placeholder subscriber for the demand-flex devkit. Signing
+            # keys are reused from p2p-trading-sandbox1.com, so DeDi
+            # lookup for bap.example.com will NACK until this BAP is
+            # registered on testnet-deg with its own key material.
+            networkParticipant: bap.example.com
             keyId: 76EU8aUqHouww7gawT6EibH4bseMCumyDv3sgyXSKENGk8NDcdVwmQ
             signingPrivateKey: Pc6dkYo5LeP0LkwvZXVRV9pcbeh8jDdtdHWymID5cjw=
             signingPublicKey: KVYEWkQB2WwnttVMWfy7KrnqiD51ZDvi8vfCac2IwRE=
@@ -59,10 +64,8 @@ modules:
         checkPolicy:
           id: opapolicychecker
           config:
-            type: url
-            location: "https://raw.githubusercontent.com/beckn/DEG/refs/heads/becknv2-demand-flex/specification/policies/demand_flex_network.rego"
-            query: "data.deg.policy.demand_flex_network.violations"
-            refreshIntervalSeconds: "300"
+            networkPolicyConfig: ./config/opa-network-policies.yaml
+            refreshInterval: "5m"
         cache:
           id: cache
           config:
@@ -100,12 +103,14 @@ modules:
           config:
             url: https://api.dev.beckn.io/registry/dedi
             registryName: subscribers.beckn.one
-            allowedParentNamespaces: "IES,IES-DISCOMS"
+            # Placeholder until the demand-flex network is stood up on
+            # testnet-deg and arazzo flows stop NACKing on lookup.
+            allowedNetworkIDs: "nfh.global/testnet-deg"
             timeout: 10
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: p2p-trading-sandbox1.com
+            networkParticipant: bap.example.com
             keyId: 76EU8aUqHouww7gawT6EibH4bseMCumyDv3sgyXSKENGk8NDcdVwmQ
             signingPrivateKey: Pc6dkYo5LeP0LkwvZXVRV9pcbeh8jDdtdHWymID5cjw=
             signingPublicKey: KVYEWkQB2WwnttVMWfy7KrnqiD51ZDvi8vfCac2IwRE=
@@ -125,10 +130,8 @@ modules:
         checkPolicy:
           id: opapolicychecker
           config:
-            type: url
-            location: "https://raw.githubusercontent.com/beckn/DEG/refs/heads/becknv2-demand-flex/specification/policies/demand_flex_network.rego"
-            query: "data.deg.policy.demand_flex_network.violations"
-            refreshIntervalSeconds: "300"
+            networkPolicyConfig: ./config/opa-network-policies.yaml
+            refreshInterval: "5m"
         cache:
           id: cache
           config:

--- a/devkits/demand-flex/config/local-demand-flex-bpp.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bpp.yaml
@@ -33,13 +33,18 @@ modules:
           config:
             url: https://api.dev.beckn.io/registry/dedi
             registryName: subscribers.beckn.one
-            allowedParentNamespaces: "IES,IES-DISCOMS"
+            # Placeholder until the demand-flex network is stood up on
+            # testnet-deg and arazzo flows stop NACKing on lookup.
+            allowedNetworkIDs: "nfh.global/testnet-deg"
             timeout: 10
         keyManager:
           id: simplekeymanager
           config:
-            # Reusing signing keys from p2p-trading devkit (BPP keys)
-            networkParticipant: p2p-trading-sandbox2.com
+            # Placeholder subscriber for the demand-flex devkit. Signing
+            # keys are reused from p2p-trading-sandbox2.com, so DeDi
+            # lookup for bpp.example.com will NACK until this BPP is
+            # registered on testnet-deg with its own key material.
+            networkParticipant: bpp.example.com
             keyId: 76EU7Mvhh7jaEf7Lcac5R1PPeFL4ddr1ALs2QYzpyTRE8g15Yr1p7C
             signingPrivateKey: AC72WfPu5ly3T7rXfRHrLA/l++BxbsNwe0qitgT9u6U=
             signingPublicKey: E9w4QejjJ6d+VODJlDKJcpI93RY3Bg4RQp4Rs1F9oQ8=
@@ -59,10 +64,8 @@ modules:
         checkPolicy:
           id: opapolicychecker
           config:
-            type: url
-            location: "https://raw.githubusercontent.com/beckn/DEG/refs/heads/becknv2-demand-flex/specification/policies/demand_flex_network.rego"
-            query: "data.deg.policy.demand_flex_network.violations"
-            refreshIntervalSeconds: "300"
+            networkPolicyConfig: ./config/opa-network-policies.yaml
+            refreshInterval: "5m"
         cache:
           id: cache
           config:
@@ -100,12 +103,14 @@ modules:
           config:
             url: https://api.dev.beckn.io/registry/dedi
             registryName: subscribers.beckn.one
-            allowedParentNamespaces: "IES,IES-DISCOMS"
+            # Placeholder until the demand-flex network is stood up on
+            # testnet-deg and arazzo flows stop NACKing on lookup.
+            allowedNetworkIDs: "nfh.global/testnet-deg"
             timeout: 10
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: p2p-trading-sandbox2.com
+            networkParticipant: bpp.example.com
             keyId: 76EU7Mvhh7jaEf7Lcac5R1PPeFL4ddr1ALs2QYzpyTRE8g15Yr1p7C
             signingPrivateKey: AC72WfPu5ly3T7rXfRHrLA/l++BxbsNwe0qitgT9u6U=
             signingPublicKey: E9w4QejjJ6d+VODJlDKJcpI93RY3Bg4RQp4Rs1F9oQ8=
@@ -125,10 +130,8 @@ modules:
         checkPolicy:
           id: opapolicychecker
           config:
-            type: url
-            location: "https://raw.githubusercontent.com/beckn/DEG/refs/heads/becknv2-demand-flex/specification/policies/demand_flex_network.rego"
-            query: "data.deg.policy.demand_flex_network.violations"
-            refreshIntervalSeconds: "300"
+            networkPolicyConfig: ./config/opa-network-policies.yaml
+            refreshInterval: "5m"
         cache:
           id: cache
           config:

--- a/devkits/demand-flex/config/opa-network-policies.yaml
+++ b/devkits/demand-flex/config/opa-network-policies.yaml
@@ -1,0 +1,16 @@
+# OPA policy config consumed by the `opapolicychecker` plugin.
+#
+# Single-policy setup: only `default:` is defined, so every message —
+# regardless of `context.networkId` — is evaluated against the same rego
+# file. Replace with per-network entries (keyed by full networkId such as
+# `nfh.global/testnet-deg`) as the demand-flex network matures and
+# distinct networks need distinct rules.
+#
+# Plugin docs:
+#   https://github.com/beckn/beckn-onix/blob/main/pkg/plugin/implementation/opapolicychecker/README.md
+
+networkPolicies:
+  default:
+    type: file
+    location: ./policies/demand_flex_network.rego
+    query: data.deg.policy.demand_flex_network.violations

--- a/devkits/demand-flex/install/docker-compose.yml
+++ b/devkits/demand-flex/install/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       retries: 5
 
   onix-bap:
-    image: onix-adapter-deg:p2p-multiarch-v7
+    image: fidedocker/onix-adapter-deg:w-deg-plugins-v1
     container_name: onix-bap
     ports:
       - "8081:8081"
@@ -87,7 +87,7 @@ services:
       retries: 5
 
   onix-bpp:
-    image: onix-adapter-deg:p2p-multiarch-v7
+    image: fidedocker/onix-adapter-deg:w-deg-plugins-v1
     container_name: onix-bpp
     ports:
       - "8082:8082"

--- a/devkits/demand-flex/policies/demand_flex_network.rego
+++ b/devkits/demand-flex/policies/demand_flex_network.rego
@@ -1,0 +1,15 @@
+# DEG Network Policy — Demand Flex (noop)
+#
+# Placeholder network policy for demand-flex devkit.
+# Imposes no additional network-level constraints.
+# All messages pass validation.
+#
+# Replace with real rules as the demand-flex network matures.
+# Canonical source: specification/policies/demand_flex_network.rego
+
+package deg.policy.demand_flex_network
+
+import rego.v1
+
+# No violations — all messages pass.
+violations := set()


### PR DESCRIPTION
## Summary

Wires the `opapolicychecker` plugin into the demand-flex devkit on the refactored `fidedocker/onix-adapter-deg:w-deg-plugins-v1` image, and migrates `dediregistry` off the deprecated `allowedParentNamespaces` config key that the new plugin errors on at startup.

## Changes

- **Image bump**: `onix-adapter-deg:p2p-multiarch-v7` → `fidedocker/onix-adapter-deg:w-deg-plugins-v1` for BAP and BPP in `install/docker-compose.yml`.
- **dediregistry**: replace commented `allowedParentNamespaces: "IES,IES-DISCOMS"` with `allowedNetworkIDs: "nfh.global/testnet-deg"` in both BAP and BPP (receiver + caller). The old key errors out under the new plugin.
- **Subscriber identity**: `networkParticipant` flipped from the borrowed `p2p-trading-sandbox{1,2}.com` to `bap.example.com` / `bpp.example.com`. Signing key material left borrowed (comments mark this as a placeholder; arazzo flows will NACK on DeDi lookup until these subscribers are registered on testnet-deg with their own keys).
- **`checkPolicy` plugin**: rewritten to the new opapolicychecker shape —

  ```yaml
  checkPolicy:
    id: opapolicychecker
    config:
      networkPolicyConfig: ./config/opa-network-policies.yaml
      refreshInterval: "5m"
  ```

  and uncommented in the `steps:` list for all four modules (`bapTxnReceiver`, `bapTxnCaller`, `bppTxnReceiver`, `bppTxnCaller`).
- **New `config/opa-network-policies.yaml`**: single `default:` entry referencing `./policies/demand_flex_network.rego` with query `data.deg.policy.demand_flex_network.violations`. Applies to every `context.networkId` until per-network rules are needed.
- **New `policies/demand_flex_network.rego`**: devkit-local copy of the canonical noop policy in `specification/policies/demand_flex_network.rego` (`package deg.policy.demand_flex_network`, `violations := set()`). Delivered into the container via the existing `../policies:/app/policies` volume mount.
- **README**: Policy Enforcement section rewritten — the prior note about loading the policy from the `becknv2-demand-flex` branch URL no longer applies. Documents the local `networkPolicyConfig` path, the `testnet-deg` `allowedNetworkIDs`, and flags the placeholder subscriber identities.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three YAML files (BAP, BPP, opa-network-policies) → all parse.
- [x] Programmatic inspection confirms every module has `checkPolicy` plugin + step, `allowedNetworkIDs='nfh.global/testnet-deg'`, and correct `networkParticipant`.
- [ ] `docker compose up` on the v1 image and verify adapter startup: opapolicychecker loads `opa-network-policies.yaml`, compiles `default` policy from `./policies/demand_flex_network.rego`, and logs a successful ready state.
- [ ] Run `uc1-demand-flex/workflows/demand-flex.arazzo.yaml` — expect NACKs on DeDi lookup while `bap.example.com`/`bpp.example.com` aren't yet registered on testnet-deg; policy evaluation itself should succeed (noop, no violations).
- [ ] Once real subscribers are registered on testnet-deg, replace the borrowed p2p-trading keys with demand-flex key material, rerun flows end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)