### PR TITLE
demand-flex(uc1): green arazzo — UUIDv4 transactionId/messageId across fixtures

### DIFF
--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/confirm-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/confirm-request.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-confirm-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "54fb3f15-48aa-4408-bca4-52486b767679",
     "timestamp": "2026-03-30T10:10:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DER/v1.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/discover-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/discover-request.json
@@ -5,8 +5,8 @@
     "action": "discover",
     "bapId": "bap.example.com",
     "bapUri": "https://bap.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-discover-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "258ed231-2def-4840-86ed-2970320c2294",
     "timestamp": "2026-03-30T09:00:00Z"
   },
   "message": {

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/init-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/init-request.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-init-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "d87a9552-d8b5-4406-a514-3268503f44c8",
     "timestamp": "2026-03-30T10:05:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-confirm-response.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-confirm-response.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-confirm-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "42306920-2f41-44b4-bd0a-bb1b969b9b6b",
     "timestamp": "2026-03-30T10:10:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-init-response.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-init-response.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-init-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "22e181e7-3050-44f8-8146-a107bb2ce940",
     "timestamp": "2026-03-30T10:05:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-select-response.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-select-response.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-select-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "717cf951-41d2-4019-aae0-3ee2bde910c3",
     "timestamp": "2026-03-30T10:00:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json
@@ -11,8 +11,8 @@
         "action": "status",
         "bapId": "bap.example.com",
         "bppId": "bpp.example.com",
-        "transactionId": "txn-flex-bulk-001",
-        "messageId": "msg-status-pull-p2-001",
+        "transactionId": "01ac9817-da6f-4f6f-908e-bec6f9b2b8cd",
+        "messageId": "e403fe18-94ba-4986-9908-4d0d2e7f133b",
         "timestamp": "2026-04-01T10:34:30Z",
         "tags": [
           {
@@ -35,8 +35,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-bulk-001",
-    "messageId": "msg-on-status-actuals-bulk-pull-p2",
+    "transactionId": "01ac9817-da6f-4f6f-908e-bec6f9b2b8cd",
+    "messageId": "ae710ba6-5687-4e72-b6d6-bcce78db1c89",
     "timestamp": "2026-04-01T10:34:31Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json
@@ -8,8 +8,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-bulk-001",
-    "messageId": "msg-on-status-actuals-bulk-p0",
+    "transactionId": "01ac9817-da6f-4f6f-908e-bec6f9b2b8cd",
+    "messageId": "6be09267-c5b0-43a1-b2ec-02c34f9f2cfb",
     "timestamp": "2026-04-01T10:35:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-status-actuals-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "4ba4381d-c64c-4a02-b188-d382b5bcb422",
     "timestamp": "2026-04-01T10:35:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-baselines.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-baselines.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-status-baselines-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "b76df16d-cd8d-454e-94ce-6233db819934",
     "timestamp": "2026-04-01T08:00:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-der-telemetry.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-der-telemetry.json
@@ -8,8 +8,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-status-der-telemetry-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "022e188f-cdc9-4eb4-af1a-21447e9bacbc",
     "timestamp": "2026-04-01T10:45:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-settled.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-settled.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-status-settled-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "acd9569e-7656-44f5-b5dd-b8f172593b3a",
     "timestamp": "2026-04-01T11:00:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/select-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/select-request.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-select-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "c02cc2f6-524e-4557-9e7e-aac540058654",
     "timestamp": "2026-03-30T10:00:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/update-request-opt-in.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/update-request-opt-in.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-update-optin-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "0ad4f2d6-a48a-4a61-ad57-eb0d2a8a6795",
     "timestamp": "2026-04-01T06:00:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BAP-DEG.postman_collection.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BAP-DEG.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "eaa558b2-549e-4774-b4da-a15f39d42ea1",
+    "_postman_id": "99a35891-bf46-4a17-8bd7-2ae4299fac0c",
     "name": "demand-flex-uc1-bdr-w-baselining.BAP-DEG",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": "Postman collection for Buyer Application Platform implementing demand-flex APIs based on Beckn Protocol v2"

--- a/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BPP-DEG.postman_collection.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BPP-DEG.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "6ff697d2-aa6e-46b2-98b2-edc15b94609d",
+    "_postman_id": "e0702f15-40ef-4090-9870-b19363199d4d",
     "name": "demand-flex-uc1-bdr-w-baselining.BPP-DEG",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": "Postman collection for Buyer Provider Platform implementing demand-flex APIs based on Beckn Protocol v2"

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_confirm.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_confirm.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-confirm-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "42306920-2f41-44b4-bd0a-bb1b969b9b6b",
     "timestamp": "2026-03-30T10:10:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DER/v1.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_init.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_init.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-init-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "22e181e7-3050-44f8-8146-a107bb2ce940",
     "timestamp": "2026-03-30T10:05:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_select.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_select.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-select-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "717cf951-41d2-4019-aae0-3ee2bde910c3",
     "timestamp": "2026-03-30T10:00:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_status.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_status.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-status-baselines-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "b76df16d-cd8d-454e-94ce-6233db819934",
     "timestamp": "2026-04-01T08:00:00Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexPerformance/v2.0/context.jsonld",

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_update.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_update.json
@@ -7,8 +7,8 @@
     "bapUri": "https://bap.example.com/beckn",
     "bppId": "bpp.example.com",
     "bppUri": "https://bpp.example.com/beckn",
-    "transactionId": "txn-flex-001",
-    "messageId": "msg-on-confirm-001",
+    "transactionId": "3d39df73-a4c0-4374-9836-ec6c365a7ecc",
+    "messageId": "42306920-2f41-44b4-bd0a-bb1b969b9b6b",
     "timestamp": "2026-03-30T10:10:05Z",
     "schemaContext": [
       "https://schema.beckn.io/DemandFlexBuyOffer/v2.0/context.jsonld",


### PR DESCRIPTION
## Summary

Replace placeholder `"txn-flex-001"` / `"msg-discover-001"` style strings across the uc1 fixtures with valid UUIDv4s so the BAP caller's schema validator (which enforces UUID-v4 format on `context.transactionId` and `context.messageId`) stops NACKing them.

This is the long-standing `discover` HTTP 400 NACK that survived every prior PR — finally cleared.

## How the UUIDs are generated

Deterministic, not random — `uuid5(namespace, placeholder_string)` with version/variant bits coerced to v4. Same placeholder string → same UUID across every fixture that references it. Preserves "what was what" in diffs and across re-runs without bringing in actual randomness.

| Old placeholder | New UUIDv4 |
|---|---|
| `txn-flex-001` (main flow) | `3d39df73-a4c0-4374-9836-ec6c365a7ecc` |
| `txn-flex-bulk-001` (paged push/pull bulk-cohort fixtures) | `01ac9817-da6f-4f6f-908e-bec6f9b2b8cd` |
| `msg-discover-001` | `258ed231-2def-4840-86ed-2970320c2294` |
| `msg-select-001` | `c02cc2f6-524e-4557-9e7e-aac540058654` |
| `msg-init-001` | `d87a9552-d8b5-4406-a514-3268503f44c8` |
| `msg-confirm-001` | `54fb3f15-48aa-4408-bca4-52486b767679` |
| `msg-update-optin-001` | `0ad4f2d6-a48a-4a61-ad57-eb0d2a8a6795` |
| … plus 10 more `msg-on-*` and paged-pull ids |  |

(Full list in the script output captured in the commit message.)

## What got touched

- 5 BAP request fixtures: discover / select / init / confirm / update
- 5 BAP-receiver `on_*` example responses
- 4 `on_status` response examples (baselines / actuals / settled / DER telemetry) + the two paged push/pull bulk-cohort examples
- 5 sandbox-bpp response fixtures under `responses/bpp/`
- Postman regenerated

21 files changed, 42 insertions, 42 deletions — pure string-replacements; no schema changes.

## Verified

```
Workflows: 4 passed, 4 total
NACK check: PASSED — all steps returned ACK.
Sandbox-callback check: PASSED — sandbox-bpp on_* callbacks accepted by BPP caller and BAP receiver.
```

First fully-green arazzo run for the demand-flex devkit since these fixtures were written. Stage 2 of the DER work is also implicitly verified here — onix containers were recreated to flush the schema cache before this run, so `schema.beckn.io/DER/v1.0/` resolution is in the loop.

## Test plan

- [x] uc1 arazzo end-to-end — both NACK check and sandbox-callback check PASS.
- [x] `python3 -m json.tool` validates every modified fixture.
- [x] Deterministic UUID generation re-runs to the same values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)