### PR TITLE
fix(deg-ledger-ui): fix infinite pagination loop and browser caching

### DIFF
--- a/devkits/p2p-trading-ies-wave1/deg-ledger-ui-kit/discom_trade_report.py
+++ b/devkits/p2p-trading-ies-wave1/deg-ledger-ui-kit/discom_trade_report.py
@@ -9,11 +9,14 @@ trades by delivery day.
 
 Usage:
     python3 discom_trade_report.py
+    python3 discom_trade_report.py --csv trades.csv
 
 Credentials and LEDGER_URL are read from .env (same as server.py).
 """
 
+import argparse
 import base64
+import csv
 import hashlib
 import json
 import os
@@ -125,7 +128,119 @@ def _delivery_date_key(trade):
         return ("9999-99-99", "Unknown")
 
 
-def generate_report():
+def _fmt_ist(raw):
+    """Convert an ISO timestamp string to a human-readable IST string."""
+    if not raw:
+        return ""
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.astimezone(IST).strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, TypeError):
+        return raw
+
+
+def _get_energy(trade):
+    details = trade.get("tradeDetails") or []
+    return sum(d.get("tradeQty", 0) for d in details if d.get("tradeUnit") == "KWH")
+
+
+def _get_trade_type(trade):
+    details = trade.get("tradeDetails") or []
+    return ", ".join(d["tradeType"] for d in details if d.get("tradeType"))
+
+
+def _get_delivery_start(trade):
+    details = trade.get("tradeDetails") or []
+    if details:
+        for key in ("deliveryStartTime", "deliveryStart"):
+            v = details[0].get(key)
+            if v:
+                return v
+    for key in ("deliveryStartTime", "deliveryStart"):
+        v = trade.get(key)
+        if v:
+            return v
+    return ""
+
+
+def _get_delivery_end(trade):
+    details = trade.get("tradeDetails") or []
+    if details:
+        for key in ("deliveryEndTime", "deliveryEnd"):
+            v = details[0].get(key)
+            if v:
+                return v
+    for key in ("deliveryEndTime", "deliveryEnd"):
+        v = trade.get(key)
+        if v:
+            return v
+    return ""
+
+
+def _duration_hours(start_raw, end_raw):
+    if not start_raw or not end_raw:
+        return ""
+    try:
+        start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+        hours = (end - start).total_seconds() / 3600
+        return f"{hours:.2f}"
+    except (ValueError, TypeError):
+        return ""
+
+
+CSV_COLUMNS = [
+    "Trade Time (IST)",
+    "Delivery Start (IST)",
+    "Duration (h)",
+    "Qty (KWH)",
+    "Buyer Alloc",
+    "Seller Alloc",
+    "Buyer Status",
+    "Seller Status",
+    "Buyer Discom",
+    "Seller Discom",
+    "Buyer ID",
+    "Seller ID",
+    "Buyer App",
+    "Seller App",
+    "Trade Type",
+    "Transaction ID",
+    "Record ID",
+]
+
+
+def write_csv(trades, path):
+    """Write all trades to a CSV file with the same columns as the UI table."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for r in trades:
+            start_raw = _get_delivery_start(r)
+            end_raw = _get_delivery_end(r)
+            writer.writerow({
+                "Trade Time (IST)": _fmt_ist(r.get("tradeTime", "")),
+                "Delivery Start (IST)": _fmt_ist(start_raw),
+                "Duration (h)": _duration_hours(start_raw, end_raw),
+                "Qty (KWH)": f"{_get_energy(r):.2f}",
+                "Buyer Alloc": r.get("buyerDiscomAllocation", ""),
+                "Seller Alloc": r.get("sellerDiscomAllocation", ""),
+                "Buyer Status": r.get("statusBuyerDiscom", ""),
+                "Seller Status": r.get("statusSellerDiscom", ""),
+                "Buyer Discom": r.get("discomIdBuyer", ""),
+                "Seller Discom": r.get("discomIdSeller", ""),
+                "Buyer ID": r.get("buyerId", ""),
+                "Seller ID": r.get("sellerId", ""),
+                "Buyer App": r.get("platformIdBuyer", ""),
+                "Seller App": r.get("platformIdSeller", ""),
+                "Trade Type": _get_trade_type(r),
+                "Transaction ID": r.get("transactionId", ""),
+                "Record ID": r.get("recordId", ""),
+            })
+    print(f"CSV written: {path} ({len(trades)} rows)", file=sys.stderr)
+
+
+def generate_report(csv_path=None):
     """Fetch trades from ledger and print a WhatsApp-friendly DISCOM trade report."""
     if not LEDGER_URL:
         print("Error: LEDGER_URL not set in .env or environment", file=sys.stderr)
@@ -234,8 +349,15 @@ def generate_report():
 
     report = "\n".join(lines)
     print(report)
+
+    if csv_path:
+        write_csv(all_trades, csv_path)
+
     return report
 
 
 if __name__ == "__main__":
-    generate_report()
+    parser = argparse.ArgumentParser(description="DISCOM Trade Report")
+    parser.add_argument("--csv", metavar="FILE", help="Optional path to write all trades as a CSV file")
+    args = parser.parse_args()
+    generate_report(csv_path=args.csv)

--- a/devkits/p2p-trading-ies-wave1/deg-ledger-ui-kit/index.html
+++ b/devkits/p2p-trading-ies-wave1/deg-ledger-ui-kit/index.html
@@ -211,63 +211,42 @@
       document.getElementById('refreshBtn').classList.add('opacity-50');
 
       const records = [];
-      let offset = 0;
       const limit = 500;
 
       try {
-        // Build request body with date range if set
-        const buildBody = () => {
+        for (let offset = 0; ; offset += limit) {
           const body = { limit, offset, sort: 'tradeTime', sortOrder: 'desc' };
           if (tradeTimeStart) body.tradeTimeFrom = new Date(tradeTimeStart).toISOString();
           if (tradeTimeEnd) body.tradeTimeTo = new Date(tradeTimeEnd).toISOString();
-          return body;
-        };
 
-        while (true) {
-          const reqBody = buildBody();
-          reqBody.offset = offset;
           const res = await fetch(API_URL, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(reqBody)
+            body: JSON.stringify(body)
           });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const data = await res.json();
-          records.push(...(data.records || []));
-          if ((data.count || 0) < limit) break;
-          offset += limit;
+          const page = data.records || [];
+          records.push(...page);
+          if (page.length < limit) break;
         }
 
         allRecords = records;
-        
-        // Initialize all discoms list
+
         const discomSet = new Set();
         records.forEach(r => {
           if (r.discomIdBuyer) discomSet.add(r.discomIdBuyer);
           if (r.discomIdSeller) discomSet.add(r.discomIdSeller);
         });
         allDiscoms = Array.from(discomSet).sort();
-        
-        // Select all non-TEST discoms by default
+
         if (selectedDiscoms.length === 0) {
           selectedDiscoms = allDiscoms.filter(d => !d.startsWith('TEST'));
         }
-        
+
         filteredRecords = null;
         selectedPair = null;
-        
-        // Initialize time range to last 10 days if not already set
-        if (!tradeTimeStart || !tradeTimeEnd) {
-          // setLastNDays() will call applyFilters() internally
-          setLastNDays(2);
-        } else {
-          // Update the input fields with current values
-          document.getElementById('tradeTimeStart').value = tradeTimeStart;
-          document.getElementById('tradeTimeEnd').value = tradeTimeEnd;
-          // Apply filters with current settings
-          applyFilters();
-        }
-        
+        applyFilters();
         updateUI();
         updatePollTime();
         resetCountdown();
@@ -1282,17 +1261,10 @@
     // ── Init ──
     updateAutoRefreshButton();
     renderTableHeader();
+    setDefaultDateRange();
 
-    // Initialize time range to last 2 days
-    setLastNDays(2);
-
-    // Add event listeners for time range inputs
     document.getElementById('tradeTimeStart').addEventListener('change', applyTimeRangeFilters);
     document.getElementById('tradeTimeEnd').addEventListener('change', applyTimeRangeFilters);
-
-    // Fetch config then records
-    // Set default date range (1 month ago to 2 days from now) before first fetch
-    setDefaultDateRange();
 
     fetch('/api/config')
       .then(res => res.json())
@@ -1300,7 +1272,7 @@
         showParticipantIds = cfg.showParticipantIds || false;
         renderTableHeader();
       })
-      .catch(() => {}) // keep default (off)
+      .catch(() => {})
       .finally(() => fetchAllRecords());
   </script>
 </body>

--- a/devkits/p2p-trading-ies-wave1/deg-ledger-ui-kit/server.py
+++ b/devkits/p2p-trading-ies-wave1/deg-ledger-ui-kit/server.py
@@ -193,8 +193,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(err)
 
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+        super().end_headers()
+
     def log_message(self, fmt, *args):
-        # Compact logging
         print(f"[{self.log_date_time_string()}] {fmt % args}")
 
 


### PR DESCRIPTION
## Summary

Two bug fixes and one new feature for the DEG Ledger UI kit.

### Bug: infinite pagination loop in dashboard (`index.html`)

The ledger API returns `count` as the **total** number of matching records, not the current page size. The original break condition `data.count < limit` never triggered when total records exceeded the 500-record page limit, causing an infinite POST loop visible as a constant stream of requests in the server terminal.

**Fix:** break on `page.length < limit` (records returned in the current page).

**Cleanup:** removed the `buildBody` closure and redundant `reqBody.offset` reassignment; replaced `while(true)` with a `for` loop using a `page` variable that makes the break condition self-evident. Removed dead init code (`setLastNDays(2)` was immediately overwritten by `setDefaultDateRange()`). Simplified post-fetch logic by removing the unreachable `if (!tradeTimeStart || !tradeTimeEnd)` branch.

### Bug: Chrome caches stale JavaScript (`server.py`)

Chrome aggressively caches `http://localhost` responses, so even after fixing `index.html` the browser served the old broken JS. Safari/Perplexity (WebKit) were unaffected due to a more conservative localhost caching policy.

**Fix:** added `Cache-Control: no-store, no-cache, must-revalidate` to all server responses via an `end_headers()` override in the `Handler` class.

### Feature: CSV export for DISCOM trade report (`discom_trade_report.py`)

Added an optional `--csv <file>` flag that writes all fetched trades to a CSV file with columns matching the UI table — trade time, delivery start, duration, quantity (KWH), buyer/seller allocation, status, DISCOM IDs, platform IDs, trade type, transaction ID, and record ID. All timestamps are converted to IST.

```
python3 discom_trade_report.py --csv trades.csv
```

## Test plan

- [x] Restart server and load dashboard in Chrome — verify records load and the request stream stops after 2 pages
- [x] Confirm a normal refresh in Chrome no longer serves stale JS
- [x] Verify Safari still loads correctly
- [x] Run `python3 discom_trade_report.py --csv out.csv` and verify the CSV contains all trades with correct columns and IST timestamps
- [x] Run without `--csv` and confirm the WhatsApp report is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)