### PR TITLE
fix(p2p-trading wave2): align sellerapp BPP-side keypair with dedi registry

### DIFF
--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerapp.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerapp.yaml
@@ -40,10 +40,10 @@ modules:
           config:
             networkParticipant: sellerapp.example.com
             keyId: 76EU9BVtj4VYcQvBdpDr84T6AbiLe2PkBdJLaJRBUsZnFgD8joffqz
-            signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            signingPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
-            encrPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            encrPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
+            signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            signingPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
+            encrPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            encrPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
         schemaValidator:
           id: schemav2validator
           config:
@@ -87,7 +87,7 @@ modules:
               actions: status
               enabled: "true"
               asyncTimeout: "30000"
-              signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+              signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
               networkParticipant: sellerapp.example.com
               keyId: 76EU9BVtj4VYcQvBdpDr84T6AbiLe2PkBdJLaJRBUsZnFgD8joffqz
       steps:
@@ -204,10 +204,10 @@ modules:
           config:
             networkParticipant: sellerapp.example.com
             keyId: 76EU9BVtj4VYcQvBdpDr84T6AbiLe2PkBdJLaJRBUsZnFgD8joffqz
-            signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            signingPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
-            encrPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            encrPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
+            signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            signingPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
+            encrPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            encrPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
         schemaValidator:
           id: schemav2validator
           config:
@@ -261,7 +261,7 @@ modules:
               actions: on_confirm
               enabled: "true"
               asyncTimeout: "30000"
-              signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+              signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
               networkParticipant: sellerapp.example.com
               keyId: 76EU9BVtj4VYcQvBdpDr84T6AbiLe2PkBdJLaJRBUsZnFgD8joffqz
       steps:


### PR DESCRIPTION
## Summary

`local-p2p-trading-sellerapp.yaml` had two distinct keypairs declared under the same `keyId`. The BPP-receiver / BPP-caller blocks used `393fVJJsf...` private / `CqVy97DW...` public; the BAP-receiver blocks used `TTQMAEy0xJ...` / `g/3sw...`. The dedi registry has the second pair registered as sellerapp's `signing_public_key`, so every `on_init` / `on_confirm` / `on_status` that sellerapp's BPP-caller signed was unverifiable at buyerapp's receiver:

```
DeDi Registry: Looking up subscriber ID: sellerapp.example.com, key ID: 76EU9BVtj4...joffqz
DeDi lookup successful, found subscription for subscriber: sellerapp.example.com
   ↓
Step validateSign failed:
  failed to validate Authorization: sign validation failed: signature verification failed
   ↓
HTTP 401 with www-authenticate: Signature realm="buyerapp.example.com"
```

The dedi call itself **succeeded** every time — the failure was the subsequent local verify step because the fetched public key didn't match the private key that actually signed the message.

## Fix

Replaced the four BPP-side occurrences (two keyManager blocks at lines ~41-46 and ~204-209, plus two `degledgerrecorder` middleware blocks at ~90 and ~264) with the same `TTQ.../g/3sw...` keypair the BAP-receiver blocks already use — which is what dedi has registered. Both subscribers (buyerapp + sellerapp) now sign with the same shared test-fixture keypair that the registry expects, consistent with the devkit's borrowed-test-key posture.

## Test plan

- [x] `git diff` — 10 line changes, all in `local-p2p-trading-sellerapp.yaml`. No other files touched.
- [x] `docker compose up -d --force-recreate onix-sellerapp onix-buyerapp` to flush schema + keyManager cache, then uc1 arazzo:
  - Before fix: 4 NACKs — discover (HTTP 400, pre-existing) + on-init / on-confirm / on-status-settled (HTTP 401 each).
  - **After fix: 1 NACK** — only the pre-existing discover HTTP 400 remains. Three of four workflows fully green, including select-through-settlement end-to-end.

## Known remaining issue (separate)

`discover / discover` still NACKs with HTTP 400 due to placeholder `txn-p2p-001` failing UUIDv4 schema validation — the same issue I cleared for demand-flex in #325. Wave2 fixtures need the same UUIDv4-ification; should land as its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)