### PR TITLE
fix(ledger-get): add statusBuyerDiscom/statusSellerDiscom as query filters

### DIFF
--- a/specification/api/deg_contract_ledger.yaml
+++ b/specification/api/deg_contract_ledger.yaml
@@ -802,6 +802,18 @@ components:
           type: integer
           minimum: 0
           default: 0
+        statusBuyerDiscom:
+          anyOf:
+            - $ref: "#/components/schemas/tradeStatus"
+            - type: string
+              maxLength: 0
+          description: Filter by buyer discom status; pass empty string to skip this filter
+        statusSellerDiscom:
+          anyOf:
+            - $ref: "#/components/schemas/tradeStatus"
+            - type: string
+              maxLength: 0
+          description: Filter by seller discom status; pass empty string to skip this filter
         sort:
           type: string
           enum: [creationTime, tradeTime, deliveryStartTime, deliveryEndTime]


### PR DESCRIPTION
## Summary

- Adds `statusBuyerDiscom` and `statusSellerDiscom` as optional filter fields on `ledgerGetRequest` in `specification/api/deg_contract_ledger.yaml`
- Enables callers to query for trades by discom lifecycle status — specifically to surface unallocated trades where a discom has not yet recorded actuals or set a terminal status
- Each field uses `anyOf` to accept either a valid `tradeStatus` enum value or an empty string (`""`), where `""` means return only records where that status field is not populated

## Test plan

- [ ] Call `POST /ledger/get` with `{"statusBuyerDiscom":"","discomIdSeller":"PVVNL","limit":100,"sort":"tradeTime","sortOrder":"desc"}` — schema validator should accept the request without error
- [ ] Call with `{"statusBuyerDiscom":"PENDING"}` — should filter to records with buyer discom status = PENDING
- [ ] Call with `{"statusBuyerDiscom":"INVALID"}` — schema validator should reject with 400
- [ ] Verify service layer treats `""` as "no status filter applied" (returns records where the field is unpopulated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)