### PR TITLE
feat(EnergyCustomer): add platformUri

### DIFF
--- a/specification/schema/EnergyCustomer/v2.0/attributes.yaml
+++ b/specification/schema/EnergyCustomer/v2.0/attributes.yaml
@@ -67,3 +67,21 @@ components:
           example: "TPDDL-DL"
           x-jsonld:
             "@id": utilityId
+
+        platformUri:
+          type: string
+          format: uri
+          description: >
+            Base URL (scheme + host[:port]) of the Beckn trading platform that
+            represents this customer on the network. The platform exposes the
+            standard Beckn paths under this base: `/bap/caller`, `/bap/receiver`,
+            `/bpp/caller`, `/bpp/receiver`. Used by downstream nodes to address
+            this customer's platform for cascade sub-transactions — e.g. a
+            seller-side adapter cascading a /status query into its own discom
+            ledger and needing the discom's response routed back to its own
+            /bap/receiver. The path appended depends on the action's
+            BAP↔BPP direction (/bap/receiver for on_*, /bpp/receiver for
+            request actions).
+          example: "http://bap.example.com:9000"
+          x-jsonld:
+            "@id": platformUri


### PR DESCRIPTION
## Summary
- Adds an optional `platformUri` property to `EnergyCustomer/v2.0/attributes.yaml`.
- `platformUri` is the base URL (scheme + host[:port]) of the participant's Beckn trading platform. Plugins append the standard Beckn path based on direction (`/bap/receiver` for `on_*` responses, `/bpp/receiver` for request actions).
- Unlocks strict per-leg context rewriting in inter-platform cascades — e.g. a seller-side adapter cascading `/status` to its own discom and routing the discom's `on_status` response back to the seller's `/bap/receiver`.

## Why
Today there is no field in `EnergyCustomer` to carry a customer's platform base URL. Adapter callers fall back to hardcoded URLs in routing configs, which breaks once participants move off a shared single-host devkit onto real per-node hostnames. With `platformUri` in the contract, callers can derive the right `/bap/*` or `/bpp/*` URL at runtime without external configuration.

## What this is *not*
- No new schema version — adds an optional property to v2.0.
- No changes to plugin code, devkit configs, or other schemas — those land separately in the wave2 split-discom PR that consumes this.

## Test plan
- [ ] CI lint on the schema file passes
- [ ] After publish to schema.beckn.io, the wave2 devkit's arazzo flows (separate PR, in flight) validate `participants[buyer/seller].participantAttributes.platformUri` and ACK end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)