### PR TITLE
Add policy violations to demand flex network rego file for BecknTimeSeries payload type

### DIFF
--- a/devkits/demand-flex/policies/demand_flex_network.rego
+++ b/devkits/demand-flex/policies/demand_flex_network.rego
@@ -1,15 +1,29 @@
-# DEG Network Policy — Demand Flex (noop)
+# DEG Network Policy — Demand Flex
 #
-# Placeholder network policy for demand-flex devkit.
-# Imposes no additional network-level constraints.
-# All messages pass validation.
+# Network-level gate evaluated by the BPP's `checkPolicy` step.
+# Fires NACK when violations is non-empty.
 #
-# Replace with real rules as the demand-flex network matures.
+# Current rules:
+#   - BecknTimeSeries cross-field type-coverage: every payload type used
+#     in intervals[*].payloads[*].type MUST be declared in
+#     payloadDescriptors[*].payloadType. Catches typos like "BASELIN" /
+#     undocumented signals on the wire.
+#
 # Canonical source: specification/policies/demand_flex_network.rego
 
 package deg.policy.demand_flex_network
 
 import rego.v1
 
-# No violations — all messages pass.
-violations := set()
+# Cross-field type-coverage check for every meter's telemetry.
+# Iterates only over USED types — declared-but-unused is allowed (e.g. a
+# pre-event report that ships full descriptors before USAGE is recorded).
+violations contains msg if {
+	some perf in input.message.contract.performance
+	some meter in perf.performanceAttributes.meters
+	declared_types := {d.payloadType | some d in meter.telemetry.payloadDescriptors}
+	some interval in meter.telemetry.intervals
+	some payload in interval.payloads
+	not payload.type in declared_types
+	msg := sprintf("meter %s: payload type '%s' used in intervals but not declared in payloadDescriptors", [meter.meterId, payload.type])
+}

--- a/specification/policies/demand_flex_network.rego
+++ b/specification/policies/demand_flex_network.rego
@@ -1,14 +1,27 @@
-# DEG Network Policy — Demand Flex (noop)
+# DEG Network Policy — Demand Flex
 #
-# Placeholder network policy for demand-flex devkit.
-# Imposes no additional network-level constraints.
-# All messages pass validation.
+# Network-level gate evaluated by the BPP's `checkPolicy` step.
+# Fires NACK when violations is non-empty.
 #
-# Replace with real rules as the demand-flex network matures.
+# Current rules:
+#   - BecknTimeSeries cross-field type-coverage: every payload type used
+#     in intervals[*].payloads[*].type MUST be declared in
+#     payloadDescriptors[*].payloadType. Catches typos like "BASELIN" /
+#     undocumented signals on the wire.
 
 package deg.policy.demand_flex_network
 
 import rego.v1
 
-# No violations — all messages pass.
-violations := set()
+# Cross-field type-coverage check for every meter's telemetry.
+# Iterates only over USED types — declared-but-unused is allowed (e.g. a
+# pre-event report that ships full descriptors before USAGE is recorded).
+violations contains msg if {
+	some perf in input.message.contract.performance
+	some meter in perf.performanceAttributes.meters
+	declared_types := {d.payloadType | some d in meter.telemetry.payloadDescriptors}
+	some interval in meter.telemetry.intervals
+	some payload in interval.payloads
+	not payload.type in declared_types
+	msg := sprintf("meter %s: payload type '%s' used in intervals but not declared in payloadDescriptors", [meter.meterId, payload.type])
+}

--- a/specification/policies/demand_flex_revenue.rego
+++ b/specification/policies/demand_flex_revenue.rego
@@ -222,17 +222,8 @@ violations contains msg if {
 	msg := sprintf("net-zero failed: revenue sum = %g (expected 0)", [_revenue_sum])
 }
 
-# Cross-field membership: every payload type used in intervals must be
-# declared in payloadDescriptors. The schema (BecknTimeSeries v1.0)
-# encodes this in JSON Schema 2020-12, but kin-openapi < v0.136.0
-# silently ignores those keywords — so the check runs here until the
-# validator is upgraded.
-violations contains msg if {
-	some i
-	meter := _meters[i]
-	declared_types := {d.payloadType | some d in meter.telemetry.payloadDescriptors}
-	some interval in meter.telemetry.intervals
-	some payload in interval.payloads
-	not payload.type in declared_types
-	msg := sprintf("meter %s: payload type '%s' used in intervals but not declared in payloadDescriptors", [meter.meterId, payload.type])
-}
+# Cross-field type-coverage (every type used in intervals must be
+# declared in payloadDescriptors) lives in the network policy
+# (specification/policies/demand_flex_network.rego) — that's the policy
+# the BPP's checkPolicy step actually evaluates. This file's `violations`
+# set is computed only as enrichment metadata, never gates ACK/NACK.


### PR DESCRIPTION
BecknTimeSeries is based on OpenADER report type. It allows for payloads to be described on the fly (without hosting the self-describing schema).. but does not provide validation support of someone makes a typo in payload type. e.g.

```
 "telemetry": {                                 
    "@type": "TimeSeries",
    "intervalPeriod": { "start": "2026-04-01T08:30:00Z", "duration": "PT1H" },                                                           
    "payloadDescriptors": [
      { "objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ" },             
      { "objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE",    "units": "KW", "readingType": "DIRECT_READ" }              
    ],                                                                                                                                   
    "intervals": [                                                                                                                       
      { "id": 0, "payloads": [ { "type": "BASEL", "values": [46.0] }, { "type": "USAGE", "values": [22.0] } ] },                      
      { "id": 1, "payloads": [ { "type": "BASELINE", "values": [44.0] }, { "type": "USAGE", "values": [18.0] } ] }                       
    ]                                                                                                                                    
  }    
```

Now with rego network policy, this gives an error:

```
{
    "message": {
        "ack": {
            "status": "NACK"
        },
        "error": {
            "code": "Bad Request",
            "message": "BAD Request: policy violation(s): meter der://meter/001: payload type 'BASEL' used in intervals but not declared in payloadDescriptors"
        }
    }
}
```