### PR TITLE
Changed the golang builder version as new onix release is using it

### DIFF
--- a/build/Dockerfile.onix-adapter-deg
+++ b/build/Dockerfile.onix-adapter-deg
@@ -10,7 +10,7 @@
 #   docker build -f DEG/build/Dockerfile.onix-adapter-deg -t onix-adapter-deg \
 #     --build-context beckn-onix=beckn-onix DEG
 
-FROM golang:1.24-bullseye AS builder
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /workspace
 
@@ -49,7 +49,7 @@ RUN go build -buildmode=plugin -o /workspace/beckn-onix/plugins/degledgerrecorde
 RUN go build -buildmode=plugin -o /workspace/beckn-onix/plugins/revenueflows.so ./revenueflows/cmd/plugin.go
 
 # Create minimal runtime image
-# Using debian-slim (glibc) for Go plugin (.so) compatibility with the bullseye builder.
+# Using debian-slim (glibc) for Go plugin (.so) compatibility with the bookworm builder.
 # Wolfi-base (cgr.dev) can be used if its registry is reachable in your environment.
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/specification/policies/demand_flex_network_test.rego
+++ b/specification/policies/demand_flex_network_test.rego
@@ -1,0 +1,101 @@
+# Unit tests for demand_flex_network.rego
+#
+# Run:  cd specification/policies && opa test demand_flex_network.rego demand_flex_network_test.rego -v
+
+package deg.policy.demand_flex_network
+
+import rego.v1
+
+# Helper: minimal on_status payload with one meter
+_payload(meter) := {"message": {"contract": {"performance": [
+	{"performanceAttributes": {"meters": [meter]}},
+]}}}
+
+# Test: clean payload (every used type declared) → no violations
+test_clean_payload if {
+	meter := {
+		"meterId": "der://meter/001",
+		"telemetry": {
+			"payloadDescriptors": [
+				{"payloadType": "BASELINE"},
+				{"payloadType": "USAGE"},
+			],
+			"intervals": [{"payloads": [
+				{"type": "BASELINE", "values": [46.0]},
+				{"type": "USAGE", "values": [22.0]},
+			]}],
+		},
+	}
+	count(violations) == 0 with input as _payload(meter)
+}
+
+# Test: typo in interval (BASELIN instead of BASELINE) → violation
+test_typo_baselin_in_interval if {
+	meter := {
+		"meterId": "der://meter/001",
+		"telemetry": {
+			"payloadDescriptors": [
+				{"payloadType": "BASELINE"},
+				{"payloadType": "USAGE"},
+			],
+			"intervals": [{"payloads": [
+				{"type": "BASELIN", "values": [46.0]},
+				{"type": "USAGE", "values": [22.0]},
+			]}],
+		},
+	}
+	vs := violations with input as _payload(meter)
+	count(vs) == 1
+	some v in vs
+	contains(v, "BASELIN")
+	contains(v, "der://meter/001")
+}
+
+# Test: declared-but-unused (USAGE in descriptors, only BASELINE in intervals) → no violation
+test_declared_but_unused_is_allowed if {
+	meter := {
+		"meterId": "der://meter/001",
+		"telemetry": {
+			"payloadDescriptors": [
+				{"payloadType": "BASELINE"},
+				{"payloadType": "USAGE"},
+			],
+			"intervals": [{"payloads": [
+				{"type": "BASELINE", "values": [46.0]},
+			]}],
+		},
+	}
+	count(violations) == 0 with input as _payload(meter)
+}
+
+# Test: action without telemetry (e.g. on_select) → no violation
+test_no_performance_no_violation if {
+	inp := {"message": {"contract": {"id": "c1"}}}
+	count(violations) == 0 with input as inp
+}
+
+# Test: typo on one meter, others clean → exactly one violation, naming the bad meter
+test_typo_isolated_to_one_meter if {
+	good := {
+		"meterId": "der://meter/002",
+		"telemetry": {
+			"payloadDescriptors": [{"payloadType": "BASELINE"}],
+			"intervals": [{"payloads": [{"type": "BASELINE", "values": [40.0]}]}],
+		},
+	}
+	bad := {
+		"meterId": "der://meter/001",
+		"telemetry": {
+			"payloadDescriptors": [{"payloadType": "BASELINE"}],
+			"intervals": [{"payloads": [{"type": "BASLN", "values": [46.0]}]}],
+		},
+	}
+	inp := {"message": {"contract": {"performance": [
+		{"performanceAttributes": {"meters": [good, bad]}},
+	]}}}
+	vs := violations with input as inp
+	count(vs) == 1
+	some v in vs
+	contains(v, "der://meter/001")
+	contains(v, "BASLN")
+}


### PR DESCRIPTION
Plugins build cleanly with new onix release (which updated golang version).
tested with demand flex network successfully, provided https://github.com/beckn/beckn-onix/pull/700 is merged.

`fidedocker/onix-adapter-deg:w-deg-plugins-v1.1` was built with this.
