### PR TITLE
schema(beckn): BecknPageInfo + BecknResourceRef for bulk-cohort pagination

### DIFF
--- a/devkits/demand-flex/README.md
+++ b/devkits/demand-flex/README.md
@@ -25,6 +25,32 @@ Settlement is computed against the DISCOM's own grid-meter measurements (`BASELI
 | [DEGContract](../../specification/schema/DEGContract/v2.0/) | `contractAttributes` | Roles (buyer/seller), policy reference, revenue flows |
 | [DemandFlexPerformance](../../specification/schema/DemandFlexPerformance/v2.0/) | `performanceAttributes` | M&V baselines and actuals per meter; per-EV vendor BecknTimeSeries for backstop |
 | [BecknReportDescriptors](../../specification/schema/BecknReportDescriptors/v1.0/) | `offerAttributes.inputs[seller].inputs.reportDescriptors` | OpenADR3-aligned descriptors with `cardinality` (PER_INTERVAL / PER_EVENT) committing what vendor telemetry types the seller will report |
+| [BecknPageInfo](../../specification/schema/BecknPageInfo/v1.0/) | `performanceAttributes.pageInfo` | Optional — present only when `meters[]` is split across messages (push or pull). Absence of `pageInfo` is the signal that the message is self-contained. |
+| [BecknResourceRef](../../specification/schema/BecknResourceRef/v1.0/) | `inputs[seller].inputs.participatingMetersRef` / `performanceAttributes.metersRef` | Optional — off-protocol delivery for bulk collections (content-addressed via `sha256`). |
+
+## Bulk cohorts (paginating thousands of meters)
+
+For demonstration purposes the example fixtures carry three meters. Real DR programs routinely span thousands. Pagination kicks in at two distinct points in the flow:
+
+| Where | When inline is fine | When to switch | Mechanism |
+|---|---|---|---|
+| Confirm-time cohort enrollment (`participatingMeters[]` on the seller's offer block) | Up to ~10k meters fits in a single confirm message | Above that threshold the confirm payload becomes unwieldy and the offer can't span messages (offers are bound at confirm) | Replace inline `participatingMeters` with `participatingMetersRef` ([BecknResourceRef](../../specification/schema/BecknResourceRef/v1.0/)) and pin the cohort with `participatingMetersDigest` (on-protocol `sha256` of the sorted meter IDs) so the contract stays auditable even after the off-protocol URL expires. |
+| Performance-time telemetry (`performanceAttributes.meters[]` on `on_status`) | Up to ~10k meters fits in a single on_status | Above that threshold the BPP either splits the delivery across multiple on_status messages (paged inline) or substitutes `metersRef` (off-protocol) | Paged inline: BPP fills `pageInfo` ([BecknPageInfo](../../specification/schema/BecknPageInfo/v1.0/)) on each message; receivers assemble by `sequence` and only settle when `isLast: true`. Off-protocol: BPP omits `meters[]` and ships `metersRef` instead. |
+
+The 10k threshold is a working guideline, not a hard cap — implementations tune to their wire budget.
+
+### Push vs pull pagination
+
+Both delivery patterns share the same `BecknPageInfo` shape; they differ only in who drives the cadence:
+
+- **BPP push** — BPP fires `N` back-to-back `on_status` messages, each with monotonically-increasing `pageInfo.sequence`, ending with `isLast: true`. The BAP does nothing special — it accumulates and fires settlement on the last page. Example: [`on-status-response-actuals-paged-push.json`](./uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json).
+- **BAP pull** — BAP issues `status` calls carrying a `pageCursor` tag, and the BPP returns one page per call. The response echoes `pageInfo.cursor` and advertises `pageInfo.nextCursor` for the next request. Use when the BAP needs flow control or wants to interleave page fetches with other work. Example: [`on-status-response-actuals-paged-pull.json`](./uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json) (the inbound `status` request that triggered this response is recorded in the `_comment_inbound_request` block of the same file).
+
+Both examples reuse the same 12,000-meter `participatingMetersRef` cohort to show how a bulk-enrolled contract performs at scale.
+
+### Network rego under pagination
+
+The cross-field type-coverage and cardinality checks in [`demand_flex_network.rego`](./policies/demand_flex_network.rego) operate per-meter — they fire on each page in isolation, with no awareness of the wider delivery. That's fine: any malformed meter telemetry NACKs immediately on the page that carries it, regardless of the page's position. Settlement runs against the assembled view only (see [`demand_flex_revenue.rego`](../../specification/policies/demand_flex_revenue.rego)).
 
 ## Postman
 

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json
@@ -1,0 +1,200 @@
+{
+  "context": {
+    "networkId": "nfh.global/testnet-deg",
+    "version": "2.0.0",
+    "action": "on_status",
+    "_comment_design": "BAP-PULL PAGINATION (illustrative). Same 12,000-meter cohort and event as the push example, but here the BAP drives the cadence — it issues `status` calls, each carrying a `pageCursor` tag, and the BPP returns one page per call. This file is the BPP's on_status response to a BAP status request whose context.tags carried `{descriptor: {code: 'pageCursor'}, value: 'evt-bulk-001-p2'}`. The response echoes that cursor on pageInfo.cursor and advertises the next slice via pageInfo.nextCursor. BAP keeps pulling until pageInfo.nextCursor is null AND pageInfo.isLast is true, then assembles meters[] and runs settlement. _comment_inbound_request below records the shape of the request that triggered this response so the example is self-contained.",
+    "_comment_inbound_request": {
+      "context": {
+        "networkId": "nfh.global/testnet-deg",
+        "version": "2.0.0",
+        "action": "status",
+        "bapId": "bap.example.com",
+        "bppId": "bpp.example.com",
+        "transactionId": "txn-flex-bulk-001",
+        "messageId": "msg-status-pull-p2-001",
+        "timestamp": "2026-04-01T10:34:30Z",
+        "tags": [
+          {
+            "descriptor": {"code": "pagination"},
+            "list": [
+              {"descriptor": {"code": "pageCursor"}, "value": "evt-bulk-001-p2"},
+              {"descriptor": {"code": "collectionId"}, "value": "perf-evt-bulk-001-actuals"}
+            ]
+          }
+        ]
+      },
+      "message": {
+        "ref": {
+          "id": "contract-flex-bulk-001",
+          "performance": [{"id": "perf-evt-bulk-001-actuals"}]
+        }
+      }
+    },
+    "bapId": "bap.example.com",
+    "bapUri": "https://bap.example.com/beckn",
+    "bppId": "bpp.example.com",
+    "bppUri": "https://bpp.example.com/beckn",
+    "transactionId": "txn-flex-bulk-001",
+    "messageId": "msg-on-status-actuals-bulk-pull-p2",
+    "timestamp": "2026-04-01T10:34:31Z",
+    "schemaContext": [
+      "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",
+      "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
+      "https://schema.beckn.io/BecknPageInfo/v1.0/context.jsonld",
+      "https://schema.beckn.io/DemandFlexNeed/v2.0/context.jsonld",
+      "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
+      "https://schema.beckn.io/BecknReportDescriptors/v1.0/context.jsonld",
+      "https://schema.beckn.io/BecknResourceRef/v1.0/context.jsonld",
+      "https://schema.beckn.io/Quantity/context.jsonld",
+      "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld"
+    ]
+  },
+  "message": {
+    "contract": {
+      "id": "contract-flex-bulk-001",
+      "status": {"code": "ACTIVE"},
+      "commitments": [
+        {
+          "id": "commitment-flex-bulk-001",
+          "status": {"descriptor": {"code": "ACTIVE"}},
+          "resources": [
+            {
+              "id": "flex-need-north-delhi-apr1-bulk",
+              "quantity": {"unitCode": "kW", "unitQuantity": 6000, "@type": "Quantity"},
+              "resourceAttributes": {
+                "@context": "https://schema.beckn.io/DemandFlexNeed/v2.0/context.jsonld",
+                "@type": "DemandFlexNeed",
+                "direction": "REDUCE",
+                "eventWindow": {"startDate": "2026-04-01T08:30:00Z", "endDate": "2026-04-01T10:30:00Z"},
+                "capacityType": "CURTAILMENT",
+                "maxCapacityKw": 20000
+              }
+            }
+          ],
+          "offer": {
+            "id": "offer-flex-bulk-001",
+            "resourceIds": ["flex-need-north-delhi-apr1-bulk"],
+            "offerAttributes": {
+              "@context": "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",
+              "@type": "DemandFlexBuyOffer",
+              "inputs": [
+                {
+                  "role": "buyer",
+                  "participantId": "tpddl-north-delhi",
+                  "inputs": {
+                    "incentivePerKwh": 3.5,
+                    "currency": "INR",
+                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
+                    "penaltyRate": 1.5,
+                    "premiumForGuaranteed": 5.0,
+                    "optOutDefault": false
+                  }
+                },
+                {
+                  "role": "seller",
+                  "participantId": "greenflex-agg",
+                  "inputs": {
+                    "plannedDemandChange": {"@type": "Quantity", "unitCode": "KWH", "unitQuantity": 6000.0},
+                    "participatingMetersRef": {
+                      "@type": "ResourceRef",
+                      "uri": "https://bpp.example.com/bulk/cohort-2026-04-01.jsonld",
+                      "contentHash": "sha256:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+                      "count": 12000,
+                      "contentType": "application/ld+json",
+                      "schemaContext": "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/participatingMeters.jsonld",
+                      "sizeBytes": 920000
+                    },
+                    "participatingMetersDigest": {
+                      "count": 12000,
+                      "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"
+                    },
+                    "reportDescriptors": [
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "performance": [
+        {
+          "id": "perf-evt-bulk-001-actuals",
+          "status": {
+            "code": "DELIVERY_COMPLETE_PARTIAL",
+            "name": "Actuals page 2 of 3 (4,000 of 12,000 meters)"
+          },
+          "commitmentIds": ["commitment-flex-bulk-001"],
+          "performanceAttributes": {
+            "@context": "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",
+            "@type": "DemandFlexPerformance",
+            "eventId": "evt-2026-04-01-bulk-001",
+            "methodology": "5of10",
+            "_comment_meters_slice": "In the wire payload this array carries 4,000 meters (this page's slice — meterIds 04001..08000). Two are shown as a representative sample.",
+            "meters": [
+              {
+                "meterId": "der://meter/04001",
+                "telemetry": {
+                  "@type": "TimeSeries",
+                  "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT1H"},
+                  "payloadDescriptors": [
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
+                  ],
+                  "intervals": [
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [52.0]}, {"type": "USAGE", "values": [26.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [24.0]}]}
+                  ]
+                }
+              },
+              {
+                "meterId": "der://meter/04002",
+                "telemetry": {
+                  "@type": "TimeSeries",
+                  "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT1H"},
+                  "payloadDescriptors": [
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
+                  ],
+                  "intervals": [
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [41.0]}, {"type": "USAGE", "values": [19.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [40.0]}, {"type": "USAGE", "values": [16.0]}]}
+                  ]
+                }
+              }
+            ],
+            "pageInfo": {
+              "@type": "PageInfo",
+              "sequence": 1,
+              "pageSize": 4000,
+              "total": 12000,
+              "isLast": false,
+              "cursor": "evt-bulk-001-p2",
+              "nextCursor": "evt-bulk-001-p3",
+              "collectionId": "perf-evt-bulk-001-actuals"
+            }
+          }
+        }
+      ],
+      "contractAttributes": {
+        "@context": "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
+        "@type": "DEGContract",
+        "roles": [
+          {"role": "buyer", "participantId": "tpddl-north-delhi"},
+          {"role": "seller", "participantId": "greenflex-agg"}
+        ],
+        "policy": {
+          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand_flex_revenue.rego",
+          "queryPath": "data.deg.contracts.demand_flex"
+        }
+      },
+      "participants": [
+        {"role": "buyer", "participantId": "tpddl-north-delhi"},
+        {"role": "seller", "participantId": "greenflex-agg"}
+      ]
+    }
+  }
+}

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json
@@ -1,0 +1,189 @@
+{
+  "context": {
+    "networkId": "nfh.global/testnet-deg",
+    "version": "2.0.0",
+    "action": "on_status",
+    "_comment_design": "BPP-PUSH PAGINATION (illustrative). Cohort = 12,000 grid meters; BPP splits the actuals delivery into 3 back-to-back on_status pushes of 4,000 meters each. This file is page 0 (sequence: 0); the next two pushes carry sequence: 1 and sequence: 2 (with isLast: true) for the same (transactionId, performance.id). The BAP accumulates meters[] across all three messages and only fires settlement-dependent checks once isLast == true is observed. Meters shown below are a 2-row representative sample of the 4,000 in this page — wire payload would carry the full 4,000.",
+    "bapId": "bap.example.com",
+    "bapUri": "https://bap.example.com/beckn",
+    "bppId": "bpp.example.com",
+    "bppUri": "https://bpp.example.com/beckn",
+    "transactionId": "txn-flex-bulk-001",
+    "messageId": "msg-on-status-actuals-bulk-p0",
+    "timestamp": "2026-04-01T10:35:00Z",
+    "schemaContext": [
+      "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",
+      "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
+      "https://schema.beckn.io/BecknPageInfo/v1.0/context.jsonld",
+      "https://schema.beckn.io/DemandFlexNeed/v2.0/context.jsonld",
+      "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
+      "https://schema.beckn.io/BecknReportDescriptors/v1.0/context.jsonld",
+      "https://schema.beckn.io/BecknResourceRef/v1.0/context.jsonld",
+      "https://schema.beckn.io/Quantity/context.jsonld",
+      "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld"
+    ]
+  },
+  "message": {
+    "contract": {
+      "id": "contract-flex-bulk-001",
+      "status": {
+        "code": "ACTIVE"
+      },
+      "commitments": [
+        {
+          "id": "commitment-flex-bulk-001",
+          "status": {
+            "descriptor": {
+              "code": "ACTIVE"
+            }
+          },
+          "resources": [
+            {
+              "id": "flex-need-north-delhi-apr1-bulk",
+              "quantity": {
+                "unitCode": "kW",
+                "unitQuantity": 6000,
+                "@type": "Quantity"
+              },
+              "resourceAttributes": {
+                "@context": "https://schema.beckn.io/DemandFlexNeed/v2.0/context.jsonld",
+                "@type": "DemandFlexNeed",
+                "direction": "REDUCE",
+                "eventWindow": {
+                  "startDate": "2026-04-01T08:30:00Z",
+                  "endDate": "2026-04-01T10:30:00Z"
+                },
+                "capacityType": "CURTAILMENT",
+                "maxCapacityKw": 20000
+              }
+            }
+          ],
+          "offer": {
+            "id": "offer-flex-bulk-001",
+            "resourceIds": ["flex-need-north-delhi-apr1-bulk"],
+            "offerAttributes": {
+              "@context": "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",
+              "@type": "DemandFlexBuyOffer",
+              "inputs": [
+                {
+                  "role": "buyer",
+                  "participantId": "tpddl-north-delhi",
+                  "inputs": {
+                    "incentivePerKwh": 3.5,
+                    "currency": "INR",
+                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
+                    "penaltyRate": 1.5,
+                    "premiumForGuaranteed": 5.0,
+                    "optOutDefault": false
+                  }
+                },
+                {
+                  "role": "seller",
+                  "participantId": "greenflex-agg",
+                  "inputs": {
+                    "plannedDemandChange": {
+                      "@type": "Quantity",
+                      "unitCode": "KWH",
+                      "unitQuantity": 6000.0
+                    },
+                    "_comment_bulk_cohort": "Cohort of 12,000 meters is too large to inline on confirm — delivered via participatingMetersRef and pinned by participatingMetersDigest. Performance-side pagination below references the same cohort.",
+                    "participatingMetersRef": {
+                      "@type": "ResourceRef",
+                      "uri": "https://bpp.example.com/bulk/cohort-2026-04-01.jsonld",
+                      "contentHash": "sha256:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+                      "count": 12000,
+                      "contentType": "application/ld+json",
+                      "schemaContext": "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/participatingMeters.jsonld",
+                      "sizeBytes": 920000
+                    },
+                    "participatingMetersDigest": {
+                      "count": 12000,
+                      "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"
+                    },
+                    "reportDescriptors": [
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "performance": [
+        {
+          "id": "perf-evt-bulk-001-actuals",
+          "status": {
+            "code": "DELIVERY_COMPLETE_PARTIAL",
+            "name": "Actuals page 1 of 3 (4,000 of 12,000 meters)"
+          },
+          "commitmentIds": ["commitment-flex-bulk-001"],
+          "performanceAttributes": {
+            "@context": "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",
+            "@type": "DemandFlexPerformance",
+            "eventId": "evt-2026-04-01-bulk-001",
+            "methodology": "5of10",
+            "_comment_meters_slice": "In the wire payload this array carries 4,000 meters (this page's slice). Two are shown here as a representative sample of the shape.",
+            "meters": [
+              {
+                "meterId": "der://meter/00001",
+                "telemetry": {
+                  "@type": "TimeSeries",
+                  "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT1H"},
+                  "payloadDescriptors": [
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
+                  ],
+                  "intervals": [
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [46.0]}, {"type": "USAGE", "values": [22.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [44.0]}, {"type": "USAGE", "values": [18.0]}]}
+                  ]
+                }
+              },
+              {
+                "meterId": "der://meter/00002",
+                "telemetry": {
+                  "@type": "TimeSeries",
+                  "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT1H"},
+                  "payloadDescriptors": [
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
+                  ],
+                  "intervals": [
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [39.0]}, {"type": "USAGE", "values": [16.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [37.0]}, {"type": "USAGE", "values": [14.0]}]}
+                  ]
+                }
+              }
+            ],
+            "pageInfo": {
+              "@type": "PageInfo",
+              "sequence": 0,
+              "pageSize": 4000,
+              "total": 12000,
+              "isLast": false,
+              "collectionId": "perf-evt-bulk-001-actuals"
+            }
+          }
+        }
+      ],
+      "contractAttributes": {
+        "@context": "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
+        "@type": "DEGContract",
+        "roles": [
+          {"role": "buyer", "participantId": "tpddl-north-delhi"},
+          {"role": "seller", "participantId": "greenflex-agg"}
+        ],
+        "policy": {
+          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand_flex_revenue.rego",
+          "queryPath": "data.deg.contracts.demand_flex"
+        }
+      },
+      "participants": [
+        {"role": "buyer", "participantId": "tpddl-north-delhi"},
+        {"role": "seller", "participantId": "greenflex-agg"}
+      ]
+    }
+  }
+}

--- a/specification/schema/BecknPageInfo/README.md
+++ b/specification/schema/BecknPageInfo/README.md
@@ -1,0 +1,39 @@
+# BecknPageInfo
+
+Domain-neutral pagination envelope embedded alongside any collection that needs multi-message delivery.
+
+**Canonical IRI:** `https://schema.beckn.io/BecknPageInfo/v1.0`
+
+**Namespace prefix:** `bpi:` → `https://schema.beckn.io/core/v2.0/`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial — covers both BPP-push and BAP-pull patterns. |
+
+---
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `sequence` | integer | ✓ | Monotonic page index (0..N-1) within a `(transactionId, collectionId)` pair. |
+| `isLast` | boolean | ✓ | `true` on the final page only. Receivers gate aggregate actions on this flag. |
+| `pageSize` | integer | | Nominal per-page element count. |
+| `total` | integer | | Expected element count across all pages. |
+| `cursor` | string | | Opaque page identifier (pull mode). |
+| `nextCursor` | string \| null | | Token for next pull request; `null` on final page. |
+| `collectionId` | string | | Disambiguates multiple paginated collections in one envelope. |
+
+---
+
+## When to use
+
+- The collection riding the message exceeds the wire budget for a single Beckn payload (rule of thumb: > 10k elements).
+- Either the BPP pushes pages back-to-back (no BAP involvement beyond assembly), or the BAP pulls pages via `status` calls carrying a `pageCursor` tag.
+- Omit entirely when one message suffices — absence of `pageInfo` is the protocol signal that the message is self-contained.
+
+For collections too large to page sanely on-protocol, see [BecknResourceRef](../BecknResourceRef/) — content-addressed off-protocol delivery.

--- a/specification/schema/BecknPageInfo/v1.0/README.md
+++ b/specification/schema/BecknPageInfo/v1.0/README.md
@@ -1,0 +1,132 @@
+# BecknPageInfo — v1.0
+
+Domain-neutral pagination envelope for any beckn payload that needs to ship a large collection across multiple messages.
+
+Part of the [DEG Schema](../../) · [BecknPageInfo](../README.md)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 `components.schemas.BecknPageInfo` |
+| [context.jsonld](./context.jsonld) | JSON-LD context — term `PageInfo` maps to `beckn:BecknPageInfo` |
+| [vocab.jsonld](./vocab.jsonld) | RDF vocabulary |
+
+## When to embed it
+
+**Don't, when you don't need to.** A sender that can fit the whole collection in a single message MUST omit `pageInfo`. The presence of `pageInfo` is itself the wire-level signal that the collection is partial. This keeps the common case (small cohort, single message) unchanged from today and makes paged delivery an opt-in concern.
+
+Consumer schemas (e.g. [DemandFlexPerformance](../../DemandFlexPerformance/v2.0/)) declare `pageInfo` as **optional** on whatever object owns the paginated array.
+
+## Modes
+
+| Mode | Who drives | What `cursor` carries |
+|---|---|---|
+| **Push** (BPP-initiated) | BPP fires N back-to-back messages | Optional; receivers rely on `sequence` for ordering |
+| **Pull** (BAP-initiated) | BAP issues subsequent calls (e.g. `status`) carrying `pageCursor` in tags | Required; BPP returns the next slice and the next `nextCursor` |
+
+Either mode terminates with `isLast: true` on the final page.
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `sequence` | integer (≥0) | ✓ | Monotonic page index within a `(transactionId, collectionId)` pair. `0` is the first page. |
+| `isLast` | boolean | ✓ | `true` on the final page only. Receivers defer aggregate-dependent actions (settlement, total-count checks) until this is observed. |
+| `pageSize` | integer (≥1) | — | Nominal per-page element count declared by the sender. Final page MAY be smaller. |
+| `total` | integer (≥0) | — | Expected element count across all pages of this delivery. May be omitted when not cheaply known. |
+| `cursor` | string | — | Opaque token identifying THIS page; echoed from the previous `nextCursor` in pull mode. |
+| `nextCursor` | string \| null | — | Token to use in the next pull request. `null` on the final page. |
+| `collectionId` | string | — | Disambiguates which collection in the envelope this `pageInfo` belongs to when more than one paginated collection rides the same transaction. |
+
+## Embedding pattern
+
+`BecknPageInfo` is a **sibling** of the paginated array, not a wrapper around it. Consumer schemas keep their existing array property and add `pageInfo` next to it:
+
+```yaml
+# In the consumer schema's attributes.yaml
+properties:
+  meters:
+    type: array
+    items: { ... }
+  pageInfo:
+    $ref: "https://schema.beckn.io/BecknPageInfo/v1.0#/components/schemas/BecknPageInfo"
+    description: Optional. Present only when the collection is paged.
+```
+
+## Minimal example — push mode, page 1 of 3
+
+```jsonc
+{
+  "performanceAttributes": {
+    "@type": "DemandFlexPerformance",
+    "eventId": "evt-2026-04-01-001",
+    "methodology": "5of10",
+    "meters": [
+      { "meterId": "der://meter/00001", "telemetry": { /* … */ } },
+      { "meterId": "der://meter/00002", "telemetry": { /* … */ } }
+      // … 3998 more on this page
+    ],
+    "pageInfo": {
+      "@type": "PageInfo",
+      "sequence": 0,
+      "pageSize": 4000,
+      "total": 12000,
+      "isLast": false,
+      "collectionId": "perf-evt-001-actuals"
+    }
+  }
+}
+```
+
+The next push carries `sequence: 1`, then `sequence: 2` with `isLast: true`. The receiver assembles `meters[]` by sorting on `sequence` and only fires settlement once `isLast: true` is observed.
+
+## Minimal example — pull mode, page 2 of N
+
+BAP requests page 2 by including `pageCursor: "evt-001-p2"` in `context.tags`. BPP responds:
+
+```jsonc
+{
+  "performanceAttributes": {
+    "@type": "DemandFlexPerformance",
+    "eventId": "evt-2026-04-01-001",
+    "methodology": "5of10",
+    "meters": [ /* slice for page 2 */ ],
+    "pageInfo": {
+      "@type": "PageInfo",
+      "sequence": 1,
+      "pageSize": 4000,
+      "total": 12000,
+      "isLast": false,
+      "cursor": "evt-001-p2",
+      "nextCursor": "evt-001-p3",
+      "collectionId": "perf-evt-001-actuals"
+    }
+  }
+}
+```
+
+## What the schema validator catches vs. what it doesn't
+
+The OpenAPI 3.1.1 validator will flag:
+
+- missing `sequence` / `isLast`
+- negative `sequence` / `pageSize` / `total`
+- `nextCursor` of a wrong type
+
+It does **not** catch (these belong in consumer profiles or the policy layer):
+
+- gap detection across pages (`sequence` is contiguous)
+- `isLast` set on a non-final page
+- `total` consistency with assembled count
+- duplicate `(transactionId, collectionId, sequence)` deliveries
+
+Encode those as profile-level cross-message checks where the receiver assembles.
+
+## Off-protocol delivery (see BecknResourceRef)
+
+For collections too large to page sanely on-protocol, the consumer schema SHOULD also allow a [BecknResourceRef](../../BecknResourceRef/v1.0/) sibling that points to a content-addressed, signed bundle. `pageInfo` is for *in-protocol* paged delivery; `BecknResourceRef` is for *off-protocol* bulk delivery. They're mutually exclusive on a given collection.
+
+## Why this lives in the top-level schema/
+
+Pagination is a Beckn-wide concern, not a domain-specific one. Catalog responses, search results, contract participant lists, performance telemetry — any of these may grow past a single-message budget. `BecknPageInfo` lives at the top of `specification/schema/` so any future schema (DEG or otherwise) can `$ref`-embed it without reinventing the cursor shape.

--- a/specification/schema/BecknPageInfo/v1.0/attributes.yaml
+++ b/specification/schema/BecknPageInfo/v1.0/attributes.yaml
@@ -1,0 +1,121 @@
+openapi: 3.1.1
+info:
+  title: BecknPageInfo — Pagination Envelope (v1.0)
+  version: 1.0.0
+  description: >
+    Domain-neutral pagination envelope for any beckn payload that may need
+    to ship a large collection across multiple messages (or out-of-band
+    via a content-addressed reference). Designed to be embedded as a
+    sibling of the collection it paginates — e.g. alongside
+    `performance.meters[]` or `offer.inputs[seller].inputs.participatingMeters[]`.
+
+    Senders that can fit the whole collection in a single message SHOULD
+    omit `pageInfo` entirely. The presence of `pageInfo` is itself the
+    signal that the collection is partial. This keeps the common case
+    (small cohort, single message) unchanged from today.
+
+    Two modes are supported via the same envelope:
+
+      • Push mode (BPP-initiated): BPP fires N back-to-back messages
+        with monotonically-increasing `sequence` (0..N-1) and
+        `isLast: true` on the final one. `cursor` / `nextCursor` are
+        optional in push mode — they exist only for ergonomic parity
+        with pull mode.
+
+      • Pull mode (BAP-initiated): BAP issues a status (or analogous)
+        call carrying `pageCursor` in tags (or wherever the action
+        schema supports it). BPP echoes the requested `cursor` and
+        sets `nextCursor` to whatever opaque value the BAP should
+        return to fetch the next slice; `nextCursor: null` signals the
+        last page (and `isLast: true` is set in parallel).
+
+components:
+  schemas:
+
+    BecknPageInfo:
+      type: object
+      additionalProperties: false
+      required: [sequence, isLast]
+      description: >
+        Pagination state for a single message in a multi-message
+        collection delivery. Sibling to the paginated array, NOT a
+        wrapper around it.
+      x-tags:
+        - pagination
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": PageInfo
+
+      properties:
+
+        "@type":
+          type: string
+          enum: ["PageInfo"]
+          description: >
+            Optional JSON-LD type discriminator. Present when the embedder
+            wants to surface the type in the payload; the parent schema's
+            `$ref` to BecknPageInfo is what drives validation.
+
+        sequence:
+          type: integer
+          minimum: 0
+          description: >
+            Monotonic page index within a (transactionId, collectionId)
+            pair. `0` is the first page. Receivers assemble the full
+            collection by sorting messages by sequence. Gaps or
+            duplicates indicate transport loss and SHOULD trigger
+            re-request (pull mode) or abort (push mode).
+
+        pageSize:
+          type: integer
+          minimum: 1
+          description: >
+            Nominal page size declared by the sender. Actual element
+            count in the accompanying array MAY be less than `pageSize`
+            on the final page; SHOULD equal `pageSize` on all other
+            pages. Useful for receiver-side pre-allocation but NOT a
+            wire-validation constraint.
+
+        total:
+          type: integer
+          minimum: 0
+          description: >
+            Total element count expected across all pages of this
+            collection delivery. Optional — senders that cannot
+            determine the total cheaply MAY omit it; receivers MUST
+            still treat `isLast: true` as authoritative.
+
+        isLast:
+          type: boolean
+          description: >
+            `true` on the final page (sequence == N-1 of a delivery of
+            N pages). Receivers MUST defer any aggregate-dependent
+            actions (settlement, network-rego cardinality checks
+            against `total`, etc.) until this flag is observed. Senders
+            MUST set this exactly once per (transactionId, collectionId)
+            delivery.
+
+        cursor:
+          type: string
+          description: >
+            Opaque token identifying THIS page. Echoed from the
+            preceding `nextCursor` in pull mode; senders MAY include
+            it in push mode for symmetry but receivers SHOULD rely on
+            `sequence` for ordering. The cursor is sender-internal;
+            receivers MUST NOT parse it.
+
+        nextCursor:
+          type: ["string", "null"]
+          description: >
+            Token to include in the next pull request to fetch the
+            following page. `null` (or omitted) on the final page.
+            Sender-opaque, receiver-opaque-other-than-echo.
+
+        collectionId:
+          type: string
+          description: >
+            Identifier of the collection being paginated within the
+            envelope, e.g. `performance.0.id` or `commitments.0.id`.
+            Optional. Disambiguates concurrent deliveries when more
+            than one paginated collection rides the same transaction
+            (rare but possible).

--- a/specification/schema/BecknPageInfo/v1.0/context.jsonld
+++ b/specification/schema/BecknPageInfo/v1.0/context.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "deg": "https://schema.beckn.io/deg/",
+
+    "PageInfo": "beckn:BecknPageInfo",
+
+    "sequence":     { "@id": "beckn:sequence",     "@type": "xsd:integer" },
+    "pageSize":     { "@id": "beckn:pageSize",     "@type": "xsd:integer" },
+    "total":        { "@id": "beckn:total",        "@type": "xsd:integer" },
+    "isLast":       { "@id": "beckn:isLast",       "@type": "xsd:boolean" },
+    "cursor":       { "@id": "beckn:cursor",       "@type": "xsd:string"  },
+    "nextCursor":   { "@id": "beckn:nextCursor",   "@type": "xsd:string"  },
+    "collectionId": { "@id": "beckn:collectionId", "@type": "xsd:string"  }
+  },
+  "@graph": []
+}

--- a/specification/schema/BecknPageInfo/v1.0/vocab.jsonld
+++ b/specification/schema/BecknPageInfo/v1.0/vocab.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "beckn:BecknPageInfo",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Page Info",
+      "rdfs:comment": "Domain-neutral pagination envelope embedded alongside any collection that needs multi-message or off-protocol delivery."
+    }
+  ]
+}

--- a/specification/schema/BecknResourceRef/README.md
+++ b/specification/schema/BecknResourceRef/README.md
@@ -1,0 +1,38 @@
+# BecknResourceRef
+
+Content-addressed, BPP-hosted reference for delivering bulk JSON bodies off-protocol while keeping the on-protocol payload small and tamper-evident.
+
+**Canonical IRI:** `https://schema.beckn.io/BecknResourceRef/v1.0`
+
+**Namespace prefix:** `brr:` → `https://schema.beckn.io/core/v2.0/`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial — covers participatingMetersRef / vendorDevicesRef / metersRef use sites in demand-flex; reusable across DEG. |
+
+---
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `uri` | string (URI) | ✓ | HTTPS URL the receiver fetches. |
+| `contentHash` | `sha256:<64-hex>` | ✓ | SHA-256 of the canonicalized body. The Beckn signature on the parent message commits the BPP to this exact hash. |
+| `count` | integer | ✓ | Element count in the referenced collection (cheap pre-fetch cross-check). |
+| `contentType` | string | | Defaults to `application/ld+json`. |
+| `schemaContext` | string (URI) | | JSON-LD `@context` URL the body conforms to. |
+| `expiresAt` | string (RFC 3339) | | Useful for signed-URL implementations. |
+| `sizeBytes` | integer | | Pre-fetch budget hint. |
+
+---
+
+## When to use
+
+- A collection is too large for both inline and paged-inline delivery — bind the on-protocol commitment to the body via `contentHash` and let the receiver fetch out-of-band.
+- Two layers of guarantees: **integrity** (via `contentHash`, in spec), **access control** (signed URL / OAuth / mutual TLS, out of spec — BPP's call).
+
+For paged on-protocol delivery (`pageInfo`), see [BecknPageInfo](../BecknPageInfo/). The two are mutually exclusive on a given collection.

--- a/specification/schema/BecknResourceRef/v1.0/README.md
+++ b/specification/schema/BecknResourceRef/v1.0/README.md
@@ -1,0 +1,98 @@
+# BecknResourceRef — v1.0
+
+Off-protocol, content-addressed reference for delivering bulk JSON bodies without bloating the on-protocol message.
+
+Part of the [DEG Schema](../../) · [BecknResourceRef](../README.md)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 `components.schemas.BecknResourceRef` |
+| [context.jsonld](./context.jsonld) | JSON-LD context — term `ResourceRef` maps to `beckn:BecknResourceRef` |
+| [vocab.jsonld](./vocab.jsonld) | RDF vocabulary |
+
+## When to use
+
+A collection — meter IDs at confirm time, per-meter telemetry at performance time — has grown too large to ride sanely on-protocol even with [BecknPageInfo](../../BecknPageInfo/v1.0/) splitting it across messages. The sender publishes the body at a BPP-hosted URL and embeds a `BecknResourceRef` pointing at it; the on-protocol message stays small and Beckn-signed; the receiver fetches the body and verifies integrity against `contentHash`.
+
+`BecknResourceRef` and `BecknPageInfo` are **mutually exclusive** on a given collection — pick one mode.
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `uri` | string (URI) | ✓ | HTTPS URL the receiver fetches. Access control on the URL is BPP-defined (signed URL, OAuth, etc.) — out of spec. |
+| `contentHash` | string (`sha256:<64-hex>`) | ✓ | SHA-256 of the fetched body after JSON canonicalization (RFC 8785). The Beckn signature on the parent message commits the BPP to this hash. |
+| `count` | integer (≥0) | ✓ | Element count in the referenced collection. Receivers MAY reject on mismatch before canonicalizing. |
+| `contentType` | string | — | MIME type. Defaults to `application/ld+json`. Use `application/x-ndjson` etc. when streaming a large body. |
+| `schemaContext` | string (URI) | — | JSON-LD `@context` URL the body conforms to. Useful for pre-fetch validator routing. |
+| `expiresAt` | string (RFC 3339) | — | Useful for signed-URL implementations. |
+| `sizeBytes` | integer (≥0) | — | Lets receivers short-circuit before downloading multi-GB bodies. |
+
+## Integrity vs. access control
+
+Two separable guarantees:
+
+1. **Integrity** — the fetched body is what the BPP committed to. Handled by `contentHash` in the on-protocol payload. Because the parent message is Beckn-signed, the BPP cannot retroactively swap the body without breaking the signature chain.
+2. **Access control** — only authorized parties can fetch `uri`. NOT in this schema. The BPP decides: signed URL with short expiry, mutual TLS, OAuth token derived from the BAP's subscriber ID, etc. The spec stays silent; integrity alone is enough to make the on-protocol payload auditable.
+
+## Receiver verification recipe
+
+```
+GET uri
+canonical = JCS(body)
+if sha256(canonical) != contentHash.split(":")[1]:
+    reject — body has been tampered with or fetched the wrong document
+if "count" provided and len(body.collection) != count:
+    reject — body shape disagrees with the on-protocol declaration
+```
+
+## Embedding pattern
+
+`BecknResourceRef` is a **replacement** for the inline array, not a wrapper around it. Consumer schemas declare the ref as a sibling of the array and document via JSON-Schema `oneOf` that exactly one is present:
+
+```yaml
+# In the consumer schema's attributes.yaml
+oneOf:
+  - required: [participatingMeters]
+  - required: [participatingMetersRef]
+properties:
+  participatingMeters:
+    type: array
+    items: { type: string }
+  participatingMetersRef:
+    $ref: "https://schema.beckn.io/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+```
+
+## Minimal example — bulk meter enrollment at confirm
+
+```jsonc
+{
+  "role": "seller",
+  "participantId": "greenflex-agg",
+  "inputs": {
+    "plannedDemandChange": { "@type": "Quantity", "unitCode": "KWH", "unitQuantity": 12500.0 },
+    "participatingMetersRef": {
+      "@type": "ResourceRef",
+      "uri": "https://bpp.example.com/bulk/cohort-2026-04-01.jsonld",
+      "contentHash": "sha256:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      "count": 25000,
+      "contentType": "application/ld+json",
+      "schemaContext": "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/participatingMeters.jsonld",
+      "sizeBytes": 1850000,
+      "expiresAt": "2026-04-08T00:00:00Z"
+    },
+    "participatingMetersDigest": {
+      "count": 25000,
+      "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"
+    }
+  }
+}
+```
+
+`participatingMetersDigest` is an **on-protocol** tamper-evidence anchor independent of the ref: even after the URL goes 404 years later, the digest in the signed contract still pins the cohort to a specific set of IDs.
+
+## Why this lives in the top-level schema/
+
+Off-protocol bulk delivery is a Beckn-wide concern (catalog payloads, contract metadata, performance telemetry, …). Lives next to [BecknPageInfo](../../BecknPageInfo/v1.0/) so any future schema can `$ref`-embed it without re-inventing the ref shape.

--- a/specification/schema/BecknResourceRef/v1.0/attributes.yaml
+++ b/specification/schema/BecknResourceRef/v1.0/attributes.yaml
@@ -1,0 +1,123 @@
+openapi: 3.1.1
+info:
+  title: BecknResourceRef — Off-Protocol Content Reference (v1.0)
+  version: 1.0.0
+  description: >
+    Domain-neutral envelope for delivering a large collection (or any
+    other resource) out-of-band, while keeping the on-protocol payload
+    small and tamper-evident. The on-protocol message carries the
+    reference; the receiver fetches the body from `uri` and verifies
+    integrity against `contentHash`.
+
+    Two use sites in DEG, both opt-in:
+
+      • Replace an inline collection on a frozen-at-confirm object
+        (e.g. `inputs[seller].inputs.participatingMetersRef` in lieu
+        of `participatingMeters[]`) when the cohort is large enough
+        that splitting across messages is impossible (the offer can't
+        span messages).
+
+      • Replace an inline collection on a streamable object (e.g.
+        `performanceAttributes.metersRef` in lieu of `meters[]`) when
+        even paged-inline (`pageInfo`) is too heavy.
+
+    `BecknResourceRef` and `BecknPageInfo` are MUTUALLY EXCLUSIVE on a
+    given collection: a sender chooses on-protocol paged delivery OR
+    off-protocol reference, not both. Consumer schemas SHOULD enforce
+    this with `oneOf`/`if-then`.
+
+    Authentication: this schema commits the BPP to a specific body
+    via `contentHash` (Beckn-signed at the envelope level). Access
+    control on `uri` — signed URLs, OAuth, IP allow-lists — is a BPP
+    implementation choice and outside the spec.
+
+components:
+  schemas:
+
+    BecknResourceRef:
+      type: object
+      additionalProperties: false
+      required: [uri, contentHash, count]
+      description: >
+        Reference to a content-addressed, BPP-hosted JSON document.
+        Receivers fetch `uri`, canonicalize the body per JSON Canonicalization
+        Scheme (RFC 8785), compute SHA-256, and reject on mismatch with
+        `contentHash`.
+      x-tags:
+        - bulk-delivery
+        - off-protocol
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": ResourceRef
+
+      properties:
+
+        "@type":
+          type: string
+          enum: ["ResourceRef"]
+          description: >
+            Optional JSON-LD type discriminator. The parent's `$ref`
+            drives validation.
+
+        uri:
+          type: string
+          format: uri
+          description: >
+            URL the receiver fetches to retrieve the body. MUST be
+            HTTPS. Access control on the URL is the BPP's
+            responsibility (signed URL, OAuth, etc.) — out of scope
+            for this schema.
+
+        contentHash:
+          type: string
+          pattern: "^sha256:[0-9a-f]{64}$"
+          description: >
+            SHA-256 of the fetched body after JSON canonicalization
+            (RFC 8785). Format `sha256:<64-hex>`. Lowercase hex.
+            This field is the integrity anchor — Beckn signing of the
+            enclosing message commits the BPP to this exact hash.
+
+        count:
+          type: integer
+          minimum: 0
+          description: >
+            Element count expected in the referenced collection
+            (e.g. number of meter IDs or number of meter telemetry
+            entries in the body). Cheap cross-check for receivers:
+            mismatched count vs. fetched body is grounds for reject
+            without canonicalizing.
+
+        contentType:
+          type: string
+          description: >
+            MIME / media type of the body at `uri`. Defaults to
+            `application/ld+json` when omitted. Implementations MAY
+            use this to switch parsers (e.g. `application/x-ndjson`
+            for large streaming bodies).
+          default: "application/ld+json"
+
+        schemaContext:
+          type: string
+          format: uri
+          description: >
+            JSON-LD `@context` URL the body conforms to. Receivers
+            use this to pick a validator. Optional but RECOMMENDED;
+            redundant with the body's own `@context` but useful for
+            pre-fetch routing.
+
+        expiresAt:
+          type: string
+          format: date-time
+          description: >
+            Optional RFC 3339 timestamp after which `uri` is no
+            longer guaranteed fetchable. Useful for signed-URL
+            implementations. Independent of `contentHash` — the body
+            itself doesn't change.
+
+        sizeBytes:
+          type: integer
+          minimum: 0
+          description: >
+            Optional declared byte size of the body. Lets receivers
+            short-circuit before downloading multi-GB bodies they
+            can't budget for.

--- a/specification/schema/BecknResourceRef/v1.0/context.jsonld
+++ b/specification/schema/BecknResourceRef/v1.0/context.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+
+    "ResourceRef": "beckn:BecknResourceRef",
+
+    "uri":            { "@id": "beckn:uri",           "@type": "xsd:anyURI"   },
+    "contentHash":    { "@id": "beckn:contentHash",   "@type": "xsd:string"   },
+    "count":          { "@id": "beckn:count",         "@type": "xsd:integer"  },
+    "contentType":    { "@id": "beckn:contentType",   "@type": "xsd:string"   },
+    "schemaContext":  { "@id": "beckn:schemaContext", "@type": "xsd:anyURI"   },
+    "expiresAt":      { "@id": "beckn:expiresAt",     "@type": "xsd:dateTime" },
+    "sizeBytes":      { "@id": "beckn:sizeBytes",     "@type": "xsd:integer"  }
+  },
+  "@graph": []
+}

--- a/specification/schema/BecknResourceRef/v1.0/vocab.jsonld
+++ b/specification/schema/BecknResourceRef/v1.0/vocab.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "beckn": "https://schema.beckn.io/core/v2.0/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "beckn:BecknResourceRef",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Resource Ref",
+      "rdfs:comment": "Content-addressed, BPP-hosted reference to a body delivered out-of-band. Used in place of large inline collections to keep the on-protocol payload small and tamper-evident."
+    }
+  ]
+}

--- a/specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml
@@ -55,8 +55,20 @@ components:
             Role-specific inputs. Structure varies by role and contract type.
             For buyer: incentivePerKwh, currency, penaltyRate, baselineMethodology, etc.
             For seller: plannedDemandChange (beckn:Quantity),
-            participatingMeters, vendorDevices, and reportDescriptors
-            (see below).
+            participatingMeters (or participatingMetersRef when the
+            cohort is bulk), vendorDevices (or vendorDevicesRef), and
+            reportDescriptors (see below).
+
+            Bulk delivery: the offer is bound at confirm and cannot
+            span Beckn messages, so when the seller's cohort would
+            stretch a single confirm payload beyond a reasonable wire
+            budget (e.g. > 10k meters) the *Ref siblings replace the
+            inline arrays. participatingMetersRef / vendorDevicesRef
+            each carry a BecknResourceRef pointing at a content-
+            addressed BPP-hosted bundle. participatingMetersDigest is
+            an on-protocol tamper-evidence anchor that survives even
+            if the ref URL later goes 404 — Beckn signing of the
+            confirm payload commits the contract to that exact cohort.
           properties:
             reportDescriptors:
               description: >
@@ -75,3 +87,47 @@ components:
               oneOf:
                 - $ref: "https://schema.beckn.io/BecknReportDescriptors/v1.0#/components/schemas/BecknReportDescriptors"
                 - type: "null"
+
+            participatingMetersRef:
+              description: >
+                Optional. Off-protocol delivery of the participatingMeters
+                cohort when it's too large to inline. Mutually exclusive
+                with `participatingMeters`. Consumers MUST treat the
+                fetched body as the authoritative meter list once the
+                receiver has verified `contentHash` and `count` against
+                the body's canonicalized form.
+              $ref: "https://schema.beckn.io/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+
+            vendorDevicesRef:
+              description: >
+                Optional. Off-protocol delivery of the vendorDevices
+                cohort when it's too large to inline. Mutually exclusive
+                with `vendorDevices`. Same verification rules as
+                `participatingMetersRef`.
+              $ref: "https://schema.beckn.io/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+
+            participatingMetersDigest:
+              type: object
+              additionalProperties: false
+              required: [count, sha256OfSortedIds]
+              description: >
+                Optional on-protocol tamper-evidence anchor for the
+                meter cohort, regardless of whether it was delivered
+                inline (`participatingMeters`) or by reference
+                (`participatingMetersRef`). Computed as SHA-256 of the
+                ASCII-sorted, newline-joined meter IDs. Beckn-signing
+                of the confirm payload then commits the seller to this
+                exact cohort permanently — useful for downstream audit
+                long after any off-protocol bundle URL has expired.
+              properties:
+                count:
+                  type: integer
+                  minimum: 0
+                  description: Total meter count in the cohort.
+                sha256OfSortedIds:
+                  type: string
+                  pattern: "^sha256:[0-9a-f]{64}$"
+                  description: >
+                    `sha256:<64-hex>` of the cohort's meter IDs after
+                    they have been ASCII-sorted and joined with a
+                    single `\n` separator (no trailing newline).

--- a/specification/schema/DemandFlexBuyOffer/v2.0/context.jsonld
+++ b/specification/schema/DemandFlexBuyOffer/v2.0/context.jsonld
@@ -24,7 +24,16 @@
     "queryPath": "deg:queryPath",
     "bundleUrl": "deg:bundleUrl",
     "plannedDemandChange": "deg:plannedDemandChange",
-    "participatingMeters": "deg:participatingMeters"
+    "participatingMeters": "deg:participatingMeters",
+    "participatingMetersRef": "https://schema.beckn.io/core/v2.0/BecknResourceRef",
+    "vendorDevicesRef": "https://schema.beckn.io/core/v2.0/BecknResourceRef",
+    "participatingMetersDigest": {
+      "@id": "deg:participatingMetersDigest",
+      "@context": {
+        "count": { "@id": "https://schema.beckn.io/core/v2.0/count", "@type": "xsd:integer" },
+        "sha256OfSortedIds": { "@id": "https://schema.beckn.io/core/v2.0/sha256OfSortedIds", "@type": "xsd:string" }
+      }
+    }
   },
   "@graph": []
 }

--- a/specification/schema/DemandFlexPerformance/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexPerformance/v2.0/attributes.yaml
@@ -43,7 +43,14 @@ components:
           type: array
           description: >
             Per-meter M&V data. Each entry binds a meter ID to its time-series
-            telemetry for the event window.
+            telemetry for the event window. When the cohort fits in a single
+            message the BPP SHOULD inline the full array and omit `pageInfo`
+            entirely. For larger cohorts the BPP either ships paged slices
+            (sibling `pageInfo` present) or substitutes `metersRef` and omits
+            `meters[]` from this message. Settlement rego runs only on the
+            assembled view — receivers MUST NOT fire settlement-dependent
+            actions until `pageInfo.isLast == true` or the `metersRef` body
+            has been fetched and verified.
           x-jsonld:
             "@id": meters
           items:
@@ -64,3 +71,26 @@ components:
                   payload only needs `@type` (optional) — `@context` is
                   declared once at the envelope level via
                   `context.schemaContext[]`.
+
+        pageInfo:
+          description: >
+            Optional. Present only when the `meters[]` collection has
+            been split across multiple on_status messages (paged inline
+            delivery). Receivers assemble all pages of the same
+            (transactionId, performance.id) by `pageInfo.sequence` and
+            defer settlement until `pageInfo.isLast == true`. Omit
+            entirely when the whole cohort fits in one message —
+            absence of `pageInfo` is the signal that this message is
+            self-contained.
+          $ref: "https://schema.beckn.io/BecknPageInfo/v1.0#/components/schemas/BecknPageInfo"
+
+        metersRef:
+          description: >
+            Optional. Off-protocol delivery of the per-meter telemetry
+            bundle when even paged-inline (`pageInfo`) is too heavy.
+            Mutually exclusive with `meters[]` and `pageInfo` on the
+            same message — the BPP substitutes this reference for the
+            entire collection. Receivers fetch `uri`, verify against
+            `contentHash` and `count`, then run settlement against the
+            fetched body.
+          $ref: "https://schema.beckn.io/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"

--- a/specification/schema/DemandFlexPerformance/v2.0/context.jsonld
+++ b/specification/schema/DemandFlexPerformance/v2.0/context.jsonld
@@ -13,7 +13,9 @@
     "methodology": "dfp:methodology",
     "meters": "dfp:meters",
     "meterId": "dfp:meterId",
-    "telemetry": "deg:BecknTimeSeries"
+    "telemetry": "deg:BecknTimeSeries",
+    "pageInfo": "beckn:BecknPageInfo",
+    "metersRef": "beckn:BecknResourceRef"
   },
   "@graph": []
 }


### PR DESCRIPTION
## Summary

- Add two domain-neutral top-level schemas — [`BecknPageInfo/v1.0`](specification/schema/BecknPageInfo/v1.0/) (in-protocol page envelope) and [`BecknResourceRef/v1.0`](specification/schema/BecknResourceRef/v1.0/) (content-addressed off-protocol reference) — so any future Beckn payload (DEG or otherwise) can ship large collections without re-inventing the cursor/ref shape.
- Extend [`DemandFlexBuyOffer/v2.0`](specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml) with optional seller-side `participatingMetersRef`, `vendorDevicesRef`, and `participatingMetersDigest` (the digest pins the cohort in the Beckn-signed contract permanently, surviving any later expiry of the off-protocol bundle URL).
- Extend [`DemandFlexPerformance/v2.0`](specification/schema/DemandFlexPerformance/v2.0/attributes.yaml) with optional `pageInfo` (paged inline delivery) and `metersRef` (off-protocol delivery). All optional — small cohorts ship inline as today; absence of `pageInfo` is itself the protocol signal that the message is self-contained.
- Two demand-flex example fixtures over the same 12,000-meter cohort:
  - [`on-status-response-actuals-paged-push.json`](devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json) — BPP-push: 3 back-to-back `on_status` messages, sequence 0/1/2, ends with `isLast: true`. Page 0 shown.
  - [`on-status-response-actuals-paged-pull.json`](devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json) — BAP-pull: BAP carries `pageCursor` in `context.tags`; BPP echoes via `pageInfo.cursor` and advertises `pageInfo.nextCursor`. The inbound BAP request shape is recorded in the response file's `_comment_inbound_request` so the example is self-contained.
- Document the push/pull patterns and 10k inline-threshold guideline in [`devkits/demand-flex/README.md`](devkits/demand-flex/README.md).

## Design choices baked into the schemas

- **`pageInfo` is opt-in.** Senders that fit in one message omit it. No churn for the small-cohort common case.
- **Push and pull share one shape.** Push relies on `sequence`; pull additionally uses `cursor`/`nextCursor`. Receivers always gate aggregate actions on `isLast: true`.
- **Two layers of bulk delivery.** Paged inline (`pageInfo`) for the "a few thousand more than fits in one message" range; content-addressed off-protocol (`BecknResourceRef`) when even paging is too heavy or when the collection can't span messages (e.g. the offer at confirm-time). They are mutually exclusive on a given collection.
- **Integrity is in spec; access control is not.** `contentHash` + Beckn-signed envelope = auditable commitment to the body. URL access control (signed URLs, OAuth, mTLS) stays a BPP implementation detail.
- **`participatingMetersDigest`** is a small on-protocol tamper-evidence anchor independent of the ref — the Beckn-signed confirm payload commits the seller to that exact cohort permanently, even if the bundle URL goes 404 a year later.

## Network + settlement rego implications

The network rego's per-meter type-coverage and PER_EVENT/PER_INTERVAL cardinality checks fire correctly on each page in isolation — no change needed. Settlement is **only** computed against the assembled view: receivers MUST defer settlement until `pageInfo.isLast == true` (paged inline) or until the `metersRef` body has been fetched and verified. README notes this; the rego itself stays single-shot and reads `meters[]` (so the BPP's responsibility is to assemble before running rego).

## Test plan

- [x] `opa test specification/policies/demand_flex_network*.rego` — 5/5 PASS
- [x] `opa test specification/policies/demand_flex_revenue*.rego` — 8/8 PASS
- [x] `devkits/demand-flex/uc1-bdr-w-baselining/workflows/run-arazzo.sh` — sandbox-callback check PASSES; existing fixtures unchanged. (Pre-existing HTTP 500s on the BAP-call NACK check are an environmental keyset-loading flake unrelated to this PR — same baseline both with and without the changes stashed.)
- [ ] Reviewer: confirm the two example fixtures read correctly as push vs pull demonstrations and that the `_comment_*` keys are acceptable as illustrative aids (alternative: split into request + response files).
- [ ] Follow-up (out of scope here): wire one of the two paged variants into the arazzo workflow as an optional `paged-actuals` step so the schema additions are exercised end-to-end through onix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)