### PR TITLE
fix: add missing README.md for DiscomLedgerProvider and BecknReportDescriptors

### DIFF
--- a/specification/schema/BecknReportDescriptors/README.md
+++ b/specification/schema/BecknReportDescriptors/README.md
@@ -1,0 +1,47 @@
+# BecknReportDescriptors
+
+OpenADR 3.1.0-aligned sidecar schema declaring which telemetry signals a seller commits to reporting under a DEG contract. Embedded as `inputs[seller].inputs.reportDescriptors` in offer attributes (e.g. `DemandFlexBuyOffer`).
+
+**Canonical IRI:** `https://schema.beckn.io/BecknReportDescriptors/v1.0`
+
+**Namespace prefix:** `deg:` → `https://schema.beckn.io/deg/BecknReportDescriptors/v1.0/`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial version. Reuses OpenADR3 `reportPayloadDescriptor` and adds a `cardinality` extension. |
+
+---
+
+## Schemas
+
+### `BecknReportDescriptors`
+
+Array of `BecknReportPayloadDescriptor` entries — one per signal the seller commits to reporting.
+
+### `BecknReportPayloadDescriptor`
+
+Extends OpenADR3 `reportPayloadDescriptor` with one DEG field:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `payloadType` | `string` | ✓ | Signal identifier (e.g. `USAGE`, `POWER`, `SOC_END`, `GPS_LAT`). |
+| `units` | `string` | ✓ | Unit of measure (e.g. `KW`, `PERCENT`, `DEGREES`). |
+| `readingType` | `string` | | OpenADR3 reading type (e.g. `DIRECT_READ`). |
+| `cardinality` | `string` enum | | `PER_INTERVAL` (default) — reported every interval; `PER_EVENT` — reported once per event on interval 0. |
+
+---
+
+## Standard payloadType vocabulary
+
+| payloadType | units | cardinality | Meaning |
+|-------------|-------|-------------|---------|
+| `BASELINE` | `KW` | `PER_INTERVAL` | Reference (vendor-rated) charge power |
+| `USAGE` | `KW` | `PER_INTERVAL` | Measured charge power during the event |
+| `POWER` | `KW` | `PER_INTERVAL` | Signed instantaneous power (charge +, discharge −) |
+| `SOC_END` | `PERCENT` | `PER_INTERVAL` | State of charge at end of each interval |
+| `GPS_LAT` | `DEGREES` | `PER_EVENT` | Vehicle latitude at start of event |
+| `GPS_LON` | `DEGREES` | `PER_EVENT` | Vehicle longitude at start of event |

--- a/specification/schema/DiscomLedgerProvider/README.md
+++ b/specification/schema/DiscomLedgerProvider/README.md
@@ -1,0 +1,24 @@
+# DiscomLedgerProvider
+
+Identity attributes for a regulated discom ledger Technical Service Provider (TSP), used on `buyerDiscom` and `sellerDiscom` participants in a DEG contract.
+
+**Canonical IRI:** `https://schema.beckn.io/DiscomLedgerProvider/v1.0`
+
+**Namespace prefix:** `deg:` → `https://schema.beckn.io/deg/DiscomLedgerProvider/v1.0/`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial version. Identity and endpoint for a discom ledger TSP. |
+
+---
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `utilityId` | `string` | ✓ | Utility / DISCOM identifier the ledger TSP serves (e.g. `BRPL-DL`). |
+| `ledgerUri` | `URI` | ✓ | Base URL of the discom ledger TSP endpoint. |


### PR DESCRIPTION
## Summary

Adds `README.md` to the two schema directories flagged by the `missing-class-readme` lint rule:

- **`DiscomLedgerProvider/`** — identity attributes for a regulated discom ledger TSP (`utilityId`, `ledgerUri`), used on `buyerDiscom`/`sellerDiscom` participants in DEG contracts.
- **`BecknReportDescriptors/`** — OpenADR 3.1.0-aligned sidecar schema declaring seller telemetry commitments (`USAGE`, `POWER`, `SOC_END`, `GPS_LAT/LON`, etc.), including the standard `payloadType` vocabulary table.

Both follow the same format as existing schema READMEs (canonical IRI, version table, properties table).

All 35 schema directories now have a `README.md` — this lint error will not recur for existing schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)