### PR TITLE
schema(BecknTimeSeries v1.0): add optional resourceName + clientName (OpenADR-aligned)

### DIFF
--- a/specification/schema/BecknTimeSeries/v1.0/README.md
+++ b/specification/schema/BecknTimeSeries/v1.0/README.md
@@ -19,6 +19,8 @@ Part of the [DEG Schema](../../) · [BecknTimeSeries](../README.md)
 | `intervalPeriod` | object | ✓ | Default `{start, duration}` (ISO 8601) for the series. |
 | `payloadDescriptors` | array | ✓ | `{payloadType, units, currency, readingType, …}` per signal. Every type used in `intervals` MUST appear here. |
 | `intervals` | array | ✓ | Series rows; each `{id, [intervalPeriod], payloads[]}`. `payloads[]` is a list of `{type, values[]}` valuesMap rows. |
+| `resourceName` | string | — | Identifies the resource the readings are about (OpenADR `Report.resources[].resourceName`). In energy contexts, the meter id. Omit (or set to `"0"`) for aggregate / unattributed series. |
+| `clientName` | string | — | Identifies the reporting client (OpenADR `Report.clientName`). In energy contexts, the utility / DISCOM / aggregator subscriber id. |
 
 ## `payloadType` is open at this layer
 

--- a/specification/schema/BecknTimeSeries/v1.0/attributes.yaml
+++ b/specification/schema/BecknTimeSeries/v1.0/attributes.yaml
@@ -89,3 +89,24 @@ components:
             optional and overrides the default.
           items:
             $ref: "https://schema.beckn.io/openadr/v3.1.0#/components/schemas/interval"
+
+        resourceName:
+          type: string
+          description: >
+            Identifies the single resource these readings are about — the
+            data source. Mirrors OpenADR 3.1.0's
+            `Report.resources[].resourceName`. Use when the series captures
+            telemetry from a specific physical device or asset; in energy
+            domains this is typically the meter id. Omit (or set to `"0"`,
+            following OpenADR convention) for aggregate / unattributed
+            series. Optional, so existing payloads continue to validate
+            without change.
+
+        clientName:
+          type: string
+          description: >
+            Identifies the reporting client — the party authoring this
+            time-series and pushing it onto the wire. Mirrors OpenADR
+            3.1.0's `Report.clientName` (VEN name). In energy domains this
+            is typically the utility / DISCOM / aggregator subscriber id.
+            Optional.

--- a/specification/schema/BecknTimeSeries/v1.0/context.jsonld
+++ b/specification/schema/BecknTimeSeries/v1.0/context.jsonld
@@ -32,7 +32,10 @@
     "values": { "@id": "oadr:values", "@container": "@list" },
 
     "x": { "@id": "oadr:x", "@type": "xsd:float" },
-    "y": { "@id": "oadr:y", "@type": "xsd:float" }
+    "y": { "@id": "oadr:y", "@type": "xsd:float" },
+
+    "resourceName": "oadr:resourceName",
+    "clientName": "oadr:clientName"
   },
   "@graph": []
 }


### PR DESCRIPTION
## Summary

Two optional top-level fields on `BecknTimeSeries` so a time-series can identify its own source on the wire — meter / utility / aggregator id — instead of relying on the embedder's wrapper to carry that context.

Both mirror OpenADR 3.1.0 Report-object slots exactly:

| New field | OpenADR slot | Energy domain meaning |
|---|---|---|
| `resourceName` | `Report.resources[].resourceName` | The meter the readings are about |
| `clientName` | `Report.clientName` (VEN name) | The utility / DISCOM / aggregator authoring the report |

Backward-compatible: both optional. `BecknTimeSeries` is `additionalProperties: false`, so without this PR these terms would be rejected; the additive properties unlock the slots without forcing any existing payload to change.

## Motivation

The wave2 sellerdiscom-actor flow (#336) currently carries meter and discom identity as `dataset:meterId` / `dataset:discomId` custom extensions on the `DatasetItem` wrapper around the TimeSeries:

```jsonc
"resourceAttributes": {
  "@type": "DatasetItem",
  "dataset:meterId": "TEST_METER_SELLER_001",     // wrapper-level
  "dataset:discomId": "TEST_DISCOM_SELLER",       // wrapper-level
  "dataPayload": {
    "@type": "TimeSeries",
    "intervals": [{...}]                          // identity-less data
  }
}
```

After this PR, that identity moves inside the data itself, using OpenADR-canonical names:

```jsonc
"dataPayload": {
  "@type": "TimeSeries",
  "resourceName": "TEST_METER_SELLER_001",        // ← lives WITH the data
  "clientName":   "TEST_DISCOM_SELLER",
  "intervals": [{...}]
}
```

Three things this unlocks:
1. The TimeSeries is no longer anonymous — `[19.2]` makes sense without reaching back to the wrapper.
2. Per-domain key conventions (`dataset:*`) are not needed for what is in fact a domain-neutral concept (every telemetry payload wants to identify its source).
3. Direct interop with OpenADR 3.x consumers — drop the BecknTimeSeries into a Report and the resourceName/clientName fields slot in unchanged.

## Files changed

- `specification/schema/BecknTimeSeries/v1.0/attributes.yaml` — two new optional properties under `BecknTimeSeries.properties`.
- `specification/schema/BecknTimeSeries/v1.0/context.jsonld` — JSON-LD terms mapping `resourceName` and `clientName` to `oadr:` IRIs.
- `specification/schema/BecknTimeSeries/v1.0/README.md` — properties table updated.

## Deployment caveat

Runtime validation against the new fields requires the hosted schema at `schema.beckn.io/BecknTimeSeries/v1.0` to be redeployed (which syncs from this repo on merge to `main`). Until that sync runs, a payload carrying `resourceName` / `clientName` would be rejected by the still-strict `additionalProperties: false` on the hosted version.

**Fixture migration in downstream devkits is intentionally NOT part of this PR** — the wave2 sellerdiscom-actor fixture (and any other DatasetItem-using callers) should switch from `dataset:meterId` / `dataset:discomId` to these new fields in a follow-up PR after the schema deploys.

## Test plan

- [x] Schema validates as OpenAPI 3.1.1 (additions are leaf-level optional string properties; no structural change).
- [x] Backward compatibility — added properties are optional; no `required` array touched.
- [ ] Post-merge: confirm `https://schema.beckn.io/BecknTimeSeries/v1.0/attributes.yaml` reflects the new fields.
- [ ] Follow-up: wave2 sellerdiscom-actor fixture migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)