### PR TITLE
fix(schema): add missing version-level README.md for espi v1.0 folders

### DIFF
--- a/specification/external/schema/espiGreenButton/v1.0/README.md
+++ b/specification/external/schema/espiGreenButton/v1.0/README.md
@@ -1,0 +1,15 @@
+# espiGreenButton — v1.0
+
+JSON-LD context and RDF vocabulary for Green Button / ESPI types (NAESB REQ.21).
+
+Part of the [DEG External Schema](../../) · [espiGreenButton](../README.md)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.0 schema definitions for ESPI types |
+| [context.jsonld](./context.jsonld) | JSON-LD context mapping ESPI types and properties to `http://naesb.org/espi#` IRIs |
+| [vocab.jsonld](./vocab.jsonld) | RDF vocabulary (RDFS classes and properties) with `skos:exactMatch` links to ESPI XSD types |
+
+See [../README.md](../README.md) for the full type reference, enumeration codes, and linked data URLs.

--- a/specification/external/schema/espiGreenButtonWithCIM/v1.0/README.md
+++ b/specification/external/schema/espiGreenButtonWithCIM/v1.0/README.md
@@ -1,0 +1,15 @@
+# espiGreenButtonWithCIM — v1.0
+
+CIM (IEC 61968/61970) extension types for Green Button / ESPI, covering meter telemetry at consumer, distribution-transformer, and transmission levels.
+
+Part of the [DEG External Schema](../../) · [espiGreenButtonWithCIM](../README.md)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.0 schema definitions for CIM extension types |
+| [context.jsonld](./context.jsonld) | JSON-LD context mapping CIM types and properties to `http://iec.ch/TC57/CIM#` IRIs |
+| [vocab.jsonld](./vocab.jsonld) | RDF vocabulary (RDFS classes and properties) for CIM extension types |
+
+See [../README.md](../README.md) for the full type reference and IEC standard mappings.


### PR DESCRIPTION
## Summary

- Adds `README.md` to `espiGreenButton/v1.0/` and `espiGreenButtonWithCIM/v1.0/`
- Fixes `[missing-readme]` validation error — the schema publishing pipeline requires a `README.md` in every version folder, not just at the class level
- Both READMEs link back to their class-level docs for full type reference and enumeration tables

Follows on from #312 which moved the files into versioned subfolders.

## Test plan

- [ ] Schema publishing pipeline reports no `[missing-readme]` errors for `espiGreenButton/v1.0` and `espiGreenButtonWithCIM/v1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)