### PR TITLE
Add vocab.jsonld for DiscomLimitCheck and RevenueFlow

### DIFF
--- a/specification/schema/DiscomLimitCheck/v2.0/vocab.jsonld
+++ b/specification/schema/DiscomLimitCheck/v2.0/vocab.jsonld
@@ -1,0 +1,129 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "deg": "https://schema.beckn.io/deg/DiscomLimitCheck/v2.0/",
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "deg:DiscomLimitCheck",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Discom Limit Check",
+      "rdfs:comment": "Optional Phase-2 limit-check performance attributes for inter-discom P2P energy trades. Attached to Performance.performanceAttributes during the init/on_init exchange that asks each discom ledger whether the contract quantity fits within the prosumer's allocation envelope for the delivery window."
+    },
+    {
+      "@id": "deg:subject",
+      "@type": "rdf:Property",
+      "rdfs:label": "Subject",
+      "rdfs:comment": "Which side of the trade this limit check is being requested against (buyer or seller). Omitted in on_init responses that report both sides.",
+      "rdfs:domain": "deg:DiscomLimitCheck",
+      "schema:rangeIncludes": "deg:LimitCheckSubject"
+    },
+    {
+      "@id": "deg:subjectMeterId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Subject meter ID",
+      "rdfs:comment": "Source meter identifier in DER address format (der://meter/{id}) for the subject prosumer.",
+      "rdfs:domain": "deg:DiscomLimitCheck",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:discomParticipantId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Discom participant ID",
+      "rdfs:comment": "Participant id of the discom ledger.",
+      "rdfs:domain": "deg:DiscomLimitCheck",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:deliveryWindow",
+      "@type": "rdf:Property",
+      "rdfs:label": "Delivery window",
+      "rdfs:comment": "Delivery window for the limit check (UTC, ISO 8601 with Z suffix).",
+      "rdfs:domain": "deg:DiscomLimitCheck",
+      "schema:rangeIncludes": "beckn:TimePeriod"
+    },
+    {
+      "@id": "deg:tradeQuantity",
+      "@type": "rdf:Property",
+      "rdfs:label": "Trade quantity",
+      "rdfs:comment": "Trade quantity being limit-checked (Quantity object with unitCode and unitQuantity).",
+      "rdfs:domain": "deg:DiscomLimitCheck",
+      "schema:rangeIncludes": "beckn:Quantity"
+    },
+    {
+      "@id": "deg:buyerSide",
+      "@type": "rdf:Property",
+      "rdfs:label": "Buyer-side limit-check result",
+      "rdfs:comment": "Buyer-side limit-check result; populated in on_init responses that report both sides. Carries discomParticipantId, limitCheckResult and remainingHeadroomKwh.",
+      "rdfs:domain": "deg:DiscomLimitCheck"
+    },
+    {
+      "@id": "deg:sellerSide",
+      "@type": "rdf:Property",
+      "rdfs:label": "Seller-side limit-check result",
+      "rdfs:comment": "Seller-side limit-check result; populated in on_init responses that report both sides. Carries discomParticipantId, limitCheckResult and remainingHeadroomKwh.",
+      "rdfs:domain": "deg:DiscomLimitCheck"
+    },
+    {
+      "@id": "deg:limitCheckResult",
+      "@type": "rdf:Property",
+      "rdfs:label": "Limit-check result",
+      "rdfs:comment": "Outcome of a per-side limit check (OK, REJECTED, or ADJUSTED).",
+      "schema:rangeIncludes": "deg:LimitCheckOutcome"
+    },
+    {
+      "@id": "deg:remainingHeadroomKwh",
+      "@type": "rdf:Property",
+      "rdfs:label": "Remaining headroom (kWh)",
+      "rdfs:comment": "Remaining allocation headroom on the discom ledger for the delivery window, in kilowatt-hours.",
+      "schema:rangeIncludes": "schema:Number"
+    },
+    {
+      "@id": "deg:LimitCheckSubject",
+      "@type": "schema:Enumeration",
+      "schema:name": "Limit-Check Subject",
+      "rdfs:comment": "Side of the trade against which the limit check is performed."
+    },
+    {
+      "@id": "deg:LimitCheckSubjectBuyer",
+      "@type": "deg:LimitCheckSubject",
+      "schema:name": "buyer",
+      "schema:identifier": "buyer"
+    },
+    {
+      "@id": "deg:LimitCheckSubjectSeller",
+      "@type": "deg:LimitCheckSubject",
+      "schema:name": "seller",
+      "schema:identifier": "seller"
+    },
+    {
+      "@id": "deg:LimitCheckOutcome",
+      "@type": "schema:Enumeration",
+      "schema:name": "Limit-Check Outcome",
+      "rdfs:comment": "Possible outcomes of a discom-ledger limit check."
+    },
+    {
+      "@id": "deg:LimitCheckOutcomeOk",
+      "@type": "deg:LimitCheckOutcome",
+      "schema:name": "OK",
+      "schema:identifier": "OK"
+    },
+    {
+      "@id": "deg:LimitCheckOutcomeRejected",
+      "@type": "deg:LimitCheckOutcome",
+      "schema:name": "REJECTED",
+      "schema:identifier": "REJECTED"
+    },
+    {
+      "@id": "deg:LimitCheckOutcomeAdjusted",
+      "@type": "deg:LimitCheckOutcome",
+      "schema:name": "ADJUSTED",
+      "schema:identifier": "ADJUSTED"
+    }
+  ]
+}

--- a/specification/schema/RevenueFlow/v2.0/vocab.jsonld
+++ b/specification/schema/RevenueFlow/v2.0/vocab.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "deg": "https://schema.beckn.io/deg/RevenueFlow/v2.0/",
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "deg:RevenueFlow",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Revenue Flow",
+      "rdfs:comment": "Settlement-time revenue-flow attributes for energy contracts. Attached to Contract.consideration[*].considerationAttributes after the linked rego policy evaluates. Each entry in revenueFlows is signed (positive = receives, negative = pays); the sum across all entries MUST be zero (net-zero invariant)."
+    },
+    {
+      "@id": "deg:revenueFlows",
+      "@type": "rdf:Property",
+      "rdfs:label": "Revenue flows",
+      "rdfs:comment": "Per-role signed revenue-flow entries computed by the contract policy after settlement. Sum MUST be zero across the array.",
+      "rdfs:domain": "deg:RevenueFlow",
+      "schema:rangeIncludes": "schema:ItemList"
+    },
+    {
+      "@id": "deg:role",
+      "@type": "rdf:Property",
+      "rdfs:label": "Role",
+      "rdfs:comment": "Contract role this flow applies to (buyer, seller, buyerDiscom, sellerDiscom).",
+      "schema:rangeIncludes": "deg:RevenueFlowRole"
+    },
+    {
+      "@id": "deg:value",
+      "@type": "rdf:Property",
+      "rdfs:label": "Value",
+      "rdfs:comment": "Signed amount of the flow. Positive = role receives; negative = role pays.",
+      "schema:rangeIncludes": "schema:Number"
+    },
+    {
+      "@id": "deg:currency",
+      "@type": "rdf:Property",
+      "rdfs:label": "Currency",
+      "rdfs:comment": "ISO-4217 currency code (e.g. INR, USD).",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:description",
+      "@type": "rdf:Property",
+      "rdfs:label": "Description",
+      "rdfs:comment": "Human-readable rationale for the flow.",
+      "rdfs:subPropertyOf": "schema:description",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:RevenueFlowRole",
+      "@type": "schema:Enumeration",
+      "schema:name": "Revenue-Flow Role",
+      "rdfs:comment": "Roles for which a revenue flow can be emitted in the four-role inter-discom P2P contract."
+    },
+    {
+      "@id": "deg:RevenueFlowRoleBuyer",
+      "@type": "deg:RevenueFlowRole",
+      "schema:name": "buyer",
+      "schema:identifier": "buyer"
+    },
+    {
+      "@id": "deg:RevenueFlowRoleSeller",
+      "@type": "deg:RevenueFlowRole",
+      "schema:name": "seller",
+      "schema:identifier": "seller"
+    },
+    {
+      "@id": "deg:RevenueFlowRoleBuyerDiscom",
+      "@type": "deg:RevenueFlowRole",
+      "schema:name": "buyerDiscom",
+      "schema:identifier": "buyerDiscom"
+    },
+    {
+      "@id": "deg:RevenueFlowRoleSellerDiscom",
+      "@type": "deg:RevenueFlowRole",
+      "schema:name": "sellerDiscom",
+      "schema:identifier": "sellerDiscom"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Schema publishing check expects every v2.0 schema folder to ship `attributes.yaml` + `context.jsonld` + `vocab.jsonld`. The two new schemas added on the wave2 P2P trading branch (`DiscomLimitCheck/v2.0`, `RevenueFlow/v2.0`) were missing `vocab.jsonld`, which fails the publishing pipeline. This PR adds both files.

The format mirrors existing v2.0 vocabs (`EnergyResource/v2.0/vocab.jsonld`, `EnergyTradeDelivery/v2.0/vocab.jsonld`, etc.):

- `@context` with the standard prefix bindings — `beckn`, `deg`, `schema`, `rdf`, `rdfs`, `xsd`.
- `@graph` listing the `rdfs:Class` for the schema, an `rdf:Property` for each attribute (with `rdfs:domain` + `schema:rangeIncludes` / `rdfs:range`), and `schema:Enumeration` entries with one instance per enum value.

## What's inside

**`specification/schema/DiscomLimitCheck/v2.0/vocab.jsonld`** (17 graph items)
- `rdfs:Class` — `deg:DiscomLimitCheck`
- Properties — `subject`, `subjectMeterId`, `discomParticipantId`, `deliveryWindow`, `tradeQuantity`, `buyerSide`, `sellerSide`, `limitCheckResult`, `remainingHeadroomKwh`
- Enumerations — `deg:LimitCheckSubject` (`buyer` | `seller`), `deg:LimitCheckOutcome` (`OK` | `REJECTED` | `ADJUSTED`)

**`specification/schema/RevenueFlow/v2.0/vocab.jsonld`** (11 graph items)
- `rdfs:Class` — `deg:RevenueFlow`
- Properties — `revenueFlows`, `role`, `value`, `currency`, `description`
- Enumeration — `deg:RevenueFlowRole` (`buyer` | `seller` | `buyerDiscom` | `sellerDiscom`)

## Test plan

- [x] Both files parse as valid JSON (`@graph` lengths verified).
- [x] Prefix bindings + `@version: 1.1` match existing v2.0 vocabs.
- [x] Property `rdfs:domain` references the schema's own class IRI.
- [x] Enum values match the corresponding `attributes.yaml` enums (`subject` ∈ {buyer, seller}; `limitCheckResult` ∈ {OK, REJECTED, ADJUSTED}; `role` ∈ {buyer, seller, buyerDiscom, sellerDiscom}).
- [ ] Schema publishing pipeline runs green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)