### PR TITLE
feat: support arrays for generationProfiles, consumptionProfiles, storageProfiles in ElectricityCredential

### DIFF
--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -38,7 +38,7 @@ components:
         credentialSubject:
           description: >
             The credential subject containing customer identity and optional
-            consumption, generation, and storage profiles for a single meter.
+            consumptionProfiles, generationProfiles, and storageProfiles arrays.
           x-jsonld:
             "@id": deg:credentialSubject
           type: object
@@ -138,78 +138,104 @@ components:
                   type: string
                   format: date-time
                   description: Date and time the electricity connection was activated (with timezone offset).
-            consumptionProfile:
-              description: Connection and consumption characteristics for load management and tariff purposes.
+            consumptionProfiles:
+              description: >
+                Connection and consumption characteristics for load management and tariff purposes.
+                Array to support customers with multiple meters or tariff categories.
               x-jsonld:
-                "@id": deg:consumptionProfile
-              type: object
-              required:
-                - premisesType
-                - connectionType
-                - sanctionedLoadKW
-                - tariffCategoryCode
-              properties:
-                premisesType:
-                  type: string
-                  enum: [Residential, Commercial, Industrial, Agricultural]
-                connectionType:
-                  type: string
-                  enum: [Single-phase, Three-phase]
-                sanctionedLoadKW:
-                  type: number
-                  description: Sanctioned electrical load in kW.
-                tariffCategoryCode:
-                  type: string
-                  description: Billing/tariff category code assigned by the utility.
-            generationProfile:
-              description: DER generation capability.
+                "@id": deg:consumptionProfiles
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/ConsumptionProfile"
+            generationProfiles:
+              description: >
+                DER generation assets. Array to support customers with multiple generation units
+                (e.g., rooftop solar + wind turbine).
               x-jsonld:
-                "@id": deg:generationProfile
-              type: object
-              required:
-                - generationType
-                - capacityKW
-                - commissioningDate
-              properties:
-                assetId:
-                  type: string
-                generationType:
-                  type: string
-                  enum: [Solar, Wind, MicroHydro, Other]
-                capacityKW:
-                  type: number
-                  description: Installed generation capacity in kW.
-                commissioningDate:
-                  type: string
-                  format: date-time
-                manufacturer:
-                  type: string
-                modelNumber:
-                  type: string
-            storageProfile:
-              description: Battery/energy storage capability.
+                "@id": deg:generationProfiles
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/GenerationProfile"
+            storageProfiles:
+              description: >
+                Energy storage assets. Array to support customers with multiple batteries.
               x-jsonld:
-                "@id": deg:storageProfile
-              type: object
-              required:
-                - storageCapacityKWh
-                - powerRatingKW
-                - commissioningDate
-              properties:
-                assetId:
-                  type: string
-                storageCapacityKWh:
-                  type: number
-                  description: Storage capacity in kWh.
-                powerRatingKW:
-                  type: number
-                  description: Charge/discharge power rating in kW.
-                commissioningDate:
-                  type: string
-                  format: date-time
-                storageType:
-                  type: string
-                  enum: [LithiumIon, LeadAcid, FlowBattery, Other]
+                "@id": deg:storageProfiles
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/StorageProfile"
+
+    ConsumptionProfile:
+      description: Connection and consumption characteristics for load management and tariff purposes.
+      type: object
+      required:
+        - premisesType
+        - connectionType
+        - sanctionedLoadKW
+        - tariffCategoryCode
+      properties:
+        premisesType:
+          type: string
+          enum: [Residential, Commercial, Industrial, Agricultural]
+        connectionType:
+          type: string
+          enum: [Single-phase, Three-phase]
+        sanctionedLoadKW:
+          type: number
+          description: Sanctioned electrical load in kW.
+        tariffCategoryCode:
+          type: string
+          description: Billing/tariff category code assigned by the utility.
+
+    GenerationProfile:
+      description: DER generation capability.
+      type: object
+      required:
+        - generationType
+        - capacityKW
+        - commissioningDate
+      properties:
+        assetId:
+          type: string
+        generationType:
+          type: string
+          enum: [Solar, Wind, MicroHydro, Other]
+        capacityKW:
+          type: number
+          description: Installed generation capacity in kW.
+        commissioningDate:
+          type: string
+          format: date-time
+        manufacturer:
+          type: string
+        modelNumber:
+          type: string
+
+    StorageProfile:
+      description: Battery/energy storage capability.
+      type: object
+      required:
+        - storageCapacityKWh
+        - powerRatingKW
+        - commissioningDate
+      properties:
+        assetId:
+          type: string
+        storageCapacityKWh:
+          type: number
+          description: Storage capacity in kWh.
+        powerRatingKW:
+          type: number
+          description: Charge/discharge power rating in kW.
+        commissioningDate:
+          type: string
+          format: date-time
+        storageType:
+          type: string
+          enum: [LithiumIon, LeadAcid, FlowBattery, Other]
 
     IdRef:
       description: Reusable identity reference — an identity issued by an external authority.

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -29,8 +29,7 @@ components:
         - deg
       type: object
       additionalProperties: true
-      allOf:
-        - $ref: "https://schema.beckn.io/EnergyCredential/v2.0"
+      x-extends: "https://schema.beckn.io/EnergyCredential/v2.0"
       x-jsonld:
         "@context": ./context.jsonld
         "@type": ElectricityCredential

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -81,19 +81,7 @@ components:
                     - NetMeter
                     - Other
                 idRef:
-                  description: Reusable identity reference — an identity issued by an external authority.
-                  type: object
-                  required:
-                    - issuedBy
-                    - subjectId
-                  properties:
-                    issuedBy:
-                      type: string
-                      format: uri
-                      description: DID of the authority that issued the identity.
-                    subjectId:
-                      type: string
-                      description: "Identifier in the format authority-domain:id-value."
+                  $ref: "#/components/schemas/IdRef"
             customerDetails:
               description: Customer personal and address information.
               x-jsonld:
@@ -159,25 +147,7 @@ components:
               type: array
               minItems: 1
               items:
-                type: object
-                required:
-                  - premisesType
-                  - connectionType
-                  - sanctionedLoadKW
-                  - tariffCategoryCode
-                properties:
-                  premisesType:
-                    type: string
-                    enum: [Residential, Commercial, Industrial, Agricultural]
-                  connectionType:
-                    type: string
-                    enum: [Single-phase, Three-phase]
-                  sanctionedLoadKW:
-                    type: number
-                    description: Sanctioned electrical load in kW.
-                  tariffCategoryCode:
-                    type: string
-                    description: Billing/tariff category code assigned by the utility.
+                $ref: "#/components/schemas/ConsumptionProfile"
             generationProfiles:
               description: >
                 DER generation assets. Array to support customers with multiple generation units
@@ -187,27 +157,7 @@ components:
               type: array
               minItems: 1
               items:
-                type: object
-                required:
-                  - generationType
-                  - capacityKW
-                  - commissioningDate
-                properties:
-                  assetId:
-                    type: string
-                  generationType:
-                    type: string
-                    enum: [Solar, Wind, MicroHydro, Other]
-                  capacityKW:
-                    type: number
-                    description: Installed generation capacity in kW.
-                  commissioningDate:
-                    type: string
-                    format: date-time
-                  manufacturer:
-                    type: string
-                  modelNumber:
-                    type: string
+                $ref: "#/components/schemas/GenerationProfile"
             storageProfiles:
               description: >
                 Energy storage assets. Array to support customers with multiple batteries.
@@ -216,30 +166,8 @@ components:
               type: array
               minItems: 1
               items:
-                type: object
-                required:
-                  - storageCapacityKWh
-                  - powerRatingKW
-                  - commissioningDate
-                properties:
-                  assetId:
-                    type: string
-                  storageCapacityKWh:
-                    type: number
-                    description: Storage capacity in kWh.
-                  powerRatingKW:
-                    type: number
-                    description: Charge/discharge power rating in kW.
-                  commissioningDate:
-                    type: string
-                    format: date-time
-                  storageType:
-                    type: string
-                    enum: [LithiumIon, LeadAcid, FlowBattery, Other]
+                $ref: "#/components/schemas/StorageProfile"
 
-    # Named schema definitions kept for discoverability and reuse by other files.
-    # Not referenced with $ref from within ElectricityCredential to avoid resolver
-    # cascade failures when the allOf external URL is unavailable (e.g. Swagger Editor).
     ConsumptionProfile:
       description: Connection and consumption characteristics for load management and tariff purposes.
       type: object

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -29,7 +29,8 @@ components:
         - deg
       type: object
       additionalProperties: true
-      x-extends: "https://schema.beckn.io/EnergyCredential/v2.0"
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyCredential/v2.0"
       x-jsonld:
         "@context": ./context.jsonld
         "@type": ElectricityCredential
@@ -80,7 +81,19 @@ components:
                     - NetMeter
                     - Other
                 idRef:
-                  $ref: "#/components/schemas/IdRef"
+                  description: Reusable identity reference — an identity issued by an external authority.
+                  type: object
+                  required:
+                    - issuedBy
+                    - subjectId
+                  properties:
+                    issuedBy:
+                      type: string
+                      format: uri
+                      description: DID of the authority that issued the identity.
+                    subjectId:
+                      type: string
+                      description: "Identifier in the format authority-domain:id-value."
             customerDetails:
               description: Customer personal and address information.
               x-jsonld:
@@ -146,7 +159,25 @@ components:
               type: array
               minItems: 1
               items:
-                $ref: "#/components/schemas/ConsumptionProfile"
+                type: object
+                required:
+                  - premisesType
+                  - connectionType
+                  - sanctionedLoadKW
+                  - tariffCategoryCode
+                properties:
+                  premisesType:
+                    type: string
+                    enum: [Residential, Commercial, Industrial, Agricultural]
+                  connectionType:
+                    type: string
+                    enum: [Single-phase, Three-phase]
+                  sanctionedLoadKW:
+                    type: number
+                    description: Sanctioned electrical load in kW.
+                  tariffCategoryCode:
+                    type: string
+                    description: Billing/tariff category code assigned by the utility.
             generationProfiles:
               description: >
                 DER generation assets. Array to support customers with multiple generation units
@@ -156,7 +187,27 @@ components:
               type: array
               minItems: 1
               items:
-                $ref: "#/components/schemas/GenerationProfile"
+                type: object
+                required:
+                  - generationType
+                  - capacityKW
+                  - commissioningDate
+                properties:
+                  assetId:
+                    type: string
+                  generationType:
+                    type: string
+                    enum: [Solar, Wind, MicroHydro, Other]
+                  capacityKW:
+                    type: number
+                    description: Installed generation capacity in kW.
+                  commissioningDate:
+                    type: string
+                    format: date-time
+                  manufacturer:
+                    type: string
+                  modelNumber:
+                    type: string
             storageProfiles:
               description: >
                 Energy storage assets. Array to support customers with multiple batteries.
@@ -165,8 +216,30 @@ components:
               type: array
               minItems: 1
               items:
-                $ref: "#/components/schemas/StorageProfile"
+                type: object
+                required:
+                  - storageCapacityKWh
+                  - powerRatingKW
+                  - commissioningDate
+                properties:
+                  assetId:
+                    type: string
+                  storageCapacityKWh:
+                    type: number
+                    description: Storage capacity in kWh.
+                  powerRatingKW:
+                    type: number
+                    description: Charge/discharge power rating in kW.
+                  commissioningDate:
+                    type: string
+                    format: date-time
+                  storageType:
+                    type: string
+                    enum: [LithiumIon, LeadAcid, FlowBattery, Other]
 
+    # Named schema definitions kept for discoverability and reuse by other files.
+    # Not referenced with $ref from within ElectricityCredential to avoid resolver
+    # cascade failures when the allOf external URL is unavailable (e.g. Swagger Editor).
     ConsumptionProfile:
       description: Connection and consumption characteristics for load management and tariff purposes.
       type: object

--- a/specification/schema/ElectricityCredential/v1.0/context.jsonld
+++ b/specification/schema/ElectricityCredential/v1.0/context.jsonld
@@ -187,9 +187,10 @@
                 }
             }
         },
-        "consumptionProfile": {
-            "@id": "deg:consumptionProfile",
+        "consumptionProfiles": {
+            "@id": "deg:consumptionProfiles",
             "@type": "@id",
+            "@container": "@set",
             "@context": {
                 "@version": 1.1,
                 "@protected": true,
@@ -211,9 +212,10 @@
                 }
             }
         },
-        "generationProfile": {
-            "@id": "deg:generationProfile",
+        "generationProfiles": {
+            "@id": "deg:generationProfiles",
             "@type": "@id",
+            "@container": "@set",
             "@context": {
                 "@version": 1.1,
                 "@protected": true,
@@ -243,9 +245,10 @@
                 }
             }
         },
-        "storageProfile": {
-            "@id": "deg:storageProfile",
+        "storageProfiles": {
+            "@id": "deg:storageProfiles",
             "@type": "@id",
+            "@container": "@set",
             "@context": {
                 "@version": 1.1,
                 "@protected": true,

--- a/specification/schema/ElectricityCredential/v1.0/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.0/examples/example.json
@@ -70,27 +70,48 @@
       },
       "serviceConnectionDate": "2025-01-10T00:00:00-05:00"
     },
-    "consumptionProfile": {
-      "premisesType": "Residential",
-      "connectionType": "Single-phase",
-      "sanctionedLoadKW": 5,
-      "tariffCategoryCode": "RES-01"
-    },
-    "generationProfile": {
-      "assetId": "DER-SOLAR-001",
-      "generationType": "Solar",
-      "capacityKW": 3,
-      "commissioningDate": "2025-01-12T00:00:00-05:00",
-      "manufacturer": "SunPower Corporation",
-      "modelNumber": "SPR-X22-360"
-    },
-    "storageProfile": {
-      "assetId": "BESS-001",
-      "storageCapacityKWh": 10,
-      "powerRatingKW": 5,
-      "commissioningDate": "2025-01-12T00:00:00-05:00",
-      "storageType": "LithiumIon"
-    }
+    "consumptionProfiles": [
+      {
+        "premisesType": "Residential",
+        "connectionType": "Single-phase",
+        "sanctionedLoadKW": 5,
+        "tariffCategoryCode": "RES-01"
+      }
+    ],
+    "generationProfiles": [
+      {
+        "assetId": "DER-SOLAR-001",
+        "generationType": "Solar",
+        "capacityKW": 3,
+        "commissioningDate": "2025-01-12T00:00:00-05:00",
+        "manufacturer": "SunPower Corporation",
+        "modelNumber": "SPR-X22-360"
+      },
+      {
+        "assetId": "DER-WIND-001",
+        "generationType": "Wind",
+        "capacityKW": 1.5,
+        "commissioningDate": "2025-03-01T00:00:00-05:00",
+        "manufacturer": "Windmill Co.",
+        "modelNumber": "WM-MICRO-150"
+      }
+    ],
+    "storageProfiles": [
+      {
+        "assetId": "BESS-001",
+        "storageCapacityKWh": 10,
+        "powerRatingKW": 5,
+        "commissioningDate": "2025-01-12T00:00:00-05:00",
+        "storageType": "LithiumIon"
+      },
+      {
+        "assetId": "BESS-002",
+        "storageCapacityKWh": 5,
+        "powerRatingKW": 2.5,
+        "commissioningDate": "2025-06-01T00:00:00-05:00",
+        "storageType": "LithiumIon"
+      }
+    ]
   },
   "proof": {
     "type": "Ed25519Signature2020",

--- a/specification/schema/ElectricityCredential/v1.0/schema.json
+++ b/specification/schema/ElectricityCredential/v1.0/schema.json
@@ -125,7 +125,7 @@
         },
         "credentialSubject": {
             "type": "object",
-            "description": "Single subject with five profile sections: customerProfile (required), customerDetails, consumptionProfile, generationProfile, storageProfile (all optional except customerProfile)",
+            "description": "Subject with profile sections: customerProfile (required), customerDetails, consumptionProfiles, generationProfiles, storageProfiles.",
             "required": [
                 "customerProfile"
             ],
@@ -141,14 +141,23 @@
                 "customerDetails": {
                     "$ref": "#/$defs/CustomerDetails"
                 },
-                "consumptionProfile": {
-                    "$ref": "#/$defs/ConsumptionProfile"
+                "consumptionProfiles": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/ConsumptionProfile" },
+                    "description": "Connection and consumption characteristics. Array supports multiple meters or tariff categories."
                 },
-                "generationProfile": {
-                    "$ref": "#/$defs/GenerationProfile"
+                "generationProfiles": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/GenerationProfile" },
+                    "description": "DER generation assets. Array supports multiple generation units."
                 },
-                "storageProfile": {
-                    "$ref": "#/$defs/StorageProfile"
+                "storageProfiles": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/StorageProfile" },
+                    "description": "Energy storage assets. Array supports multiple batteries."
                 }
             }
         },


### PR DESCRIPTION
## Summary

- Rename `generationProfile` / `consumptionProfile` / `storageProfile` in `credentialSubject` to plural `generationProfiles` / `consumptionProfiles` / `storageProfiles`
- Type each as a strict `array` (minItems: 1) — no oneOf, no backwards-compat shim
- The profile object schemas themselves (GenerationProfile, ConsumptionProfile, StorageProfile) are **unchanged**

### Files changed

| File | What changed |
|------|-------------|
| `schema.json` | `credentialSubject` properties renamed + typed as arrays; `$defs` untouched |
| `attributes.yaml` | Plural array properties; profile schemas extracted to `components/schemas` to avoid duplication |
| `context.jsonld` | Terms renamed to plural; `@container: "@set"` added to each |
| `examples/example.json` | Keys renamed to plural; shows 1 consumption + 2 generation + 2 storage entries |

### OpenAPI lint note
The 3 pre-existing lint errors from Redocly (the external `$ref` to `EnergyCredential/v2.0` being an OpenAPI doc rather than pure JSON Schema) are unchanged — not introduced by this PR.

## Test plan
- [ ] Validate `schema.json` against a credential with a single-item array for each profile
- [ ] Validate `schema.json` against the updated `examples/example.json` (multi-item arrays)
- [ ] Confirm a credential missing `generationProfiles` / `storageProfiles` / `consumptionProfiles` still validates (all three are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)