### PR TITLE
feat(wave2): RoleInputs payload/payloadDescriptors oneOf, N14 network policy, updated schema

### DIFF
--- a/specification/schema/EnergyTradeOffer/v2.0/context.jsonld
+++ b/specification/schema/EnergyTradeOffer/v2.0/context.jsonld
@@ -10,17 +10,15 @@
     "startTime": "schema:startTime",
     "endTime": "schema:endTime",
     "EnergyTradeOffer": "deg:EnergyTradeOffer",
+    "RoleInputs": "deg:RoleInputs",
     "validityWindow": "deg:validityWindow",
-    "deliveryWindow": "deg:deliveryWindow",
-    "gift": "deg:gift",
-    "offerTimeseries": "deg:offerTimeseries",
-    "bidTimeseries": "deg:bidTimeseries",
-    "PER_KWH": "deg:PricingModelPerKwh",
-    "PER-KWH": "deg:PricingModelPerKwh",
-    "TIME_OF_DAY": "deg:PricingModelTimeOfDay",
-    "TIME-OF-DAY": "deg:PricingModelTimeOfDay",
-    "SUBSCRIPTION": "deg:PricingModelSubscription",
-    "FIXED": "deg:PricingModelFixed"
+    "contractTerms": "deg:contractTerms",
+    "commitmentAttributes": "deg:commitmentAttributes",
+    "inputs": "deg:inputs",
+    "role": "deg:role",
+    "participantId": "deg:participantId",
+    "payload": "deg:payload",
+    "payloadDescriptors": "deg:payloadDescriptors"
   },
   "@graph": []
 }

--- a/specification/schema/EnergyTradeOffer/v2.0/vocab.jsonld
+++ b/specification/schema/EnergyTradeOffer/v2.0/vocab.jsonld
@@ -16,12 +16,10 @@
       "rdfs:comment": "Offer attributes for P2P energy trading, attached to Offer.offerAttributes."
     },
     {
-      "@id": "deg:pricingModel",
-      "@type": "rdf:Property",
-      "rdfs:label": "Pricing model",
-      "rdfs:comment": "Pricing model classification (PER_KWH, TIME_OF_DAY, SUBSCRIPTION, FIXED).",
-      "rdfs:domain": "deg:EnergyTradeOffer",
-      "schema:rangeIncludes": "deg:PricingModel"
+      "@id": "deg:RoleInputs",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Role Inputs",
+      "rdfs:comment": "Per-role declaration within an EnergyTradeOffer. Carries either payloadDescriptors (intent-only) or payload (actual BecknTimeSeries contribution). Mutually exclusive: seller MUST use payload from catalog publish onwards."
     },
     {
       "@id": "deg:validityWindow",
@@ -32,66 +30,57 @@
       "schema:rangeIncludes": "schema:TimePeriod"
     },
     {
-      "@id": "deg:deliveryWindow",
+      "@id": "deg:contractTerms",
       "@type": "rdf:Property",
-      "rdfs:label": "Delivery window",
-      "rdfs:comment": "Specific time period when energy delivery occurs.",
+      "rdfs:label": "Contract terms",
+      "rdfs:comment": "JSON-LD container for contract terms (DEGContract) published at catalog time.",
       "rdfs:domain": "deg:EnergyTradeOffer",
-      "schema:rangeIncludes": "schema:TimePeriod"
+      "schema:rangeIncludes": { "@id": "https://schema.beckn.io/deg/DEGContract/v2.0/DEGContract" }
     },
     {
-      "@id": "deg:gift",
+      "@id": "deg:commitmentAttributes",
       "@type": "rdf:Property",
-      "rdfs:label": "Gift",
-      "rdfs:comment": "Optional gift parameters for energy gifting on this offer.",
-      "rdfs:domain": "deg:EnergyTradeOffer",
-      "schema:rangeIncludes": { "@id": "https://schema.beckn.io/deg/EnergyGift/v2.0/EnergyGift" }
-    },
-    {
-      "@id": "deg:offerTimeseries",
-      "@type": "rdf:Property",
-      "rdfs:label": "Offer timeseries",
-      "rdfs:comment": "Seller's BecknTimeSeries of delivery slots (PRICE_PER_KWH, AVAILABLE_QTY per interval).",
+      "rdfs:label": "Commitment attributes",
+      "rdfs:comment": "Seller's initial BecknTimeSeries at catalog time (PRICE_PER_KWH + AVAILABLE_QTY intervals). Seed of Commitment.commitmentAttributes; other roles append as lifecycle progresses.",
       "rdfs:domain": "deg:EnergyTradeOffer",
       "schema:rangeIncludes": { "@id": "https://schema.beckn.io/deg/BecknTimeSeries/v1.0/TimeSeries" }
     },
     {
-      "@id": "deg:bidTimeseries",
+      "@id": "deg:inputs",
       "@type": "rdf:Property",
-      "rdfs:label": "Bid timeseries",
-      "rdfs:comment": "Buyer's BecknTimeSeries of requested quantities (REQUESTED_QTY per interval); ids subset of seller's offerTimeseries.",
+      "rdfs:label": "Inputs",
+      "rdfs:comment": "Per-role declarations (seller, buyer, buyerDiscom, sellerDiscom). Each entry carries either payload or payloadDescriptors.",
       "rdfs:domain": "deg:EnergyTradeOffer",
+      "schema:rangeIncludes": "deg:RoleInputs"
+    },
+    {
+      "@id": "deg:role",
+      "@type": "rdf:Property",
+      "rdfs:label": "Role",
+      "rdfs:comment": "Role this entry applies to: buyer, seller, buyerDiscom, or sellerDiscom.",
+      "rdfs:domain": "deg:RoleInputs"
+    },
+    {
+      "@id": "deg:participantId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Participant ID",
+      "rdfs:comment": "Beckn participant ID of the role-holder once bound. Null at catalog publish for buyer and discom roles.",
+      "rdfs:domain": "deg:RoleInputs"
+    },
+    {
+      "@id": "deg:payload",
+      "@type": "rdf:Property",
+      "rdfs:label": "Payload",
+      "rdfs:comment": "The role's actual BecknTimeSeries contribution to Commitment.commitmentAttributes. Mutually exclusive with payloadDescriptors (oneOf). Seller MUST use this form.",
+      "rdfs:domain": "deg:RoleInputs",
       "schema:rangeIncludes": { "@id": "https://schema.beckn.io/deg/BecknTimeSeries/v1.0/TimeSeries" }
     },
     {
-      "@id": "deg:PricingModel",
-      "@type": "schema:Enumeration",
-      "schema:name": "Pricing Model",
-      "rdfs:comment": "Enumeration of supported pricing models for energy trade offers."
-    },
-    {
-      "@id": "deg:PricingModelPerKwh",
-      "@type": "deg:PricingModel",
-      "schema:name": "PER_KWH",
-      "schema:identifier": "PER_KWH"
-    },
-    {
-      "@id": "deg:PricingModelTimeOfDay",
-      "@type": "deg:PricingModel",
-      "schema:name": "TIME_OF_DAY",
-      "schema:identifier": "TIME_OF_DAY"
-    },
-    {
-      "@id": "deg:PricingModelSubscription",
-      "@type": "deg:PricingModel",
-      "schema:name": "SUBSCRIPTION",
-      "schema:identifier": "SUBSCRIPTION"
-    },
-    {
-      "@id": "deg:PricingModelFixed",
-      "@type": "deg:PricingModel",
-      "schema:name": "FIXED",
-      "schema:identifier": "FIXED"
+      "@id": "deg:payloadDescriptors",
+      "@type": "rdf:Property",
+      "rdfs:label": "Payload descriptors",
+      "rdfs:comment": "Metadata-only declaration of signal types this role will contribute. Mutually exclusive with payload (oneOf). Used by roles that have not yet written interval data.",
+      "rdfs:domain": "deg:RoleInputs"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **`EnergyTradeOffer` schema** (`RoleInputs`): `inputs[x]` now enforces a `oneOf` — either `payloadDescriptors` (metadata-only intent declaration) or `payload` (actual `BecknTimeSeries` contribution), mutually exclusive. Sellers MUST carry `payload` from catalog publish onwards.
- **Network policy N14** (`p2p-trading-ies-wave2_network.rego`): new rule requiring the seller `offerAttributes.inputs` entry to carry a `payload` field, not just `payloadDescriptors`. Policy synced to `specification/policies/`.
- **All 8 devkit examples** updated: `inputs[seller]` carries full `BecknTimeSeries` (PRICE_PER_KWH + AVAILABLE_QTY intervals) via `payload` field, including `publish-catalog.json`.
- **`context.jsonld` + `vocab.jsonld`** updated: replaced old wave1 terms (`offerTimeseries`, `bidTimeseries`, `deliveryWindow`, `gift`, `PricingModel` enums) with wave2 terms (`inputs`, `payload`, `payloadDescriptors`, `contractTerms`, `commitmentAttributes`, `RoleInputs`).
- **Compact interval format**: each `{"type": "...", "values": [x]}` payload item in examples is now on a single line.
- **Postman collections** regenerated.

## Root cause of current arazzo NACKs

All NACKs share one cause: `property "payload" is unsupported` — the onix extended schema validator fetches `EnergyTradeOffer` schema from `schema.beckn.io`, which still has the old `RoleInputs` definition. Once this PR's schema files are published to `schema.beckn.io` and containers are restarted (to clear the 86400s cache), flows will ACK.

## Test plan

- [ ] Publish `specification/schema/EnergyTradeOffer/v2.0/` to `schema.beckn.io`
- [ ] Restart onix containers to clear extended schema cache
- [ ] Run `npx @redocly/cli respect workflows/p2p-trading-ies-wave2.arazzo.yaml --severity 'SCHEMA_CHECK=off'` — expect all 4 target workflows to pass with ACK

🤖 Generated with [Claude Code](https://claude.com/claude-code)