### PR TITLE
fix: add missing publisher files for ElectricityCredential schema

### DIFF
--- a/specification/schema/ElectricityCredential/README.md
+++ b/specification/schema/ElectricityCredential/README.md
@@ -1,0 +1,63 @@
+# ElectricityCredential
+
+Unified W3C Verifiable Credential (VC Data Model 2.0) issued per meter by electricity distribution utilities. Combines customer identity with optional consumption, generation, and storage profiles in a single credential.
+
+**Canonical IRI:** `https://schema.beckn.io/ElectricityCredential/v1.0`
+
+**Namespace prefix:** `deg:` → `https://schema.beckn.io/deg/`
+
+**Tags:** `energy` · `credential` · `verifiable-credential` · `electricity` · `customer` · `deg`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Unified credential replacing separate per-profile VCs |
+
+---
+
+## Inheritance
+
+```
+beckn:Credential
+  └── EnergyCredential
+        └── ElectricityCredential  ← this schema
+```
+
+---
+
+## credentialSubject Properties
+
+| Property | Type | Required | Description |
+|----------|------|:--------:|-------------|
+| `id` | `string` (URI) | | Optional DID of the customer/credential subject |
+| `customerProfile` | object | ✅ | Customer number, meter number, meter type, identity reference |
+| `customerDetails` | object | | Full name, installation address, service connection date |
+| `consumptionProfile` | object | | Premises type, connection type, sanctioned load, tariff |
+| `generationProfile` | object | | DER type, capacity, commissioning date, manufacturer |
+| `storageProfile` | object | | Battery capacity, power rating, storage type |
+
+---
+
+## Linked Data
+
+| Term | IRI |
+|------|-----|
+| `ElectricityCredential` | `deg:ElectricityCredential` |
+| `customerProfile` | `deg:customerProfile` |
+| `customerDetails` | `deg:customerDetails` |
+| `consumptionProfile` | `deg:consumptionProfile` |
+| `generationProfile` | `deg:generationProfile` |
+| `storageProfile` | `deg:storageProfile` |
+
+---
+
+## Usage
+
+Issued by electricity distribution utilities to consumers and prosumers. Used for:
+- P2P energy trading eligibility and identity verification
+- Demand response and virtual power plant enrollment
+- DER asset registration and grid service qualification
+- Program enrollment and tariff management

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -1,0 +1,227 @@
+openapi: 3.1.1
+info:
+  title: ElectricityCredential
+  version: 1.0.0
+  description: >
+    Unified W3C Verifiable Credential (VC Data Model 2.0) issued per meter by
+    electricity distribution utilities. Combines customer identity with optional
+    consumption, generation, and storage profiles in a single credential subject.
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+servers:
+  - url: https://schema.beckn.io
+    description: Canonical schema registry
+paths: {}
+components:
+  schemas:
+    ElectricityCredential:
+      $id: https://schema.beckn.io/ElectricityCredential/v1.0
+      title: ElectricityCredential
+      description: >
+        Unified W3C Verifiable Credential issued per meter by electricity
+        distribution utilities. Combines customer identity, consumption,
+        generation, and storage profiles in a single credentialSubject.
+      x-tags:
+        - energy
+        - credential
+        - verifiable-credential
+        - electricity
+        - customer
+        - deg
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyCredential/v2.0"
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": ElectricityCredential
+      properties:
+        credentialSubject:
+          description: >
+            The credential subject containing customer identity and optional
+            consumption, generation, and storage profiles for a single meter.
+          x-jsonld:
+            "@id": deg:credentialSubject
+          type: object
+          required:
+            - customerProfile
+          properties:
+            id:
+              type: string
+              format: uri
+              description: Optional DID of the customer/credential subject.
+              x-jsonld:
+                "@id": "@id"
+            customerProfile:
+              description: Core customer identity — customer number, meter number, meter type, identity reference.
+              x-jsonld:
+                "@id": deg:customerProfile
+              type: object
+              required:
+                - customerNumber
+                - meterNumber
+                - meterType
+              properties:
+                customerNumber:
+                  type: string
+                  description: Full customer account number assigned by the utility.
+                meterNumber:
+                  type: string
+                  description: Unique meter serial number.
+                meterType:
+                  type: string
+                  description: Type of electricity meter. Values derived from Green Button / ESPI meter kind classifications.
+                  enum:
+                    - AMR
+                    - AMI
+                    - Electromechanical
+                    - Forward
+                    - Reverse
+                    - Bidirectional
+                    - Prepaid
+                    - NetMeter
+                    - Other
+                idRef:
+                  $ref: "#/components/schemas/IdRef"
+            customerDetails:
+              description: Customer personal and address information.
+              x-jsonld:
+                "@id": deg:customerDetails
+              type: object
+              required:
+                - fullName
+                - installationAddress
+                - serviceConnectionDate
+              properties:
+                fullName:
+                  type: string
+                  description: Full name of the customer as per ID proof.
+                installationAddress:
+                  type: object
+                  description: Physical location of the installation. Follows the beckn Location schema.
+                  required:
+                    - address
+                    - area_code
+                    - country
+                  properties:
+                    address:
+                      type: string
+                    city:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        code: { type: string }
+                    district:
+                      type: string
+                    state:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        code: { type: string }
+                    country:
+                      type: object
+                      required: [code]
+                      properties:
+                        name: { type: string }
+                        code:
+                          type: string
+                          pattern: "^[A-Z]{2}$"
+                          description: ISO 3166-1 alpha-2 country code.
+                    area_code:
+                      type: string
+                    gps:
+                      type: string
+                      description: "GPS coordinates as 'lat,lng' string."
+                    openLocationCode:
+                      type: string
+                      description: Open Location Code (OLC) for the installation.
+                serviceConnectionDate:
+                  type: string
+                  format: date-time
+                  description: Date and time the electricity connection was activated (with timezone offset).
+            consumptionProfile:
+              description: Connection and consumption characteristics for load management and tariff purposes.
+              x-jsonld:
+                "@id": deg:consumptionProfile
+              type: object
+              required:
+                - premisesType
+                - connectionType
+                - sanctionedLoadKW
+                - tariffCategoryCode
+              properties:
+                premisesType:
+                  type: string
+                  enum: [Residential, Commercial, Industrial, Agricultural]
+                connectionType:
+                  type: string
+                  enum: [Single-phase, Three-phase]
+                sanctionedLoadKW:
+                  type: number
+                  description: Sanctioned electrical load in kW.
+                tariffCategoryCode:
+                  type: string
+                  description: Billing/tariff category code assigned by the utility.
+            generationProfile:
+              description: DER generation capability.
+              x-jsonld:
+                "@id": deg:generationProfile
+              type: object
+              required:
+                - generationType
+                - capacityKW
+                - commissioningDate
+              properties:
+                assetId:
+                  type: string
+                generationType:
+                  type: string
+                  enum: [Solar, Wind, MicroHydro, Other]
+                capacityKW:
+                  type: number
+                  description: Installed generation capacity in kW.
+                commissioningDate:
+                  type: string
+                  format: date-time
+                manufacturer:
+                  type: string
+                modelNumber:
+                  type: string
+            storageProfile:
+              description: Battery/energy storage capability.
+              x-jsonld:
+                "@id": deg:storageProfile
+              type: object
+              required:
+                - storageCapacityKWh
+                - powerRatingKW
+                - commissioningDate
+              properties:
+                assetId:
+                  type: string
+                storageCapacityKWh:
+                  type: number
+                  description: Storage capacity in kWh.
+                powerRatingKW:
+                  type: number
+                  description: Charge/discharge power rating in kW.
+                commissioningDate:
+                  type: string
+                  format: date-time
+                storageType:
+                  type: string
+                  enum: [LithiumIon, LeadAcid, FlowBattery, Other]
+
+    IdRef:
+      description: Reusable identity reference — an identity issued by an external authority.
+      type: object
+      required:
+        - issuedBy
+        - subjectId
+      properties:
+        issuedBy:
+          type: string
+          format: uri
+          description: DID of the authority that issued the identity.
+        subjectId:
+          type: string
+          description: "Identifier in the format authority-domain:id-value."

--- a/specification/schema/ElectricityCredential/v1.0/vocab.jsonld
+++ b/specification/schema/ElectricityCredential/v1.0/vocab.jsonld
@@ -1,0 +1,49 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "deg": "https://schema.beckn.io/deg/",
+        "energyCred": "https://schema.beckn.io/deg/EnergyCredential/v2.0/",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "deg:ElectricityCredential",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Electricity Credential",
+            "rdfs:comment": "A W3C Verifiable Credential issued per meter by electricity distribution utilities. Combines customer identity with optional consumption, generation, and storage profiles in a single credential subject.",
+            "rdfs:subClassOf": { "@id": "energyCred:EnergyCredential" }
+        },
+        {
+            "@id": "deg:customerProfile",
+            "@type": "rdf:Property",
+            "rdfs:label": "Customer Profile",
+            "rdfs:comment": "Core customer identity: customer number, meter number, meter type, and external identity reference."
+        },
+        {
+            "@id": "deg:customerDetails",
+            "@type": "rdf:Property",
+            "rdfs:label": "Customer Details",
+            "rdfs:comment": "Customer personal and address information: full name, installation address, service connection date."
+        },
+        {
+            "@id": "deg:consumptionProfile",
+            "@type": "rdf:Property",
+            "rdfs:label": "Consumption Profile",
+            "rdfs:comment": "Connection and consumption characteristics: premises type, connection type, sanctioned load, tariff category."
+        },
+        {
+            "@id": "deg:generationProfile",
+            "@type": "rdf:Property",
+            "rdfs:label": "Generation Profile",
+            "rdfs:comment": "DER generation capability: type, capacity, commissioning date, manufacturer."
+        },
+        {
+            "@id": "deg:storageProfile",
+            "@type": "rdf:Property",
+            "rdfs:label": "Storage Profile",
+            "rdfs:comment": "Battery/energy storage capability: capacity, power rating, commissioning date, storage type."
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Fixes publishing errors for the `ElectricityCredential` schema introduced in #305.

- **`[missing-class-readme]`** — added `specification/schema/ElectricityCredential/README.md` with credential overview, property table, inheritance, and linked data terms
- **`[missing-attributes]`** — added `specification/schema/ElectricityCredential/v1.0/attributes.yaml` (OpenAPI 3.1.1) covering all five `credentialSubject` sections: `customerProfile`, `customerDetails`, `consumptionProfile`, `generationProfile`, `storageProfile`
- **`[missing-version-vocab]`** — added `specification/schema/ElectricityCredential/v1.0/vocab.jsonld` defining `deg:ElectricityCredential` as a subclass of `EnergyCredential` and all `deg:` property terms

## Test plan
- [ ] Re-run publisher against `ElectricityCredential/` — all three checks should pass
- [ ] Confirm `attributes.yaml` is valid OpenAPI 3.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)