### PR TITLE
Fix default bap_id, bpp_id variables in demand flex postman collection

### DIFF
--- a/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BAP-DEG.postman_collection.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BAP-DEG.postman_collection.json
@@ -196,11 +196,11 @@
     },
     {
       "key": "bap_id",
-      "value": "p2p-trading-sandbox1.com"
+      "value": "bap.example.com"
     },
     {
       "key": "bpp_id",
-      "value": "p2p-trading-sandbox2.com"
+      "value": "bpp.example.com"
     },
     {
       "key": "transaction_id",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BPP-DEG.postman_collection.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BPP-DEG.postman_collection.json
@@ -247,11 +247,11 @@
     },
     {
       "key": "bap_id",
-      "value": "p2p-trading-sandbox1.com"
+      "value": "bap.example.com"
     },
     {
       "key": "bpp_id",
-      "value": "p2p-trading-sandbox2.com"
+      "value": "bpp.example.com"
     },
     {
       "key": "transaction_id",

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -125,9 +125,9 @@ DEVKIT_CONFIGS = {
     },
     "demand-flex": {
         "domain": "beckn.one:deg:demand-flex:2.0.0",
-        "bap_id": "p2p-trading-sandbox1.com",
+        "bap_id": "bap.example.com",
         "bap_host_root": "http://beckn-router:9000",
-        "bpp_id": "p2p-trading-sandbox2.com",
+        "bpp_id": "bpp.example.com",
         "bpp_host_root": "http://beckn-router:9000",
         "bap_adapter_url": "http://localhost:8081/bap/caller",
         "bpp_adapter_url": "http://localhost:8082/bpp/caller",


### PR DESCRIPTION
This ensures that devkit postman collection runs with default subscriber_id and keys