### PR TITLE
DEG-196: degledgerrecorder supports beckn API + payload-sourced ledgerUri (wave2)

### DIFF
--- a/devkits/p2p-trading-ies-wave1/config/local-p2p-bap.yaml
+++ b/devkits/p2p-trading-ies-wave1/config/local-p2p-bap.yaml
@@ -78,6 +78,12 @@ modules:
               policyUrls: "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/p2p-trading-interdiscom.rego"
           - id: degledgerrecorder
             config:
+              # Wave1 mode flags — explicit so behavior is visible in YAML, not
+              # buried as code defaults. Wave1 keeps ledgerHost from config and
+              # the legacy_ledger JSON shape; bit-identical to prior behavior.
+              payloadShape: wave1
+              ledgerUriSource: config
+              ledgerApi: legacy_ledger
               # ledgerHost: "https://34.93.166.38.sslip.io" OLD URL
               ledgerHost: "https://ies-p2p-energy-ledger.beckn.io"
               role: "BUYER"

--- a/devkits/p2p-trading-ies-wave1/config/local-p2p-bpp.yaml
+++ b/devkits/p2p-trading-ies-wave1/config/local-p2p-bpp.yaml
@@ -135,10 +135,16 @@ modules:
         steps:
           - id: degledgerrecorder
             config:
+              # Wave1 mode flags — explicit so behavior is visible in YAML, not
+              # buried as code defaults. Wave1 keeps ledgerHost from config and
+              # the legacy_ledger JSON shape; bit-identical to prior behavior.
+              payloadShape: wave1
+              ledgerUriSource: config
+              ledgerApi: legacy_ledger
               # ledgerHost: "https://34.93.166.38.sslip.io" # OLD URL
               ledgerHost: "https://ies-p2p-energy-ledger.beckn.io"
               role: "SELLER"
-              actions: "on_confirm,on_status"  # Handle both actions 
+              actions: "on_confirm,on_status"  # Handle both actions
               enabled: "true"
               asyncTimeout: "30000"
               # Signing config (same keys as simplekeymanager)

--- a/devkits/p2p-trading-ies-wave2/README.md
+++ b/devkits/p2p-trading-ies-wave2/README.md
@@ -34,6 +34,7 @@ The contract names four conceptual actors. Only buyer and seller speak Beckn dir
 | [EnergyTradeOffer](../../specification/schema/EnergyTradeOffer/v2.0/) | `offerAttributes` | Pricing model, validity / delivery window |
 | [EnergyTradeDelivery](../../specification/schema/EnergyTradeDelivery/v2.0/) | `performance.performanceAttributes` | Delivery status, meter readings, settled qty |
 | [DEGContract](../../specification/schema/DEGContract/v2.0/) | `contractAttributes` | Roles, policy reference, computed revenueFlows |
+| [DiscomLedgerProvider](../../specification/schema/DiscomLedgerProvider/v1.0/) | `participants[role=buyerDiscom\|sellerDiscom].participantAttributes` | Discom ledger TSP identity — `utilityId` + `ledgerUri` so the `degledgerrecorder` plugin can pick the right ledger URL per discom from the payload |
 
 ## Postman
 
@@ -47,6 +48,16 @@ Two layers, both via the `opapolicychecker` plugin:
 - **Contract policy** — every payload's `contractAttributes.policy.url` points to [`specification/policies/p2p_trading_ies_wave2_revenue.rego`](../../specification/policies/p2p_trading_ies_wave2_revenue.rego). The rego computes a four-role `revenueFlows` array from the seller's `inputs.offers[0].pricePerKwh` and the settled quantity. The on-status payload carries the result at `message.contract.consideration[0].considerationAttributes` (RevenueFlow JSON-LD, Beckn-native). Wheeling and penalty charges are `0` placeholders in the rego today — flip them to real expressions when the tariff/penalty rules land; no payload changes needed. (The legacy BPP-side `revenueflows` middleware that auto-injected into `contractAttributes` is currently disabled — see `config/local-p2p-trading-bpp.yaml` — until it can target the consideration block.)
 
 Signature/registry lookups currently target `nfh.global/testnet-deg` via the `allowedNetworkIDs` key on the `dediregistry` plugin. Subscriber IDs are placeholders (`bap.example.com` / `bpp.example.com`) with signing keys borrowed from the p2p-trading devkit, so arazzo flows will NACK on lookup until real subscribers are registered on testnet-deg.
+
+## Ledger recording
+
+On `on_confirm` both platforms write a trade record to their own discom's ledger TSP via the [`degledgerrecorder`](../../plugins/degledgerrecorder/) plugin:
+- BAP-Receiver runs the plugin with `role: BUYER` and reads `participants[role=buyerDiscom].participantAttributes.ledgerUri` from the payload.
+- BPP-Caller runs the plugin with `role: SELLER` and reads `participants[role=sellerDiscom].participantAttributes.ledgerUri` from the payload.
+
+Both URIs are wired in the example payloads to the IES ledger service (`https://ies-p2p-energy-ledger.beckn.io`); two discoms MAY share a TSP — each platform still writes only to its own side.
+
+Mode flags in the [BAP](./config/local-p2p-trading-bap.yaml) and [BPP](./config/local-p2p-trading-bpp.yaml) configs: `payloadShape: wave2`, `ledgerUriSource: payload`, `ledgerApi: legacy_ledger`. Flip `ledgerApi` to `beckn` once the ledger TSP is upgraded to accept beckn `on_confirm`.
 
 ## Related
 

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-bap.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-bap.yaml
@@ -75,11 +75,28 @@ modules:
             config:
               uuidKeys: transaction_id,message_id
               role: bap
+        steps:
+          - id: degledgerrecorder
+            config:
+              # Wave2 (P2PTrade/v2.0) on_confirm shape; ledger URL is read
+              # per-call from the payload's buyerDiscom participantAttributes.
+              payloadShape: wave2
+              ledgerUriSource: payload
+              ledgerApi: legacy_ledger
+              role: BUYER
+              actions: on_confirm
+              enabled: "true"
+              asyncTimeout: "30000"
+              # Signing config (same keys as simplekeymanager)
+              signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+              networkParticipant: bap.example.com
+              keyId: 76EU7LZ7gfqj13dWDKR1Uitnim11mCoxWBPdzLxUpAMBPVdANKgyFM
       steps:
         - validateSign
         - checkPolicy
         - addRoute
         - validateSchema
+        - degledgerrecorder
 
   - name: bapTxnCaller
     path: /bap/caller/

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-bpp.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-bpp.yaml
@@ -155,8 +155,25 @@ modules:
               outputContextURL: "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/RevenueFlow/v2.0/context.jsonld"
               outputArrayKey: "revenueFlows"
               entryDefaults: '{"status":{"code":"SETTLED"}}'
+        steps:
+          - id: degledgerrecorder
+            config:
+              # Wave2 (P2PTrade/v2.0) on_confirm shape; ledger URL is read
+              # per-call from the payload's sellerDiscom participantAttributes.
+              payloadShape: wave2
+              ledgerUriSource: payload
+              ledgerApi: legacy_ledger
+              role: SELLER
+              actions: on_confirm
+              enabled: "true"
+              asyncTimeout: "30000"
+              # Signing config (same keys as simplekeymanager)
+              signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+              networkParticipant: bpp.example.com
+              keyId: 76EU7ofwRCF1aobQkShARrf1PAUsNpHqWUJoynPu9w45YFKmzqaPmy
       steps:
         - validateSchema
         - checkPolicy
         - addRoute
         - sign
+        - degledgerrecorder

--- a/devkits/p2p-trading-ies-wave2/install/docker-compose.yml
+++ b/devkits/p2p-trading-ies-wave2/install/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       retries: 5
 
   onix-bap:
-    image: fidedocker/onix-adapter-deg:w-deg-plugins-v1.1
+    image: fidedocker/onix-adapter-deg:w-deg-plugins-v1
     container_name: onix-bap
     ports:
       - "8081:8081"
@@ -89,7 +89,7 @@ services:
       retries: 5
 
   onix-bpp:
-    image: fidedocker/onix-adapter-deg:w-deg-plugins-v1.1
+    image: fidedocker/onix-adapter-deg:w-deg-plugins-v1
     container_name: onix-bpp
     ports:
       - "8082:8082"

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
@@ -192,11 +192,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/init-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/init-request.json
@@ -195,11 +195,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
@@ -193,11 +193,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
@@ -192,11 +192,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-select-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-select-response.json
@@ -194,11 +194,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
@@ -271,11 +271,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/select-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/select-request.json
@@ -193,11 +193,23 @@
         },
         {
           "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger"
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         },
         {
           "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger"
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@context": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
         }
       ]
     }

--- a/plugins/degledgerrecorder/README.md
+++ b/plugins/degledgerrecorder/README.md
@@ -35,7 +35,11 @@ plugins:
   steps:
     - id: degledgerrecorder
       config:
-        ledgerHost: "https://ledger.example.org"
+        # Required mode flags — no code defaults; behavior must be visible here.
+        payloadShape: wave2          # wave1 | wave2
+        ledgerUriSource: payload     # config | payload
+        ledgerApi: legacy_ledger     # legacy_ledger | beckn
+        # ledgerHost: "https://ledger.example.org"  # required only when ledgerUriSource=config
         role: "BUYER"        # BUYER, SELLER, BUYER_DISCOM, or SELLER_DISCOM
         enabled: "true"      # Enable/disable the plugin
         asyncTimeout: "5000" # Timeout in milliseconds
@@ -49,17 +53,65 @@ steps:
 
 ### Configuration Options
 
+#### Mode Flags (all required, no code defaults)
+
+| Option | Values | Description |
+|--------|--------|-------------|
+| `payloadShape` | `wave1`, `wave2` | Which on_confirm body the mapper expects. `wave1` = `beckn:Order`/`orderItems` (p2p-trading-ies-wave1). `wave2` = `message.contract.commitments` (p2p-trading-ies-wave2, P2PTrade/v2.0). |
+| `ledgerUriSource` | `config`, `payload` | Where to find the target ledger base URL. `config` reads `ledgerHost`. `payload` reads `participants[role=buyerDiscom\|sellerDiscom].participantAttributes.ledgerUri` from the on_confirm body — required for wave2 since the URI varies per discom. |
+| `ledgerApi` | `legacy_ledger`, `beckn` | API style. `legacy_ledger` POSTs to `<uri>/ledger/put` with the custom JSON body. `beckn` POSTs the original on_confirm verbatim (with rewritten context) to `<uri>/on_confirm` and expects a beckn ACK envelope wrapping the legacy ledger response. |
+
 #### Core Settings
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `ledgerHost` | Yes | - | Base URL of the DEG Ledger service |
+| `ledgerHost` | When `ledgerUriSource=config` | - | Base URL of the DEG Ledger service |
 | `role` | No | `BUYER` | Role for ledger records (see below) |
 | `actions` | No | `on_confirm` | Comma-separated list of actions to trigger recording |
 | `enabled` | No | `true` | Enable/disable plugin |
 | `asyncTimeout` | No | `5000` | API call timeout (ms) |
 | `retryCount` | No | `0` | Retry count for failed calls |
 | `debugLogging` | No | `false` | Enable verbose request/response logging |
+
+#### Per-call ledger URI from payload
+
+When `ledgerUriSource=payload`, the plugin picks the URI based on `role`:
+- `BUYER` → `participants[role=buyerDiscom].participantAttributes.ledgerUri`
+- `SELLER` → `participants[role=sellerDiscom].participantAttributes.ledgerUri`
+
+A platform instance (BAP or BPP) only writes to its own side's discom ledger. The same trade is logged in two ledgers (one per discom) at the system level, with each platform contacting only its own; if the two discoms share a TSP, both calls land at the same URL.
+
+The discom `ledgerUri` is carried via the [`DiscomLedgerProvider/v1.0`](../../specification/schema/DiscomLedgerProvider/v1.0/) schema.
+
+#### `ledgerApi: beckn` mode
+
+In beckn mode the plugin forwards the original `on_confirm` body verbatim — except for the `context` block, which is rewritten so the ledger TSP receives it as a BPP→BAP call:
+
+| Field | Rewritten to |
+|-------|--------------|
+| `context.bppUri` | `<senderHost>/bpp/caller` |
+| `context.bapUri` | `<discomLedgerUri>/bap/receiver` |
+
+`senderHost` resolution order:
+1. `senderHost` config option (e.g., `https://bap.example.com`).
+2. Falls back to the host portion of `context.bapUri` (BUYER role) or `context.bppUri` (SELLER role) from the incoming payload.
+
+The plugin then POSTs the rewritten body to `<discomLedgerUri>/on_confirm` and expects a beckn ACK envelope back:
+
+```json
+{
+  "message": {
+    "ack":    { "status": "ACK" },
+    "ledger": { "success": true, "recordId": "rec-...", "creationTime": "...", "rowDigest": "sha256:..." }
+  }
+}
+```
+
+The inner `message.ledger` block carries the same fields the legacy `/ledger/put` API used to return; the plugin surfaces it identically so call-site logging stays uniform across the two modes.
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `senderHost` | When `ledgerApi=beckn` and you want to override the derived value | derived from incoming context | Base URL (`scheme://host[:port]`) advertised as the BPP-side caller in the rewritten context |
 
 #### Actions and Roles
 
@@ -117,6 +169,9 @@ plugins:
   steps:
     - id: degledgerrecorder
       config:
+        payloadShape: wave1
+        ledgerUriSource: config
+        ledgerApi: legacy_ledger
         ledgerHost: "https://ledger.example.org"
         role: "BUYER"
         # Signing config automatically loaded from env vars
@@ -136,12 +191,50 @@ plugins:
   steps:
     - id: degledgerrecorder
       config:
+        payloadShape: wave1
+        ledgerUriSource: config
+        ledgerApi: legacy_ledger
         ledgerHost: "https://ledger.example.org"
         role: "BUYER"                    # Platform role
         actions: "on_confirm"            # Default, records trade agreements
         signingPrivateKey: "${SIGNING_PRIVATE_KEY}"
         networkParticipant: "bap.example.org"
         keyId: "bap.example.org.k1"
+```
+
+### Example 2a: Wave 2 — payload-sourced ledger URI
+
+For p2p-trading-ies-wave2 the ledger URL is read per-call from the on_confirm payload:
+
+```yaml
+plugins:
+  steps:
+    - id: degledgerrecorder
+      config:
+        payloadShape: wave2
+        ledgerUriSource: payload         # read from participants[role=*Discom].participantAttributes.ledgerUri
+        ledgerApi: legacy_ledger         # flip to "beckn" once the TSP is upgraded
+        # ledgerHost intentionally omitted — the URI comes from the payload
+        role: "BUYER"                    # BUYER on BAP side reads buyerDiscom; SELLER on BPP reads sellerDiscom
+        actions: "on_confirm"
+        signingPrivateKey: "${SIGNING_PRIVATE_KEY}"
+        networkParticipant: "bap.example.com"
+        keyId: "bap.example.com.k1"
+```
+
+The on_confirm payload must carry, in `message.contract.participants`:
+
+```json
+{
+  "role": "buyerDiscom",
+  "participantId": "buyer-discom-ledger",
+  "participantAttributes": {
+    "@context": ".../specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
+    "@type": "DiscomLedgerProvider",
+    "utilityId": "BRPL-DL",
+    "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+  }
+}
 ```
 
 ### Example 3: Discom Recording (on_status with meter readings)
@@ -151,6 +244,9 @@ plugins:
   steps:
     - id: degledgerrecorder
       config:
+        payloadShape: wave1
+        ledgerUriSource: config
+        ledgerApi: legacy_ledger
         ledgerHost: "https://ledger.example.org"
         role: "BUYER_DISCOM"             # Discom role for validation metrics
         actions: "on_status"             # Record meter readings
@@ -166,6 +262,9 @@ plugins:
   steps:
     - id: degledgerrecorder
       config:
+        payloadShape: wave1
+        ledgerUriSource: config
+        ledgerApi: legacy_ledger
         ledgerHost: "https://ledger.example.org"
         role: "BUYER_DISCOM"             # Use discom role if handling both
         actions: "on_confirm,on_status"  # Handle both actions

--- a/plugins/degledgerrecorder/beckn_rewrite_test.go
+++ b/plugins/degledgerrecorder/beckn_rewrite_test.go
@@ -1,0 +1,131 @@
+package degledgerrecorder
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRewriteContextForBeckn_Wave2CamelCase(t *testing.T) {
+	body := []byte(sampleWave2OnConfirm)
+	out, err := RewriteContextForBeckn(body, "https://bap.example.com", "https://ies-p2p-energy-ledger.beckn.io")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ctx := got["context"].(map[string]interface{})
+
+	if v := ctx["bppUri"]; v != "https://bap.example.com/bpp/caller" {
+		t.Errorf("bppUri: got %v", v)
+	}
+	if v := ctx["bapUri"]; v != "https://ies-p2p-energy-ledger.beckn.io/bap/receiver" {
+		t.Errorf("bapUri: got %v", v)
+	}
+	// Other fields preserved
+	if v := ctx["transactionId"]; v != "txn-p2p-001" {
+		t.Errorf("transactionId clobbered: got %v", v)
+	}
+	if v := ctx["bapId"]; v != "bap.example.com" {
+		t.Errorf("bapId clobbered: got %v", v)
+	}
+}
+
+func TestRewriteContextForBeckn_TrimsTrailingSlashes(t *testing.T) {
+	body := []byte(sampleWave2OnConfirm)
+	out, err := RewriteContextForBeckn(body, "https://bap.example.com/", "https://ledger.example.com//")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	var got map[string]interface{}
+	_ = json.Unmarshal(out, &got)
+	ctx := got["context"].(map[string]interface{})
+	if v := ctx["bppUri"]; v != "https://bap.example.com/bpp/caller" {
+		t.Errorf("bppUri trim failed: got %v", v)
+	}
+	if v := ctx["bapUri"]; v != "https://ledger.example.com/bap/receiver" {
+		t.Errorf("bapUri trim failed: got %v", v)
+	}
+}
+
+func TestRewriteContextForBeckn_SnakeCaseFallback(t *testing.T) {
+	// Wave1-style snake_case context — rewrite must operate on bpp_uri/bap_uri.
+	body := []byte(`{"context":{"bpp_uri":"https://x","bap_uri":"https://y","transaction_id":"t1"},"message":{"order":{}}}`)
+	out, err := RewriteContextForBeckn(body, "https://sender.com", "https://ledger.com")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	var got map[string]interface{}
+	_ = json.Unmarshal(out, &got)
+	ctx := got["context"].(map[string]interface{})
+	if v := ctx["bpp_uri"]; v != "https://sender.com/bpp/caller" {
+		t.Errorf("bpp_uri: got %v", v)
+	}
+	if v := ctx["bap_uri"]; v != "https://ledger.com/bap/receiver" {
+		t.Errorf("bap_uri: got %v", v)
+	}
+	// Camel keys must NOT have been added.
+	if _, present := ctx["bppUri"]; present {
+		t.Errorf("rewrite leaked camel-case bppUri into snake-case payload")
+	}
+}
+
+func TestRewriteContextForBeckn_MissingContextErrors(t *testing.T) {
+	if _, err := RewriteContextForBeckn([]byte(`{}`), "h", "l"); err == nil {
+		t.Errorf("expected error on missing context")
+	}
+}
+
+func TestDeriveSenderHostFromWave2(t *testing.T) {
+	p, err := ParseOnConfirmWave2([]byte(sampleWave2OnConfirm))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := DeriveSenderHostFromWave2(p, "BUYER"); got != "https://bap.example.com" {
+		t.Errorf("BUYER: got %q", got)
+	}
+	if got := DeriveSenderHostFromWave2(p, "SELLER"); got != "https://bpp.example.com" {
+		t.Errorf("SELLER: got %q", got)
+	}
+	if got := DeriveSenderHostFromWave2(p, "BUYER_DISCOM"); got != "" {
+		t.Errorf("unrecognized role: got %q, want empty", got)
+	}
+}
+
+func TestDeriveSenderHostFromWave2_MalformedURI(t *testing.T) {
+	p := &Wave2OnConfirmPayload{}
+	p.Context.BapURI = "not-a-uri"
+	if got := DeriveSenderHostFromWave2(p, "BUYER"); got != "" {
+		t.Errorf("expected empty for unparseable URI, got %q", got)
+	}
+}
+
+// Smoke: when senderHost is missing, the recorder must skip with a warning
+// rather than POST garbage. We exercise that branch indirectly via the
+// helpers — recorder logic is small and reads the same fields here.
+func TestDeriveSenderHost_MissingURIInPayload(t *testing.T) {
+	p := &Wave2OnConfirmPayload{}
+	if got := DeriveSenderHostFromWave2(p, "BUYER"); got != "" {
+		t.Errorf("expected empty when bapUri missing, got %q", got)
+	}
+	if got := DeriveSenderHostFromWave2(p, "SELLER"); got != "" {
+		t.Errorf("expected empty when bppUri missing, got %q", got)
+	}
+}
+
+// Defensive: rewrite leaves message untouched verbatim.
+func TestRewriteContextForBeckn_MessagePreserved(t *testing.T) {
+	body := []byte(sampleWave2OnConfirm)
+	out, err := RewriteContextForBeckn(body, "https://x", "https://y")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !strings.Contains(string(out), `"commitment-p2p-001"`) {
+		t.Errorf("rewrite dropped or altered message body")
+	}
+	if !strings.Contains(string(out), `"der://meter/buyer-001"`) {
+		t.Errorf("rewrite dropped participant attributes")
+	}
+}

--- a/plugins/degledgerrecorder/client.go
+++ b/plugins/degledgerrecorder/client.go
@@ -40,6 +40,18 @@ type LedgerErrorResponse struct {
 	Details map[string]interface{} `json:"details,omitempty"`
 }
 
+// BecknAckEnvelope is the response shape the ledger TSP returns when called
+// over beckn `on_confirm`. The legacy ledger record metadata is wrapped inside
+// `message.ledger` so callers can unwrap it back into a `LedgerPutResponse`.
+type BecknAckEnvelope struct {
+	Message struct {
+		Ack struct {
+			Status string `json:"status"`
+		} `json:"ack"`
+		Ledger LedgerPutResponse `json:"ledger"`
+	} `json:"message"`
+}
+
 // RequestLog captures details of an HTTP request for logging.
 type RequestLog struct {
 	RequestID   string            `json:"request_id"`
@@ -75,8 +87,14 @@ func NewLedgerClient(baseURL string, timeout time.Duration, retryCount int, apiK
 	}
 }
 
-// PutRecord sends a record to the ledger PUT API.
-func (c *LedgerClient) PutRecord(ctx context.Context, record LedgerPutRequest) (*LedgerPutResponse, error) {
+// PutRecord sends a record to the ledger PUT API at the given baseURL. The
+// baseURL is supplied per-call (rather than taken from the client) so the same
+// client can target different discom ledger TSPs based on payload-extracted
+// URIs.
+func (c *LedgerClient) PutRecord(ctx context.Context, baseURL string, record LedgerPutRequest) (*LedgerPutResponse, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("baseURL is required for PutRecord")
+	}
 	var lastErr error
 
 	for attempt := 0; attempt <= c.retryCount; attempt++ {
@@ -85,7 +103,7 @@ func (c *LedgerClient) PutRecord(ctx context.Context, record LedgerPutRequest) (
 				attempt, c.retryCount, record.OrderItemID)
 		}
 
-		resp, err := c.doPutRequest(ctx, record, attempt)
+		resp, err := c.doPutRequest(ctx, baseURL, record, attempt)
 		if err == nil {
 			return resp, nil
 		}
@@ -106,6 +124,145 @@ func (c *LedgerClient) PutRecord(ctx context.Context, record LedgerPutRequest) (
 	}
 
 	return nil, lastErr
+}
+
+// PostBecknOnConfirm forwards a beckn on_confirm body verbatim to a ledger TSP
+// at <baseURL>/on_confirm. The caller must have already rewritten context.bapUri
+// and context.bppUri appropriately. The TSP is expected to return a
+// BecknAckEnvelope; the inner `message.ledger` block is returned as a
+// LedgerPutResponse so call sites can be uniform with the legacy_ledger path.
+func (c *LedgerClient) PostBecknOnConfirm(ctx context.Context, baseURL string, body []byte) (*LedgerPutResponse, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("baseURL is required for PostBecknOnConfirm")
+	}
+	var lastErr error
+	for attempt := 0; attempt <= c.retryCount; attempt++ {
+		if attempt > 0 {
+			fmt.Printf("[DEGLedgerRecorder] Retry attempt %d/%d for beckn on_confirm\n",
+				attempt, c.retryCount)
+		}
+		resp, err := c.doBecknOnConfirmRequest(ctx, baseURL, body, attempt)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("context cancelled: %w", ctx.Err())
+		}
+		if attempt < c.retryCount {
+			backoff := time.Duration(attempt+1) * 100 * time.Millisecond
+			time.Sleep(backoff)
+		}
+	}
+	return nil, lastErr
+}
+
+// doBecknOnConfirmRequest performs a single beckn on_confirm POST.
+func (c *LedgerClient) doBecknOnConfirmRequest(ctx context.Context, baseURL string, body []byte, attempt int) (*LedgerPutResponse, error) {
+	requestID := uuid.New().String()[:8]
+	startTime := time.Now()
+
+	url := fmt.Sprintf("%s/on_confirm", strings.TrimRight(baseURL, "/"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Request-ID", requestID)
+
+	if c.signer != nil && c.signer.IsConfigured() {
+		authHeader, err := c.signer.GenerateAuthHeader(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate Authorization header: %w", err)
+		}
+		req.Header.Set("Authorization", authHeader)
+	} else if c.apiKey != "" {
+		req.Header.Set(c.authHeader, c.apiKey)
+	}
+
+	c.logBecknRequest(requestID, req, body, attempt)
+
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(startTime)
+	if err != nil {
+		c.logError(requestID, "HTTP request failed", err, duration)
+		return nil, fmt.Errorf("ledger beckn on_confirm request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logError(requestID, "Failed to read response body", err, duration)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	c.logResponse(requestID, resp, respBody, duration)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var envelope BecknAckEnvelope
+		if err := json.Unmarshal(respBody, &envelope); err != nil {
+			return nil, fmt.Errorf("failed to parse beckn ack envelope: %w", err)
+		}
+		// Surface the inner ledger response so call sites are uniform.
+		ledger := envelope.Message.Ledger
+		return &ledger, nil
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusConflict:
+		var errResp LedgerErrorResponse
+		if err := json.Unmarshal(respBody, &errResp); err != nil {
+			return nil, fmt.Errorf("ledger TSP error (status %d): %s", resp.StatusCode, string(respBody))
+		}
+		return nil, fmt.Errorf("ledger TSP error (status %d, code %s): %s", resp.StatusCode, errResp.Code, errResp.Message)
+	default:
+		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(respBody))
+	}
+}
+
+// logBecknRequest renders the outgoing beckn on_confirm body in the same
+// boxed-banner style as the legacy ledger logger.
+func (c *LedgerClient) logBecknRequest(requestID string, req *http.Request, body []byte, attempt int) {
+	headers := make(map[string]string)
+	for key, values := range req.Header {
+		value := strings.Join(values, ", ")
+		if strings.Contains(strings.ToLower(key), "auth") ||
+			strings.Contains(strings.ToLower(key), "api-key") ||
+			strings.Contains(strings.ToLower(key), "x-api-key") ||
+			key == c.authHeader {
+			if len(value) > 8 {
+				headers[key] = value[:4] + "****" + value[len(value)-4:]
+			} else {
+				headers[key] = "****"
+			}
+		} else {
+			headers[key] = value
+		}
+	}
+
+	fmt.Println("")
+	fmt.Println("╔════════════════════════════════════════════════════════════════════╗")
+	fmt.Println("║       DEGLedgerRecorder - OUTGOING REQUEST (BECKN on_confirm)      ║")
+	fmt.Println("╠════════════════════════════════════════════════════════════════════╣")
+	fmt.Printf("║ Request ID:     %s\n", requestID)
+	fmt.Printf("║ Timestamp:      %s\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Printf("║ Attempt:        %d/%d\n", attempt+1, c.retryCount+1)
+	fmt.Printf("║ Method:         %s\n", req.Method)
+	fmt.Printf("║ URL:            %s\n", req.URL.String())
+	fmt.Println("╠════════════════════════════════════════════════════════════════════╣")
+	fmt.Println("║ HEADERS:")
+	for k, v := range headers {
+		fmt.Printf("║   %s: %s\n", k, v)
+	}
+	fmt.Println("╠════════════════════════════════════════════════════════════════════╣")
+	fmt.Println("║ REQUEST BODY (JSON):")
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, body, "║   ", "  "); err == nil {
+		for _, line := range strings.Split(pretty.String(), "\n") {
+			fmt.Printf("║   %s\n", line)
+		}
+	} else {
+		fmt.Printf("║   %s\n", string(body))
+	}
+	fmt.Println("╚════════════════════════════════════════════════════════════════════╝")
 }
 
 // RecordActuals sends meter readings/validation metrics to the ledger RECORD API.
@@ -230,7 +387,7 @@ func (c *LedgerClient) doRecordRequest(ctx context.Context, record LedgerRecordR
 }
 
 // doPutRequest performs a single PUT request to the ledger API.
-func (c *LedgerClient) doPutRequest(ctx context.Context, record LedgerPutRequest, attempt int) (*LedgerPutResponse, error) {
+func (c *LedgerClient) doPutRequest(ctx context.Context, baseURL string, record LedgerPutRequest, attempt int) (*LedgerPutResponse, error) {
 	// Generate unique request ID for correlation
 	requestID := uuid.New().String()[:8]
 	startTime := time.Now()
@@ -242,7 +399,7 @@ func (c *LedgerClient) doPutRequest(ctx context.Context, record LedgerPutRequest
 	}
 
 	// Create the HTTP request
-	url := fmt.Sprintf("%s/ledger/put", c.baseURL)
+	url := fmt.Sprintf("%s/ledger/put", baseURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/plugins/degledgerrecorder/config.go
+++ b/plugins/degledgerrecorder/config.go
@@ -24,10 +24,50 @@ const (
 	ActionOnStatus  = "on_status"
 )
 
+// Supported payload shapes — selects which mapper parses the on_confirm body.
+const (
+	PayloadShapeWave1 = "wave1" // beckn:Order / beckn:orderItems (p2p-trading-ies-wave1)
+	PayloadShapeWave2 = "wave2" // message.contract.commitments (p2p-trading-ies-wave2)
+)
+
+// Sources for the target ledger URI.
+const (
+	LedgerUriSourceConfig  = "config"  // use plugin config ledgerHost
+	LedgerUriSourcePayload = "payload" // read participants[role=*Discom].participantAttributes.ledgerUri from payload
+)
+
+// Ledger API styles the plugin can speak to.
+const (
+	LedgerApiLegacyLedger = "legacy_ledger" // POST <uri>/ledger/put with custom JSON body
+	LedgerApiBeckn        = "beckn"         // POST verbatim on_confirm to <uri>/on_confirm with rewritten context
+)
+
 // Config holds the configuration for the DEG Ledger Recorder plugin.
 type Config struct {
-	// LedgerHost is the base URL of the DEG Ledger service (e.g., "https://ledger.example.org")
+	// PayloadShape selects which on_confirm body the mapper expects.
+	// Required. One of: "wave1", "wave2".
+	PayloadShape string
+
+	// LedgerUriSource determines where the target ledger URI comes from.
+	// Required. One of: "config" (uses LedgerHost), "payload" (reads
+	// participants[role=*Discom].participantAttributes.ledgerUri).
+	LedgerUriSource string
+
+	// LedgerApi selects which API style the plugin speaks.
+	// Required. One of: "legacy_ledger" (POST <uri>/ledger/put with custom
+	// JSON), "beckn" (POST verbatim on_confirm to <uri>/on_confirm).
+	LedgerApi string
+
+	// LedgerHost is the base URL of the DEG Ledger service.
+	// Required only when LedgerUriSource == "config".
 	LedgerHost string
+
+	// SenderHost is the base URL (scheme + host[:port]) the plugin advertises
+	// when forwarding a beckn on_confirm to a ledger TSP. Used only when
+	// LedgerApi == "beckn" to rewrite context.bppUri to "<SenderHost>/bpp/caller".
+	// Optional — falls back to the host of context.bapUri (BUYER role) or
+	// context.bppUri (SELLER role) extracted from the incoming payload.
+	SenderHost string
 
 	// Role is the ledger role for this platform (BUYER, SELLER, BUYER_DISCOM, SELLER_DISCOM)
 	Role string
@@ -79,9 +119,16 @@ type Config struct {
 }
 
 // DefaultConfig returns a Config with sensible defaults.
+// Note: PayloadShape, LedgerUriSource, and LedgerApi have no defaults — the
+// caller must set them in YAML so the active behavior is always visible there
+// instead of hidden in code.
 func DefaultConfig() *Config {
 	return &Config{
+		PayloadShape:             "",
+		LedgerUriSource:          "",
+		LedgerApi:                "",
 		LedgerHost:               "",
+		SenderHost:               "",
 		Role:                     "BUYER",
 		Actions:                  []string{ActionOnConfirm}, // Default: only on_confirm
 		Enabled:                  true,
@@ -101,11 +148,47 @@ func DefaultConfig() *Config {
 func ParseConfig(cfg map[string]string) (*Config, error) {
 	config := DefaultConfig()
 
+	// payloadShape — required, no default
+	shape, ok := cfg["payloadShape"]
+	if !ok || shape == "" {
+		return nil, fmt.Errorf("payloadShape is required (one of: %s, %s)", PayloadShapeWave1, PayloadShapeWave2)
+	}
+	if !isValidPayloadShape(shape) {
+		return nil, fmt.Errorf("invalid payloadShape: %s (must be %s or %s)", shape, PayloadShapeWave1, PayloadShapeWave2)
+	}
+	config.PayloadShape = shape
+
+	// ledgerUriSource — required, no default
+	source, ok := cfg["ledgerUriSource"]
+	if !ok || source == "" {
+		return nil, fmt.Errorf("ledgerUriSource is required (one of: %s, %s)", LedgerUriSourceConfig, LedgerUriSourcePayload)
+	}
+	if !isValidLedgerUriSource(source) {
+		return nil, fmt.Errorf("invalid ledgerUriSource: %s (must be %s or %s)", source, LedgerUriSourceConfig, LedgerUriSourcePayload)
+	}
+	config.LedgerUriSource = source
+
+	// ledgerApi — required, no default
+	api, ok := cfg["ledgerApi"]
+	if !ok || api == "" {
+		return nil, fmt.Errorf("ledgerApi is required (one of: %s, %s)", LedgerApiLegacyLedger, LedgerApiBeckn)
+	}
+	if !isValidLedgerApi(api) {
+		return nil, fmt.Errorf("invalid ledgerApi: %s (must be %s or %s)", api, LedgerApiLegacyLedger, LedgerApiBeckn)
+	}
+	config.LedgerApi = api
+
+	// ledgerHost — required only when ledgerUriSource = config
 	if host, ok := cfg["ledgerHost"]; ok && host != "" {
 		config.LedgerHost = host
 	}
-	if config.LedgerHost == "" {
-		return nil, fmt.Errorf("ledgerHost is required")
+	if config.LedgerUriSource == LedgerUriSourceConfig && config.LedgerHost == "" {
+		return nil, fmt.Errorf("ledgerHost is required when ledgerUriSource=%s", LedgerUriSourceConfig)
+	}
+
+	// senderHost — optional; only consulted when ledgerApi=beckn
+	if sh, ok := cfg["senderHost"]; ok && sh != "" {
+		config.SenderHost = sh
 	}
 
 	if role, ok := cfg["role"]; ok && role != "" {
@@ -258,6 +341,21 @@ func isValidAction(action string) bool {
 		ActionOnStatus:  true,
 	}
 	return validActions[action]
+}
+
+// isValidPayloadShape checks if the provided payload shape is supported.
+func isValidPayloadShape(shape string) bool {
+	return shape == PayloadShapeWave1 || shape == PayloadShapeWave2
+}
+
+// isValidLedgerUriSource checks if the provided ledger URI source is supported.
+func isValidLedgerUriSource(source string) bool {
+	return source == LedgerUriSourceConfig || source == LedgerUriSourcePayload
+}
+
+// isValidLedgerApi checks if the provided ledger API style is supported.
+func isValidLedgerApi(api string) bool {
+	return api == LedgerApiLegacyLedger || api == LedgerApiBeckn
 }
 
 // IsActionEnabled checks if the given action is enabled in the config.

--- a/plugins/degledgerrecorder/config_test.go
+++ b/plugins/degledgerrecorder/config_test.go
@@ -1,0 +1,103 @@
+package degledgerrecorder
+
+import (
+	"strings"
+	"testing"
+)
+
+// baseValidCfg returns a minimal valid config map for a wave2/payload setup.
+func baseValidCfg() map[string]string {
+	return map[string]string{
+		"payloadShape":    "wave2",
+		"ledgerUriSource": "payload",
+		"ledgerApi":       "legacy_ledger",
+	}
+}
+
+func TestParseConfig_RequiresPayloadShape(t *testing.T) {
+	cfg := baseValidCfg()
+	delete(cfg, "payloadShape")
+	if _, err := ParseConfig(cfg); err == nil {
+		t.Fatalf("expected error when payloadShape is missing")
+	}
+}
+
+func TestParseConfig_RequiresLedgerUriSource(t *testing.T) {
+	cfg := baseValidCfg()
+	delete(cfg, "ledgerUriSource")
+	if _, err := ParseConfig(cfg); err == nil {
+		t.Fatalf("expected error when ledgerUriSource is missing")
+	}
+}
+
+func TestParseConfig_RequiresLedgerApi(t *testing.T) {
+	cfg := baseValidCfg()
+	delete(cfg, "ledgerApi")
+	if _, err := ParseConfig(cfg); err == nil {
+		t.Fatalf("expected error when ledgerApi is missing")
+	}
+}
+
+func TestParseConfig_RejectsInvalidValues(t *testing.T) {
+	cases := []struct {
+		key, val string
+	}{
+		{"payloadShape", "wave99"},
+		{"ledgerUriSource", "elsewhere"},
+		{"ledgerApi", "rest"},
+	}
+	for _, c := range cases {
+		cfg := baseValidCfg()
+		cfg[c.key] = c.val
+		_, err := ParseConfig(cfg)
+		if err == nil {
+			t.Errorf("expected error for %s=%s", c.key, c.val)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.key) {
+			t.Errorf("error %q should mention %q", err.Error(), c.key)
+		}
+	}
+}
+
+func TestParseConfig_LedgerHostRequiredWhenSourceConfig(t *testing.T) {
+	cfg := baseValidCfg()
+	cfg["ledgerUriSource"] = "config"
+	if _, err := ParseConfig(cfg); err == nil {
+		t.Fatalf("expected error when ledgerUriSource=config and ledgerHost is empty")
+	}
+
+	cfg["ledgerHost"] = "https://ledger.example.com"
+	got, err := ParseConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error with ledgerHost set: %v", err)
+	}
+	if got.LedgerHost != "https://ledger.example.com" {
+		t.Errorf("LedgerHost: got %q", got.LedgerHost)
+	}
+}
+
+func TestParseConfig_LedgerHostNotRequiredWhenSourcePayload(t *testing.T) {
+	cfg := baseValidCfg() // ledgerUriSource=payload, no ledgerHost
+	got, err := ParseConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.LedgerHost != "" {
+		t.Errorf("expected empty LedgerHost, got %q", got.LedgerHost)
+	}
+}
+
+func TestParseConfig_AcceptsAllValidCombos(t *testing.T) {
+	combos := []map[string]string{
+		{"payloadShape": "wave1", "ledgerUriSource": "config", "ledgerApi": "legacy_ledger", "ledgerHost": "https://x"},
+		{"payloadShape": "wave2", "ledgerUriSource": "payload", "ledgerApi": "legacy_ledger"},
+		{"payloadShape": "wave2", "ledgerUriSource": "payload", "ledgerApi": "beckn"},
+		{"payloadShape": "wave1", "ledgerUriSource": "config", "ledgerApi": "beckn", "ledgerHost": "https://x"},
+	}
+	for _, cfg := range combos {
+		if _, err := ParseConfig(cfg); err != nil {
+			t.Errorf("combo %+v should parse cleanly, got %v", cfg, err)
+		}
+	}
+}

--- a/plugins/degledgerrecorder/mapper_wave2.go
+++ b/plugins/degledgerrecorder/mapper_wave2.go
@@ -1,0 +1,291 @@
+package degledgerrecorder
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+)
+
+// Side identifies which discom's ledgerUri to read from the payload.
+type Side string
+
+const (
+	SideBuyer  Side = "buyerDiscom"
+	SideSeller Side = "sellerDiscom"
+)
+
+// Wave2OnConfirmPayload is the wave2 (P2PTrade/v2.0) on_confirm body.
+// Wave2 uses camelCase context keys and a `message.contract.commitments` shape.
+type Wave2OnConfirmPayload struct {
+	Context Wave2Context `json:"context"`
+	Message struct {
+		Contract Wave2Contract `json:"contract"`
+	} `json:"message"`
+}
+
+// Wave2Context — wave2 uses camelCase (bapId, bppId, transactionId), not snake_case.
+type Wave2Context struct {
+	NetworkID     string `json:"networkId"`
+	Version       string `json:"version"`
+	Action        string `json:"action"`
+	BapID         string `json:"bapId"`
+	BapURI        string `json:"bapUri"`
+	BppID         string `json:"bppId"`
+	BppURI        string `json:"bppUri"`
+	TransactionID string `json:"transactionId"`
+	MessageID     string `json:"messageId"`
+	Timestamp     string `json:"timestamp"`
+}
+
+// Wave2Contract is `message.contract`.
+type Wave2Contract struct {
+	ID                 string                 `json:"id"`
+	Commitments        []Wave2Commitment      `json:"commitments"`
+	Participants       []Wave2Participant     `json:"participants"`
+	ContractAttributes map[string]interface{} `json:"contractAttributes"`
+}
+
+// Wave2Commitment is `message.contract.commitments[*]`.
+type Wave2Commitment struct {
+	ID        string          `json:"id"`
+	Resources []Wave2Resource `json:"resources"`
+	Offer     Wave2Offer      `json:"offer"`
+}
+
+// Wave2Resource is `commitments[*].resources[*]`.
+type Wave2Resource struct {
+	ID       string        `json:"id"`
+	Quantity Wave2Quantity `json:"quantity"`
+}
+
+// Wave2Quantity captures unitCode + unitQuantity (kWh, kW, etc.).
+type Wave2Quantity struct {
+	UnitCode     string  `json:"unitCode"`
+	UnitQuantity float64 `json:"unitQuantity"`
+}
+
+// Wave2Offer is `commitments[*].offer`.
+type Wave2Offer struct {
+	ID              string                 `json:"id"`
+	ResourceIDs     []string               `json:"resourceIds"`
+	OfferAttributes map[string]interface{} `json:"offerAttributes"`
+}
+
+// Wave2Participant is `contract.participants[*]`. participantAttributes is
+// loose-typed because its shape varies by role: EnergyCustomer for buyer/seller,
+// DiscomLedgerProvider for buyerDiscom/sellerDiscom.
+type Wave2Participant struct {
+	Role                  string                 `json:"role"`
+	ParticipantID         string                 `json:"participantId"`
+	ParticipantAttributes map[string]interface{} `json:"participantAttributes"`
+}
+
+// ParseOnConfirmWave2 unmarshals a wave2 on_confirm body.
+func ParseOnConfirmWave2(body []byte) (*Wave2OnConfirmPayload, error) {
+	var payload Wave2OnConfirmPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse wave2 on_confirm payload: %w", err)
+	}
+	return &payload, nil
+}
+
+// MapWave2ToLedgerRecord builds a single LedgerPutRequest from a wave2 on_confirm
+// payload. orderItemId == context.transactionId per the wave2 mapping
+// (one ledger record per transaction; multi-commitment is collapsed by taking
+// the first commitment).
+func MapWave2ToLedgerRecord(payload *Wave2OnConfirmPayload, role string) (LedgerPutRequest, error) {
+	if len(payload.Message.Contract.Commitments) == 0 {
+		return LedgerPutRequest{}, fmt.Errorf("wave2 payload has no commitments")
+	}
+	commitment := payload.Message.Contract.Commitments[0]
+	if len(payload.Message.Contract.Commitments) > 1 {
+		log.Printf("WARNING: wave2 payload has %d commitments; using only the first (txn: %s)",
+			len(payload.Message.Contract.Commitments), payload.Context.TransactionID)
+	}
+
+	buyerPart := findWave2Participant(payload.Message.Contract.Participants, "buyer")
+	sellerPart := findWave2Participant(payload.Message.Contract.Participants, "seller")
+
+	deliveryStart, deliveryEnd := extractWave2DeliveryWindow(commitment.Offer.OfferAttributes)
+	if deliveryStart == "" {
+		log.Printf("WARNING: wave2 deliveryStartTime not found (txn: %s, commitment: %s)",
+			payload.Context.TransactionID, commitment.ID)
+	}
+	if deliveryEnd == "" {
+		log.Printf("WARNING: wave2 deliveryEndTime not found (txn: %s, commitment: %s)",
+			payload.Context.TransactionID, commitment.ID)
+	}
+
+	tradeQty, tradeUnit := extractWave2QuantityAndUnit(commitment.Resources)
+
+	record := LedgerPutRequest{
+		Role:              role,
+		TransactionID:     payload.Context.TransactionID,
+		OrderItemID:       payload.Context.TransactionID, // wave2: single record per txn
+		PlatformIDBuyer:   payload.Context.BapID,
+		PlatformIDSeller:  payload.Context.BppID,
+		DiscomIDBuyer:     wave2StringAttr(buyerPart, "utilityId"),
+		DiscomIDSeller:    wave2StringAttr(sellerPart, "utilityId"),
+		BuyerID:           wave2StringAttr(buyerPart, "meterId"),
+		SellerID:          wave2StringAttr(sellerPart, "meterId"),
+		TradeTime:         payload.Context.Timestamp,
+		DeliveryStartTime: deliveryStart,
+		DeliveryEndTime:   deliveryEnd,
+		TradeDetails: []TradeDetail{
+			{
+				TradeQty:  tradeQty,
+				TradeType: "ENERGY",
+				TradeUnit: normalizeTradeUnit(tradeUnit),
+			},
+		},
+		ClientReference: generateClientReference(payload.Context.TransactionID, payload.Context.TransactionID),
+	}
+	return record, nil
+}
+
+// ExtractWave2DiscomLedgerUri returns the ledgerUri for the requested side from
+// `participants[role=buyerDiscom|sellerDiscom].participantAttributes.ledgerUri`.
+// Returns "" if the side is missing or has no ledgerUri.
+func ExtractWave2DiscomLedgerUri(payload *Wave2OnConfirmPayload, side Side) string {
+	part := findWave2Participant(payload.Message.Contract.Participants, string(side))
+	return wave2StringAttr(part, "ledgerUri")
+}
+
+// findWave2Participant returns the first participant entry matching the role.
+func findWave2Participant(participants []Wave2Participant, role string) *Wave2Participant {
+	for i := range participants {
+		if participants[i].Role == role {
+			return &participants[i]
+		}
+	}
+	return nil
+}
+
+// wave2StringAttr reads a string attribute from a participant's participantAttributes.
+func wave2StringAttr(p *Wave2Participant, key string) string {
+	if p == nil || p.ParticipantAttributes == nil {
+		return ""
+	}
+	if v, ok := p.ParticipantAttributes[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractWave2DeliveryWindow walks
+// offerAttributes.inputs[role=seller].inputs.offers[0].deliveryWindow.{schema:startTime, schema:endTime}.
+// Returns ("", "") if any hop is missing.
+func extractWave2DeliveryWindow(offerAttrs map[string]interface{}) (string, string) {
+	if offerAttrs == nil {
+		return "", ""
+	}
+	inputs, ok := offerAttrs["inputs"].([]interface{})
+	if !ok {
+		return "", ""
+	}
+	for _, raw := range inputs {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if entry["role"] != "seller" {
+			continue
+		}
+		inner, ok := entry["inputs"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		offers, ok := inner["offers"].([]interface{})
+		if !ok || len(offers) == 0 {
+			continue
+		}
+		first, ok := offers[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		dw, ok := first["deliveryWindow"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		start, _ := dw["schema:startTime"].(string)
+		end, _ := dw["schema:endTime"].(string)
+		return start, end
+	}
+	return "", ""
+}
+
+// extractWave2QuantityAndUnit reads the first resource's quantity. wave2 keeps
+// trade qty/unit on commitment.resources[0].quantity; returns 0 / "" if missing.
+func extractWave2QuantityAndUnit(resources []Wave2Resource) (float64, string) {
+	if len(resources) == 0 {
+		return 0, ""
+	}
+	q := resources[0].Quantity
+	return q.UnitQuantity, q.UnitCode
+}
+
+// RewriteContextForBeckn rewrites context.bppUri and context.bapUri on the
+// raw on_confirm body so that, from the ledger TSP's POV:
+//   - bppUri = "<senderHost>/bpp/caller"   — the platform sending this call
+//   - bapUri = "<ledgerURI>/bap/receiver"  — the TSP itself, as the receiving BAP
+//
+// Everything else (other context fields, message body) is preserved verbatim.
+// Handles both wave2 (camelCase: bapUri/bppUri) and wave1 (snake_case:
+// bap_uri/bpp_uri) shapes by detecting which key style the original uses.
+func RewriteContextForBeckn(body []byte, senderHost, ledgerURI string) ([]byte, error) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("rewriteContext: parse body: %w", err)
+	}
+	ctxRaw, ok := raw["context"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("rewriteContext: missing or invalid context")
+	}
+
+	bppKey, bapKey := "bppUri", "bapUri"
+	if _, hasCamel := ctxRaw[bppKey]; !hasCamel {
+		if _, hasSnake := ctxRaw["bpp_uri"]; hasSnake {
+			bppKey, bapKey = "bpp_uri", "bap_uri"
+		}
+	}
+
+	ctxRaw[bppKey] = strings.TrimRight(senderHost, "/") + "/bpp/caller"
+	ctxRaw[bapKey] = strings.TrimRight(ledgerURI, "/") + "/bap/receiver"
+	raw["context"] = ctxRaw
+
+	return json.Marshal(raw)
+}
+
+// DeriveSenderHostFromWave2 returns "<scheme>://<host[:port]>" extracted from
+// the original payload's bapUri (BUYER role) or bppUri (SELLER role). Used as
+// a fallback when SenderHost is not configured explicitly. Returns "" if the
+// chosen URI is missing or unparseable.
+func DeriveSenderHostFromWave2(payload *Wave2OnConfirmPayload, role string) string {
+	var rawURI string
+	switch role {
+	case "BUYER":
+		rawURI = payload.Context.BapURI
+	case "SELLER":
+		rawURI = payload.Context.BppURI
+	default:
+		return ""
+	}
+	return hostBase(rawURI)
+}
+
+// hostBase parses a URI and returns "<scheme>://<host[:port]>", or "" if the
+// URI is missing or unparseable.
+func hostBase(rawURI string) string {
+	if rawURI == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURI)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}

--- a/plugins/degledgerrecorder/mapper_wave2_test.go
+++ b/plugins/degledgerrecorder/mapper_wave2_test.go
@@ -1,0 +1,202 @@
+package degledgerrecorder
+
+import (
+	"testing"
+)
+
+// Trimmed wave2 on_confirm body covering all the fields the mapper reads:
+// context (transactionId, bapId, bppId, timestamp), participants
+// (buyer/seller with utilityId+meterId, buyerDiscom/sellerDiscom with
+// ledgerUri), and a single commitment with a seller-side delivery window.
+const sampleWave2OnConfirm = `{
+  "context": {
+    "networkId": "nfh.global/testnet-deg",
+    "version": "2.0.0",
+    "action": "on_confirm",
+    "bapId": "bap.example.com",
+    "bapUri": "https://bap.example.com/beckn",
+    "bppId": "bpp.example.com",
+    "bppUri": "https://bpp.example.com/beckn",
+    "transactionId": "txn-p2p-001",
+    "messageId": "msg-on-confirm-001",
+    "timestamp": "2026-04-25T10:10:05Z"
+  },
+  "message": {
+    "contract": {
+      "id": "contract-p2p-001",
+      "commitments": [
+        {
+          "id": "commitment-p2p-001",
+          "resources": [
+            {
+              "id": "energy-resource-solar-001",
+              "quantity": {
+                "@type": "Quantity",
+                "unitCode": "KWH",
+                "unitQuantity": 35.0
+              }
+            }
+          ],
+          "offer": {
+            "id": "offer-p2p-001",
+            "offerAttributes": {
+              "@type": "EnergyTradeOffer",
+              "inputs": [
+                {
+                  "role": "seller",
+                  "participantId": "TPDDL-DL-seller-001",
+                  "inputs": {
+                    "offers": [
+                      {
+                        "pricePerKwh": 12,
+                        "deliveryWindow": {
+                          "@type": "beckn:TimePeriod",
+                          "schema:startTime": "2026-04-26T04:30:00Z",
+                          "schema:endTime": "2026-04-26T05:30:00Z"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "role": "buyer",
+                  "participantId": "BRPL-DL-buyer-001",
+                  "inputs": {}
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "participants": [
+        {
+          "role": "seller",
+          "participantId": "TPDDL-DL-seller-001",
+          "participantAttributes": {
+            "@type": "EnergyCustomer",
+            "meterId": "der://meter/seller-001",
+            "utilityId": "TPDDL-DL",
+            "utilityCustomerId": "TPDDL-CUST-S-001"
+          }
+        },
+        {
+          "role": "buyer",
+          "participantId": "BRPL-DL-buyer-001",
+          "participantAttributes": {
+            "@type": "EnergyCustomer",
+            "meterId": "der://meter/buyer-001",
+            "utilityId": "BRPL-DL",
+            "utilityCustomerId": "BRPL-CUST-B-001"
+          }
+        },
+        {
+          "role": "buyerDiscom",
+          "participantId": "buyer-discom-ledger",
+          "participantAttributes": {
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "BRPL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
+        },
+        {
+          "role": "sellerDiscom",
+          "participantId": "seller-discom-ledger",
+          "participantAttributes": {
+            "@type": "DiscomLedgerProvider",
+            "utilityId": "TPDDL-DL",
+            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+          }
+        }
+      ]
+    }
+  }
+}`
+
+func TestParseOnConfirmWave2_ContextFields(t *testing.T) {
+	p, err := ParseOnConfirmWave2([]byte(sampleWave2OnConfirm))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if p.Context.TransactionID != "txn-p2p-001" {
+		t.Errorf("transactionId: got %q", p.Context.TransactionID)
+	}
+	if p.Context.BapID != "bap.example.com" || p.Context.BppID != "bpp.example.com" {
+		t.Errorf("bapId/bppId: got %q/%q", p.Context.BapID, p.Context.BppID)
+	}
+	if len(p.Message.Contract.Commitments) != 1 {
+		t.Errorf("commitments: got %d", len(p.Message.Contract.Commitments))
+	}
+}
+
+func TestMapWave2ToLedgerRecord_AllFields(t *testing.T) {
+	p, err := ParseOnConfirmWave2([]byte(sampleWave2OnConfirm))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rec, err := MapWave2ToLedgerRecord(p, "BUYER")
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+
+	checks := []struct{ name, got, want string }{
+		{"role", rec.Role, "BUYER"},
+		{"transactionId", rec.TransactionID, "txn-p2p-001"},
+		{"orderItemId", rec.OrderItemID, "txn-p2p-001"}, // wave2: orderItemId == transactionId
+		{"platformIdBuyer", rec.PlatformIDBuyer, "bap.example.com"},
+		{"platformIdSeller", rec.PlatformIDSeller, "bpp.example.com"},
+		{"discomIdBuyer", rec.DiscomIDBuyer, "BRPL-DL"},
+		{"discomIdSeller", rec.DiscomIDSeller, "TPDDL-DL"},
+		{"buyerId", rec.BuyerID, "der://meter/buyer-001"},
+		{"sellerId", rec.SellerID, "der://meter/seller-001"},
+		{"tradeTime", rec.TradeTime, "2026-04-25T10:10:05Z"},
+		{"deliveryStartTime", rec.DeliveryStartTime, "2026-04-26T04:30:00Z"},
+		{"deliveryEndTime", rec.DeliveryEndTime, "2026-04-26T05:30:00Z"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+
+	if len(rec.TradeDetails) != 1 {
+		t.Fatalf("tradeDetails: got %d", len(rec.TradeDetails))
+	}
+	td := rec.TradeDetails[0]
+	if td.TradeQty != 35.0 || td.TradeUnit != "KWH" || td.TradeType != "ENERGY" {
+		t.Errorf("tradeDetail: got qty=%v, unit=%q, type=%q", td.TradeQty, td.TradeUnit, td.TradeType)
+	}
+}
+
+func TestExtractWave2DiscomLedgerUri(t *testing.T) {
+	p, err := ParseOnConfirmWave2([]byte(sampleWave2OnConfirm))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := ExtractWave2DiscomLedgerUri(p, SideBuyer); got != "https://ies-p2p-energy-ledger.beckn.io" {
+		t.Errorf("buyerDiscom ledgerUri: got %q", got)
+	}
+	if got := ExtractWave2DiscomLedgerUri(p, SideSeller); got != "https://ies-p2p-energy-ledger.beckn.io" {
+		t.Errorf("sellerDiscom ledgerUri: got %q", got)
+	}
+}
+
+func TestExtractWave2DiscomLedgerUri_MissingReturnsEmpty(t *testing.T) {
+	const noLedgerUri = `{"context":{"transactionId":"x"},"message":{"contract":{"participants":[{"role":"buyerDiscom","participantId":"x"}]}}}`
+	p, err := ParseOnConfirmWave2([]byte(noLedgerUri))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := ExtractWave2DiscomLedgerUri(p, SideBuyer); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+	if got := ExtractWave2DiscomLedgerUri(p, SideSeller); got != "" {
+		t.Errorf("expected empty for missing side, got %q", got)
+	}
+}
+
+func TestMapWave2_NoCommitmentsErrors(t *testing.T) {
+	p := &Wave2OnConfirmPayload{}
+	if _, err := MapWave2ToLedgerRecord(p, "BUYER"); err == nil {
+		t.Errorf("expected error for empty commitments, got nil")
+	}
+}

--- a/plugins/degledgerrecorder/recorder.go
+++ b/plugins/degledgerrecorder/recorder.go
@@ -53,9 +53,11 @@ func New(cfg map[string]string) (*DEGLedgerRecorder, error) {
 		fmt.Printf("[DEGLedgerRecorder] WARNING: No authentication configured for ledger API calls\n")
 	}
 
-	// Log enabled actions and role
-	fmt.Printf("[DEGLedgerRecorder] Enabled actions: [%s], role: %s\n",
-		strings.Join(config.Actions, ", "), config.Role)
+	// Log enabled actions, role, and the three required mode flags so the
+	// active behavior is visible at startup.
+	fmt.Printf("[DEGLedgerRecorder] payloadShape=%s, ledgerUriSource=%s, ledgerApi=%s, role=%s, actions=[%s]\n",
+		config.PayloadShape, config.LedgerUriSource, config.LedgerApi, config.Role,
+		strings.Join(config.Actions, ", "))
 
 	client := NewLedgerClient(
 		config.LedgerHost,
@@ -104,50 +106,172 @@ func (r *DEGLedgerRecorder) Run(ctx *model.StepContext) error {
 }
 
 // handleOnConfirm processes on_confirm events and sends to /ledger/put.
+// Branches on PayloadShape (wave1 vs wave2) and resolves the target ledger
+// base URL per LedgerUriSource (config vs payload).
 func (r *DEGLedgerRecorder) handleOnConfirm(ctx *model.StepContext) error {
-	log.Infof(ctx, "DEGLedgerRecorder: processing on_confirm")
+	log.Infof(ctx, "DEGLedgerRecorder: processing on_confirm (payloadShape=%s, ledgerUriSource=%s, ledgerApi=%s)",
+		r.config.PayloadShape, r.config.LedgerUriSource, r.config.LedgerApi)
 
-	// DEBUG: Log the raw body received
-	log.Debugf(ctx, "DEGLedgerRecorder DEBUG: raw body length=%d", len(ctx.Body))
 	if len(ctx.Body) < 5000 {
 		log.Debugf(ctx, "DEGLedgerRecorder DEBUG: raw body:\n%s", string(ctx.Body))
 	} else {
 		log.Debugf(ctx, "DEGLedgerRecorder DEBUG: raw body (truncated):\n%s...", string(ctx.Body[:5000]))
 	}
 
-	// Parse the on_confirm payload
+	switch r.config.PayloadShape {
+	case PayloadShapeWave1:
+		return r.handleOnConfirmWave1(ctx)
+	case PayloadShapeWave2:
+		return r.handleOnConfirmWave2(ctx)
+	default:
+		log.Warnf(ctx, "DEGLedgerRecorder: unsupported payloadShape=%s", r.config.PayloadShape)
+		return nil
+	}
+}
+
+// handleOnConfirmWave1 — legacy wave1 path: parses beckn:Order/orderItems and
+// emits one ledger record per order item.
+func (r *DEGLedgerRecorder) handleOnConfirmWave1(ctx *model.StepContext) error {
+	if r.config.LedgerApi != LedgerApiLegacyLedger {
+		log.Warnf(ctx, "DEGLedgerRecorder: wave1 path only supports ledgerApi=legacy_ledger (got %s); skipping",
+			r.config.LedgerApi)
+		return nil
+	}
 	payload, err := ParseOnConfirm(ctx.Body)
 	if err != nil {
-		log.Warnf(ctx, "DEGLedgerRecorder: failed to parse on_confirm payload: %v", err)
+		log.Warnf(ctx, "DEGLedgerRecorder: failed to parse wave1 on_confirm payload: %v", err)
 		return nil
 	}
 
-	// DEBUG: Log parsed payload details
-	log.Debugf(ctx, "DEGLedgerRecorder DEBUG: parsed context - transaction_id=%s, action=%s, bap_id=%s, bpp_id=%s",
-		payload.Context.TransactionID, payload.Context.Action, payload.Context.BapID, payload.Context.BppID)
-	log.Debugf(ctx, "DEGLedgerRecorder DEBUG: order items count=%d", len(payload.Message.Order.OrderItems))
+	log.Debugf(ctx, "DEGLedgerRecorder DEBUG: parsed wave1 context - transaction_id=%s, bap_id=%s, bpp_id=%s",
+		payload.Context.TransactionID, payload.Context.BapID, payload.Context.BppID)
 
-	// Map to ledger records (one per order item)
 	records := MapToLedgerRecords(payload, r.config.Role)
-
-	// DEBUG: Log mapped records
-	for i, rec := range records {
-		log.Debugf(ctx, "DEGLedgerRecorder DEBUG: record[%d] - transactionId=%s, orderItemId=%s, platformIdBuyer=%s, platformIdSeller=%s",
-			i, rec.TransactionID, rec.OrderItemID, rec.PlatformIDBuyer, rec.PlatformIDSeller)
-	}
-
 	if len(records) == 0 {
-		log.Warnf(ctx, "DEGLedgerRecorder: no order items found in on_confirm, skipping ledger recording")
+		log.Warnf(ctx, "DEGLedgerRecorder: no order items found in on_confirm, skipping")
 		return nil
 	}
 
-	log.Infof(ctx, "DEGLedgerRecorder: mapped %d ledger records from on_confirm (transaction_id=%s)",
-		len(records), payload.Context.TransactionID)
+	// wave1 always has ledgerUriSource=config; falling back to LedgerHost.
+	baseURL := r.config.LedgerHost
+	if r.config.LedgerUriSource != LedgerUriSourceConfig || baseURL == "" {
+		log.Warnf(ctx, "DEGLedgerRecorder: wave1 path requires ledgerUriSource=config and a non-empty ledgerHost (have source=%s, host=%q); skipping",
+			r.config.LedgerUriSource, baseURL)
+		return nil
+	}
 
-	// Send records to ledger asynchronously (fire-and-forget)
-	r.sendPutRecordsAsync(ctx, records, payload.Context.TransactionID)
-
+	log.Infof(ctx, "DEGLedgerRecorder: wave1 mapped %d records (transaction_id=%s) -> %s",
+		len(records), payload.Context.TransactionID, baseURL)
+	r.sendPutRecordsAsync(ctx, baseURL, records)
 	return nil
+}
+
+// handleOnConfirmWave2 — wave2 (P2PTrade/v2.0) path: parses
+// message.contract.commitments, resolves the target URL from either config or
+// the payload's discom participantAttributes, then dispatches to either the
+// legacy_ledger PUT shape or the beckn on_confirm forwarder per LedgerApi.
+func (r *DEGLedgerRecorder) handleOnConfirmWave2(ctx *model.StepContext) error {
+	payload, err := ParseOnConfirmWave2(ctx.Body)
+	if err != nil {
+		log.Warnf(ctx, "DEGLedgerRecorder: failed to parse wave2 on_confirm payload: %v", err)
+		return nil
+	}
+
+	log.Debugf(ctx, "DEGLedgerRecorder DEBUG: parsed wave2 context - transactionId=%s, bapId=%s, bppId=%s",
+		payload.Context.TransactionID, payload.Context.BapID, payload.Context.BppID)
+
+	baseURL, err := r.resolveWave2BaseURL(payload)
+	if err != nil {
+		log.Warnf(ctx, "DEGLedgerRecorder: wave2 base URL resolution failed (transaction_id=%s): %v",
+			payload.Context.TransactionID, err)
+		return nil
+	}
+
+	switch r.config.LedgerApi {
+	case LedgerApiLegacyLedger:
+		record, err := MapWave2ToLedgerRecord(payload, r.config.Role)
+		if err != nil {
+			log.Warnf(ctx, "DEGLedgerRecorder: wave2 mapping failed: %v", err)
+			return nil
+		}
+		log.Infof(ctx, "DEGLedgerRecorder: wave2 (legacy_ledger) mapped 1 record (transaction_id=%s) -> %s",
+			payload.Context.TransactionID, baseURL)
+		r.sendPutRecordsAsync(ctx, baseURL, []LedgerPutRequest{record})
+
+	case LedgerApiBeckn:
+		senderHost := r.config.SenderHost
+		if senderHost == "" {
+			senderHost = DeriveSenderHostFromWave2(payload, r.config.Role)
+		}
+		if senderHost == "" {
+			log.Warnf(ctx, "DEGLedgerRecorder: beckn mode requires a sender host (config.senderHost or context.bapUri/bppUri); skipping (transaction_id=%s)",
+				payload.Context.TransactionID)
+			return nil
+		}
+		rewritten, err := RewriteContextForBeckn(ctx.Body, senderHost, baseURL)
+		if err != nil {
+			log.Warnf(ctx, "DEGLedgerRecorder: beckn context rewrite failed: %v", err)
+			return nil
+		}
+		log.Infof(ctx, "DEGLedgerRecorder: wave2 (beckn) forwarding on_confirm (transaction_id=%s) -> %s/on_confirm (sender=%s)",
+			payload.Context.TransactionID, baseURL, senderHost)
+		r.sendBecknOnConfirmAsync(ctx, baseURL, rewritten, payload.Context.TransactionID)
+
+	default:
+		log.Warnf(ctx, "DEGLedgerRecorder: unsupported ledgerApi=%s", r.config.LedgerApi)
+	}
+	return nil
+}
+
+// sendBecknOnConfirmAsync forwards a beckn on_confirm body in the background.
+// Mirrors sendPutRecordsAsync but for the beckn API path.
+func (r *DEGLedgerRecorder) sendBecknOnConfirmAsync(parentCtx *model.StepContext, baseURL string, body []byte, transactionID string) {
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), r.config.AsyncTimeout)
+		defer cancel()
+		resp, err := r.client.PostBecknOnConfirm(ctx, baseURL, body)
+		if err != nil {
+			log.Errorf(parentCtx, err,
+				"DEGLedgerRecorder: failed to forward beckn on_confirm (transaction_id=%s, base_url=%s): %v",
+				transactionID, baseURL, err)
+			return
+		}
+		log.Infof(parentCtx,
+			"DEGLedgerRecorder: successfully forwarded beckn on_confirm (transaction_id=%s, record_id=%s, base_url=%s)",
+			transactionID, resp.RecordID, baseURL)
+	}()
+}
+
+// resolveWave2BaseURL picks the target ledger URL according to LedgerUriSource.
+// For payload mode, the side is determined by the configured role:
+// BUYER → buyerDiscom.ledgerUri, SELLER → sellerDiscom.ledgerUri.
+func (r *DEGLedgerRecorder) resolveWave2BaseURL(payload *Wave2OnConfirmPayload) (string, error) {
+	switch r.config.LedgerUriSource {
+	case LedgerUriSourceConfig:
+		if r.config.LedgerHost == "" {
+			return "", fmt.Errorf("ledgerHost is empty")
+		}
+		return r.config.LedgerHost, nil
+	case LedgerUriSourcePayload:
+		var side Side
+		switch r.config.Role {
+		case "BUYER":
+			side = SideBuyer
+		case "SELLER":
+			side = SideSeller
+		default:
+			return "", fmt.Errorf("payload-sourced ledger URI requires role BUYER or SELLER, got %s", r.config.Role)
+		}
+		uri := ExtractWave2DiscomLedgerUri(payload, side)
+		if uri == "" {
+			return "", fmt.Errorf("no ledgerUri found in participants[role=%s].participantAttributes", side)
+		}
+		return uri, nil
+	default:
+		return "", fmt.Errorf("unsupported ledgerUriSource: %s", r.config.LedgerUriSource)
+	}
 }
 
 // handleOnStatus processes on_status events and sends meter readings to /ledger/record.
@@ -205,8 +329,9 @@ func (r *DEGLedgerRecorder) handleOnStatus(ctx *model.StepContext) error {
 }
 
 // sendPutRecordsAsync sends ledger PUT records in the background without blocking the main flow.
-// Used for on_confirm → /ledger/put
-func (r *DEGLedgerRecorder) sendPutRecordsAsync(parentCtx *model.StepContext, records []LedgerPutRequest, transactionID string) {
+// Used for on_confirm → /ledger/put. baseURL is supplied per-call so the same
+// recorder can target different discom ledger TSPs based on payload-sourced URIs.
+func (r *DEGLedgerRecorder) sendPutRecordsAsync(parentCtx *model.StepContext, baseURL string, records []LedgerPutRequest) {
 	for _, record := range records {
 		r.wg.Add(1)
 		go func(rec LedgerPutRequest) {
@@ -216,17 +341,17 @@ func (r *DEGLedgerRecorder) sendPutRecordsAsync(parentCtx *model.StepContext, re
 			ctx, cancel := context.WithTimeout(context.Background(), r.config.AsyncTimeout)
 			defer cancel()
 
-			resp, err := r.client.PutRecord(ctx, rec)
+			resp, err := r.client.PutRecord(ctx, baseURL, rec)
 			if err != nil {
 				log.Errorf(parentCtx, err,
-					"DEGLedgerRecorder: failed to PUT record to ledger (transaction_id=%s, order_item_id=%s): %v",
-					rec.TransactionID, rec.OrderItemID, err)
+					"DEGLedgerRecorder: failed to PUT record to ledger (transaction_id=%s, order_item_id=%s, base_url=%s): %v",
+					rec.TransactionID, rec.OrderItemID, baseURL, err)
 				return
 			}
 
 			log.Infof(parentCtx,
-				"DEGLedgerRecorder: successfully PUT record to ledger (transaction_id=%s, order_item_id=%s, record_id=%s)",
-				rec.TransactionID, rec.OrderItemID, resp.RecordID)
+				"DEGLedgerRecorder: successfully PUT record to ledger (transaction_id=%s, order_item_id=%s, record_id=%s, base_url=%s)",
+				rec.TransactionID, rec.OrderItemID, resp.RecordID, baseURL)
 		}(record)
 	}
 }

--- a/specification/schema/DiscomLedgerProvider/v1.0/README.md
+++ b/specification/schema/DiscomLedgerProvider/v1.0/README.md
@@ -1,0 +1,26 @@
+# DiscomLedgerProvider — v1.0
+
+Identity attributes for a regulated discom ledger Technical Service Provider (TSP). Attached to `Contract.participants[*].participantAttributes` for entries with role `buyerDiscom` or `sellerDiscom`, and carries the `ledgerUri` that platforms use to write trade records after `on_confirm`.
+
+Part of the [DEG Schema](../../../specification/schema/) · [DiscomLedgerProvider](../README.md)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [attributes.yaml](./attributes.yaml) | JSON Schema 2020-12 definition for `DiscomLedgerProvider` |
+| [context.jsonld](./context.jsonld) | JSON-LD context (namespace: `https://schema.beckn.io/deg/DiscomLedgerProvider/v1.0/`) |
+| [vocab.jsonld](./vocab.jsonld) | RDF vocabulary for `DiscomLedgerProvider` terms |
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `ledgerUri` | `string` (uri) | ✅ | Base URL of the discom ledger TSP |
+| `utilityId` | `string` | | Utility/DISCOM identifier the TSP serves (e.g., `BRPL-DL`) |
+
+## Usage
+
+Two discoms MAY point at the same `ledgerUri` if they share a TSP. Each platform still calls only its own side's discom URI: BAP → `buyerDiscom.ledgerUri`, BPP → `sellerDiscom.ledgerUri`.
+
+The `degledgerrecorder` plugin reads `ledgerUri` from the payload when configured with `ledgerUriSource: payload`.

--- a/specification/schema/DiscomLedgerProvider/v1.0/attributes.yaml
+++ b/specification/schema/DiscomLedgerProvider/v1.0/attributes.yaml
@@ -1,0 +1,50 @@
+openapi: 3.1.1
+info:
+  title: DiscomLedgerProvider — Discom Ledger TSP Attributes (v1.0)
+  version: 1.0.0
+  description: >
+    Identity attributes for a regulated discom ledger Technical Service
+    Provider (TSP). Attached to Contract.participants[*].participantAttributes
+    for entries with role buyerDiscom or sellerDiscom, and carries the
+    `ledgerUri` that platforms use to write trade records to that discom's
+    ledger after on_confirm.
+
+    Two discoms MAY point at the same `ledgerUri` if they share a TSP; each
+    platform still calls only its own side's discom URI (BAP -> buyerDiscom,
+    BPP -> sellerDiscom).
+
+components:
+  schemas:
+    DiscomLedgerProvider:
+      type: object
+      additionalProperties: false
+      required: [ledgerUri]
+      x-tags:
+        - p2p-trading
+        - discom-ledger
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": DiscomLedgerProvider
+      properties:
+
+        utilityId:
+          type: string
+          description: >
+            Utility/DISCOM identifier the ledger TSP serves (e.g.,
+            "TPDDL-DL", "BRPL-DL"). Mirrors EnergyCustomer.utilityId on
+            buyer/seller participants for cross-reference.
+          example: "BRPL-DL"
+          x-jsonld:
+            "@id": utilityId
+
+        ledgerUri:
+          type: string
+          format: uri
+          description: >
+            Base URL of the discom ledger TSP. Platforms POST trade records
+            to `<ledgerUri>/ledger/put` (legacy_ledger mode) or beckn
+            `on_confirm` to `<ledgerUri>/on_confirm` (beckn mode), depending
+            on the platform's `degledgerrecorder` plugin configuration.
+          example: "https://ies-p2p-energy-ledger.beckn.io"
+          x-jsonld:
+            "@id": ledgerUri

--- a/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld
+++ b/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "deg": "https://schema.beckn.io/deg/DiscomLedgerProvider/v1.0/",
+    "DiscomLedgerProvider": "deg:DiscomLedgerProvider",
+    "utilityId": "deg:utilityId",
+    "ledgerUri": "deg:ledgerUri"
+  },
+  "@graph": []
+}

--- a/specification/schema/DiscomLedgerProvider/v1.0/vocab.jsonld
+++ b/specification/schema/DiscomLedgerProvider/v1.0/vocab.jsonld
@@ -1,0 +1,35 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "deg": "https://schema.beckn.io/deg/DiscomLedgerProvider/v1.0/",
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "deg:DiscomLedgerProvider",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Discom Ledger Provider",
+      "rdfs:comment": "Identity attributes for a regulated discom ledger Technical Service Provider (TSP), attached to Contract.participants[*].participantAttributes for buyerDiscom/sellerDiscom roles."
+    },
+    {
+      "@id": "deg:utilityId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Utility ID",
+      "rdfs:comment": "Utility/DISCOM identifier the ledger TSP serves.",
+      "rdfs:domain": "deg:DiscomLedgerProvider",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:ledgerUri",
+      "@type": "rdf:Property",
+      "rdfs:label": "Ledger URI",
+      "rdfs:comment": "Base URL of the discom ledger TSP.",
+      "rdfs:domain": "deg:DiscomLedgerProvider",
+      "rdfs:range": "xsd:anyURI"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Wave2 platforms read each discom's ledger TSP URL from the `on_confirm` payload (`participants[role=*Discom].participantAttributes.ledgerUri`) instead of from plugin config; new `DiscomLedgerProvider/v1.0` schema carries it.
- Plugin gains three required mode flags (no code defaults): `payloadShape` (wave1|wave2), `ledgerUriSource` (config|payload), `ledgerApi` (legacy_ledger|beckn). `ledgerHost` is now required only when `ledgerUriSource=config`.
- `legacy_ledger` mode keeps the existing `/ledger/put` JSON shape; `beckn` mode forwards the on_confirm verbatim to `<uri>/on_confirm` with rewritten context (`bppUri = senderHost/bpp/caller`, `bapUri = ledgerUri/bap/receiver`) and unwraps the inner `message.ledger` from the ACK envelope.
- Wave2 BAP/BPP configs wired (`payloadShape=wave2`, `ledgerUriSource=payload`, `ledgerApi=legacy_ledger`); flip to `beckn` is a one-line YAML change once the TSP upgrades. Wave1 configs explicitly carry their three flags so behavior is visible in YAML, not buried in code.

## Files of note
- `specification/schema/DiscomLedgerProvider/v1.0/` — new schema (utilityId + ledgerUri).
- `plugins/degledgerrecorder/{config,recorder,client}.go` — flags, dispatch, beckn forwarder.
- `plugins/degledgerrecorder/mapper_wave2.go` — wave2 mapper + context rewrite + senderHost derivation.
- `plugins/degledgerrecorder/{config_test,mapper_wave2_test,beckn_rewrite_test}.go` — new tests (config validation, wave2 mapping, beckn rewrite, senderHost fallback).
- `devkits/p2p-trading-ies-wave2/uc1/examples/*.json` — `participantAttributes` injected on buyerDiscom/sellerDiscom in 7 payloads, all pointing at `https://ies-p2p-energy-ledger.beckn.io`.
- `devkits/p2p-trading-ies-wave2/install/docker-compose.yml` — pinned to `fidedocker/onix-adapter-deg:w-deg-plugins-v1` (multi-arch image already pushed).
- `devkits/p2p-trading-ies-wave1/config/*.yaml` — additive flag backfill (no behavioral change).

## Test plan
- [x] `go test ./degledgerrecorder/...` (run inside `golang:1.26-bookworm` since the plugin module's beckn-onix replace target needs Go 1.26+) — all wave1, wave2 mapper, config-validation, beckn-rewrite, and senderHost-derivation tests pass.
- [x] Multi-arch image built and pushed: `docker buildx imagetools inspect fidedocker/onix-adapter-deg:w-deg-plugins-v1` shows linux/amd64 + linux/arm64.
- [x] Wave2 stack starts cleanly. Both onix-bap and onix-bpp log the new flags at startup:
  `[DEGLedgerRecorder] payloadShape=wave2, ledgerUriSource=payload, ledgerApi=legacy_ledger, role=BUYER|SELLER, actions=[on_confirm]`
  and the processor step list includes `degledgerrecorder` after `addRoute`/`sign`.
- [ ] **End-to-end on_confirm → ledger TSP not exercised** in this branch: arazzo `select-through-settlement` runs all 9 steps but each NACKs at `validateSign` because `bap.example.com` / `bpp.example.com` are placeholder subscribers not registered on `nfh.global/testnet-deg`. The plugin's outbound call cannot fire until real subscribers are wired up. Behavior of the new code path is covered by unit tests.

## Flipping to beckn mode (future)
Once the ledger TSP starts accepting beckn `on_confirm`, change `ledgerApi: legacy_ledger` → `ledgerApi: beckn` in `devkits/p2p-trading-ies-wave2/config/local-p2p-trading-{bap,bpp}.yaml`. No image rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)