### PR TITLE
refactor(ElectricityCredential v1.0): modularize attributes.yaml via canonical $refs

### DIFF
--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -160,6 +160,50 @@ def get_attributes_url_from_context_url(context_url):
     """
     return context_url.replace('/context.jsonld', '/attributes.yaml')
 
+def select_context_url(context_url, obj_type):
+    """
+    Normalize the @context value to a single string URL.
+
+    JSON-LD allows @context to be a string or an array of strings. When it is an
+    array, select the URL that best matches the @type. Heuristic:
+    1. Prefer a URL whose path contains "/<TypeName>/" (case-insensitive).
+    2. Otherwise, return the first URL that is not the W3C credentials context
+       or a generic vocabulary (schema.org, beckn Location, etc.).
+    3. As a final fallback, return the first string URL.
+
+    Returns a string URL or None.
+    """
+    if isinstance(context_url, str):
+        return context_url
+    if not isinstance(context_url, list):
+        return None
+
+    string_urls = [u for u in context_url if isinstance(u, str)]
+    if not string_urls:
+        return None
+
+    type_name = (obj_type or "").split(":")[-1].lower() if obj_type else ""
+
+    # 1. Match by @type name in URL path
+    if type_name:
+        for url in string_urls:
+            if f"/{type_name}/" in url.lower():
+                return url
+
+    # 2. Skip generic / vocabulary URLs
+    generic_substrings = (
+        "www.w3.org/ns/credentials",
+        "schema.org",
+        "/Location/",
+    )
+    for url in string_urls:
+        if not any(s in url for s in generic_substrings):
+            return url
+
+    # 3. Fallback
+    return string_urls[0]
+
+
 def is_core_context_url(context_url):
     """
     Check if @context URL points to core schema.
@@ -450,8 +494,13 @@ def validate_payload(payload, registry_list, attributes_schema, attribute_schema
         if isinstance(data, dict):
             # Check for objects with @context and @type
             if "@context" in data and "@type" in data and attribute_schemas_map is not None:
-                context_url = data.get("@context")
                 obj_type = data.get("@type")
+                context_url = select_context_url(data.get("@context"), obj_type)
+                if context_url is None:
+                    # Recurse without attempting validation at this node
+                    for key, value in data.items():
+                        find_and_validate_objects(value, f"{path}/{key}" if path else key)
+                    return
                 
                 # Handle core Beckn objects (e.g., beckn:Order, beckn:Offer)
                 if obj_type and obj_type.startswith("beckn:"):

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -5,7 +5,17 @@ info:
   description: >
     Unified W3C Verifiable Credential (VC Data Model 2.0) issued per meter by
     electricity distribution utilities. Combines customer identity with optional
-    consumption, generation, and storage profiles in a single credential subject.
+    consumption, generation, and storage profiles in a single credentialSubject.
+
+    The profile sections are modular and reuse the credentialSubject definitions
+    of the sibling credentials published from this schema directory:
+    - https://schema.beckn.io/EnergyCustomerProfile (customerProfile)
+    - https://schema.beckn.io/ConsumptionProfileCredential (consumptionProfiles items)
+    - https://schema.beckn.io/GenerationProfileCredential (generationProfiles items)
+    - https://schema.beckn.io/StorageProfileCredential (storageProfiles items)
+    customerDetails (fullName, installationAddress, serviceConnectionDate) remains
+    inline because it uses the rich beckn Location shape for installationAddress,
+    which is broader than the address shape used by UtilityCustomerCredential.
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 servers:
   - url: https://schema.beckn.io
@@ -19,7 +29,8 @@ components:
       description: >
         Unified W3C Verifiable Credential issued per meter by electricity
         distribution utilities. Combines customer identity, consumption,
-        generation, and storage profiles in a single credentialSubject.
+        generation, and storage profiles in a single credentialSubject by
+        composing the credentialSubject schemas of sibling profile credentials.
       x-tags:
         - energy
         - credential
@@ -39,6 +50,8 @@ components:
           description: >
             The credential subject containing customer identity and optional
             consumptionProfiles, generationProfiles, and storageProfiles arrays.
+            Each profile entry conforms to the credentialSubject of the
+            corresponding sibling credential.
           x-jsonld:
             "@id": deg:credentialSubject
           type: object
@@ -52,38 +65,17 @@ components:
               x-jsonld:
                 "@id": "@id"
             customerProfile:
-              description: Core customer identity — customer number, meter number, meter type, identity reference.
+              $ref: "https://schema.beckn.io/EnergyCustomerProfile/v1.0"
+              description: >
+                Shared customer identity (customer/consumer number, meter
+                number, meter type, optional idRef). Reuses EnergyCustomerProfile.
               x-jsonld:
                 "@id": deg:customerProfile
-              type: object
-              required:
-                - customerNumber
-                - meterNumber
-                - meterType
-              properties:
-                customerNumber:
-                  type: string
-                  description: Full customer account number assigned by the utility.
-                meterNumber:
-                  type: string
-                  description: Unique meter serial number.
-                meterType:
-                  type: string
-                  description: Type of electricity meter. Values derived from Green Button / ESPI meter kind classifications.
-                  enum:
-                    - AMR
-                    - AMI
-                    - Electromechanical
-                    - Forward
-                    - Reverse
-                    - Bidirectional
-                    - Prepaid
-                    - NetMeter
-                    - Other
-                idRef:
-                  $ref: "#/components/schemas/IdRef"
             customerDetails:
-              description: Customer personal and address information.
+              description: >
+                Customer personal and address information. Kept inline because
+                installationAddress here follows the rich beckn Location shape,
+                broader than the address shape in UtilityCustomerCredential.
               x-jsonld:
                 "@id": deg:customerDetails
               type: object
@@ -140,114 +132,36 @@ components:
                   description: Date and time the electricity connection was activated (with timezone offset).
             consumptionProfiles:
               description: >
-                Connection and consumption characteristics for load management and tariff purposes.
-                Array to support customers with multiple meters or tariff categories.
+                Connection and consumption characteristics for load management
+                and tariff purposes. Each entry conforms to the credentialSubject
+                of ConsumptionProfileCredential, allowing a customer with
+                multiple meters or tariff categories to embed them inline.
               x-jsonld:
                 "@id": deg:consumptionProfiles
               type: array
               minItems: 1
               items:
-                $ref: "#/components/schemas/ConsumptionProfile"
+                $ref: "https://schema.beckn.io/ConsumptionProfileCredential/v2.0#/components/schemas/ConsumptionProfileCredential/properties/credentialSubject"
             generationProfiles:
               description: >
-                DER generation assets. Array to support customers with multiple generation units
-                (e.g., rooftop solar + wind turbine).
+                DER generation assets. Each entry conforms to the credentialSubject
+                of GenerationProfileCredential, allowing a customer with multiple
+                generation units (e.g., rooftop solar + wind turbine) to embed
+                them inline.
               x-jsonld:
                 "@id": deg:generationProfiles
               type: array
               minItems: 1
               items:
-                $ref: "#/components/schemas/GenerationProfile"
+                $ref: "https://schema.beckn.io/GenerationProfileCredential/v2.0#/components/schemas/GenerationProfileCredential/properties/credentialSubject"
             storageProfiles:
               description: >
-                Energy storage assets. Array to support customers with multiple batteries.
+                Energy storage assets. Each entry conforms to the credentialSubject
+                of StorageProfileCredential, allowing a customer with multiple
+                batteries to embed them inline.
               x-jsonld:
                 "@id": deg:storageProfiles
               type: array
               minItems: 1
               items:
-                $ref: "#/components/schemas/StorageProfile"
-
-    ConsumptionProfile:
-      description: Connection and consumption characteristics for load management and tariff purposes.
-      type: object
-      required:
-        - premisesType
-        - connectionType
-        - sanctionedLoadKW
-        - tariffCategoryCode
-      properties:
-        premisesType:
-          type: string
-          enum: [Residential, Commercial, Industrial, Agricultural]
-        connectionType:
-          type: string
-          enum: [Single-phase, Three-phase]
-        sanctionedLoadKW:
-          type: number
-          description: Sanctioned electrical load in kW.
-        tariffCategoryCode:
-          type: string
-          description: Billing/tariff category code assigned by the utility.
-
-    GenerationProfile:
-      description: DER generation capability.
-      type: object
-      required:
-        - generationType
-        - capacityKW
-        - commissioningDate
-      properties:
-        assetId:
-          type: string
-        generationType:
-          type: string
-          enum: [Solar, Wind, MicroHydro, Other]
-        capacityKW:
-          type: number
-          description: Installed generation capacity in kW.
-        commissioningDate:
-          type: string
-          format: date-time
-        manufacturer:
-          type: string
-        modelNumber:
-          type: string
-
-    StorageProfile:
-      description: Battery/energy storage capability.
-      type: object
-      required:
-        - storageCapacityKWh
-        - powerRatingKW
-        - commissioningDate
-      properties:
-        assetId:
-          type: string
-        storageCapacityKWh:
-          type: number
-          description: Storage capacity in kWh.
-        powerRatingKW:
-          type: number
-          description: Charge/discharge power rating in kW.
-        commissioningDate:
-          type: string
-          format: date-time
-        storageType:
-          type: string
-          enum: [LithiumIon, LeadAcid, FlowBattery, Other]
-
-    IdRef:
-      description: Reusable identity reference — an identity issued by an external authority.
-      type: object
-      required:
-        - issuedBy
-        - subjectId
-      properties:
-        issuedBy:
-          type: string
-          format: uri
-          description: DID of the authority that issued the identity.
-        subjectId:
-          type: string
-          description: "Identifier in the format authority-domain:id-value."
+                $ref: "https://schema.beckn.io/StorageProfileCredential/v2.0#/components/schemas/StorageProfileCredential/properties/credentialSubject"

--- a/specification/schema/ElectricityCredential/v1.0/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.0/examples/example.json
@@ -3,21 +3,22 @@
     "https://www.w3.org/ns/credentials/v2",
     "https://schema.org/",
     "https://schema.beckn.io/Location/2.0/context.jsonld",
-    "https://schema.beckn.io/deg/CustomerCredential/context.jsonld",
-    "https://schema.beckn.io/deg/CustomerProfile/context.jsonld",
-    "https://schema.beckn.io/deg/CustomerDetails/context.jsonld",
-    "https://schema.beckn.io/deg/ConsumptionProfile/context.jsonld",
-    "https://schema.beckn.io/deg/GenerationProfile/context.jsonld",
-    "https://schema.beckn.io/deg/StorageProfile/context.jsonld"
+    "https://schema.beckn.io/ElectricityCredential/v1.0/context.jsonld",
+    "https://schema.beckn.io/EnergyCustomerProfile/v1.0/context.jsonld",
+    "https://schema.beckn.io/ConsumptionProfileCredential/v2.0/context.jsonld",
+    "https://schema.beckn.io/GenerationProfileCredential/v2.0/context.jsonld",
+    "https://schema.beckn.io/StorageProfileCredential/v2.0/context.jsonld"
   ],
+  "@type": "ElectricityCredential",
   "id": "urn:uuid:e5f6a7b8-9012-34ab-cdef-567890123456",
   "type": [
     "VerifiableCredential",
-    "CustomerCredential"
+    "ElectricityCredential"
   ],
   "issuer": {
     "id": "https://example-utility.com/issuers/energy-dept",
     "name": "Example Energy Utility",
+    "licenseNumber": "REG-2025-00001",
     "idRef": {
       "issuedBy": "did:web:exreg.gov",
       "subjectId": "exreg.gov:AABPC00001"
@@ -27,7 +28,7 @@
   "validUntil": "2026-01-13T10:30:00-05:00",
   "credentialStatus": {
     "id": "https://dedi.global/dedi/lookup/example-utility.com/vc-revocation-registry/e5f6a7b8-9012-34ab-cdef-567890123456",
-    "type": "dedi",
+    "type": "dediregistry",
     "statusPurpose": "revocation",
     "statusListCredential": "https://dedi.global/dedi/query/example-utility.com/vc-revocation-registry"
   },
@@ -45,12 +46,6 @@
     "customerDetails": {
       "fullName": "Jane Doe",
       "installationAddress": {
-        "id": "LOC-001",
-        "descriptor": {
-          "name": "Jane Doe Residence",
-          "short_desc": "Residential installation at 123 Energy Street"
-        },
-        "gps": "37.7749,-122.4194",
         "address": "123 Energy Street, Unit 4",
         "city": {
           "name": "Metro City",
@@ -66,12 +61,17 @@
           "code": "US"
         },
         "area_code": "12345",
+        "gps": "37.7749,-122.4194",
         "openLocationCode": "849VCWC8+R9"
       },
       "serviceConnectionDate": "2025-01-10T00:00:00-05:00"
     },
     "consumptionProfiles": [
       {
+        "id": "did:example:customer:abc123",
+        "consumerNumber": "UTIL-2025-001234567",
+        "fullName": "Jane Doe",
+        "meterNumber": "MET2025789456123",
         "premisesType": "Residential",
         "connectionType": "Single-phase",
         "sanctionedLoadKW": 5,
@@ -80,35 +80,51 @@
     ],
     "generationProfiles": [
       {
+        "id": "did:example:customer:abc123",
+        "consumerNumber": "UTIL-2025-001234567",
+        "fullName": "Jane Doe",
+        "meterNumber": "MET2025789456123",
         "assetId": "DER-SOLAR-001",
         "generationType": "Solar",
         "capacityKW": 3,
-        "commissioningDate": "2025-01-12T00:00:00-05:00",
+        "commissioningDate": "2025-01-12",
         "manufacturer": "SunPower Corporation",
         "modelNumber": "SPR-X22-360"
       },
       {
+        "id": "did:example:customer:abc123",
+        "consumerNumber": "UTIL-2025-001234567",
+        "fullName": "Jane Doe",
+        "meterNumber": "MET2025789456123",
         "assetId": "DER-WIND-001",
         "generationType": "Wind",
         "capacityKW": 1.5,
-        "commissioningDate": "2025-03-01T00:00:00-05:00",
+        "commissioningDate": "2025-03-01",
         "manufacturer": "Windmill Co.",
         "modelNumber": "WM-MICRO-150"
       }
     ],
     "storageProfiles": [
       {
+        "id": "did:example:customer:abc123",
+        "consumerNumber": "UTIL-2025-001234567",
+        "fullName": "Jane Doe",
+        "meterNumber": "MET2025789456123",
         "assetId": "BESS-001",
         "storageCapacityKWh": 10,
         "powerRatingKW": 5,
-        "commissioningDate": "2025-01-12T00:00:00-05:00",
+        "commissioningDate": "2025-01-12",
         "storageType": "LithiumIon"
       },
       {
+        "id": "did:example:customer:abc123",
+        "consumerNumber": "UTIL-2025-001234567",
+        "fullName": "Jane Doe",
+        "meterNumber": "MET2025789456123",
         "assetId": "BESS-002",
         "storageCapacityKWh": 5,
         "powerRatingKW": 2.5,
-        "commissioningDate": "2025-06-01T00:00:00-05:00",
+        "commissioningDate": "2025-06-01",
         "storageType": "LithiumIon"
       }
     ]

--- a/specification/schema/ElectricityCredential/v1.0/schema.json
+++ b/specification/schema/ElectricityCredential/v1.0/schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/beckn/DEG/blob/main/specification/schema/ElectricityCredential/v1.0/schema.json",
-    "title": "Customer Credential Schema",
-    "description": "JSON Schema for a unified customer credential that combines customer identity, customer details, consumption characteristics, generation capability, and storage capability as equal-level properties within a single W3C Verifiable Credential (VC Data Model 2.0). Issued by energy providers.",
+    "title": "ElectricityCredential Schema",
+    "description": "JSON Schema for the unified ElectricityCredential — a W3C Verifiable Credential (VC Data Model 2.0) issued per meter by electricity distribution utilities. Combines customer identity, customer details, consumption characteristics, generation capability, and storage capability as equal-level properties within the credentialSubject. Bundled (self-contained, no external $refs) for distribution alongside the modular attributes.yaml.",
     "type": "object",
     "required": [
         "@context",
@@ -35,7 +35,7 @@
                 "type": "string"
             },
             "contains": {
-                "const": "CustomerCredential"
+                "const": "ElectricityCredential"
             },
             "minItems": 2
         },
@@ -105,8 +105,8 @@
                 },
                 "type": {
                     "type": "string",
-                    "const": "dedi",
-                    "description": "Type of status check mechanism (DeDi)"
+                    "const": "dediregistry",
+                    "description": "Type of status check mechanism (DeDi Registry)"
                 },
                 "statusPurpose": {
                     "type": "string",
@@ -450,14 +450,33 @@
         },
         "ConsumptionProfile": {
             "type": "object",
-            "description": "Connection and consumption characteristics for load management and tariff purposes",
+            "description": "Connection and consumption characteristics for load management and tariff purposes. Mirrors ConsumptionProfileCredential.credentialSubject.",
             "required": [
+                "id",
+                "consumerNumber",
+                "fullName",
                 "premisesType",
                 "connectionType",
                 "sanctionedLoadKW",
                 "tariffCategoryCode"
             ],
             "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "DID of the customer/credential subject (links to customer)"
+                },
+                "consumerNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Full consumer account number assigned by the utility"
+                },
+                "fullName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "Consumer name"
+                },
                 "premisesType": {
                     "type": "string",
                     "enum": [
@@ -486,18 +505,48 @@
                     "type": "string",
                     "minLength": 1,
                     "description": "Billing/tariff category code assigned by the utility"
+                },
+                "meterNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "Meter serial number (optional, for linking to specific meter)"
                 }
             }
         },
         "GenerationProfile": {
             "type": "object",
-            "description": "DER (Distributed Energy Resource) generation capability",
+            "description": "DER (Distributed Energy Resource) generation capability. Mirrors GenerationProfileCredential.credentialSubject.",
             "required": [
+                "id",
+                "consumerNumber",
                 "generationType",
                 "capacityKW",
                 "commissioningDate"
             ],
             "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "DID of the customer/credential subject (links to customer)"
+                },
+                "consumerNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Consumer account number assigned by the utility"
+                },
+                "fullName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "Consumer name (optional)"
+                },
+                "meterNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "Meter serial number associated with this generation asset (optional)"
+                },
                 "assetId": {
                     "type": "string",
                     "minLength": 1,
@@ -521,8 +570,8 @@
                 },
                 "commissioningDate": {
                     "type": "string",
-                    "format": "date-time",
-                    "description": "Date and time when the generation system was activated (with timezone offset)"
+                    "format": "date",
+                    "description": "Date when the generation system was activated"
                 },
                 "manufacturer": {
                     "type": "string",
@@ -540,13 +589,37 @@
         },
         "StorageProfile": {
             "type": "object",
-            "description": "Battery/energy storage capability",
+            "description": "Battery/energy storage capability. Mirrors StorageProfileCredential.credentialSubject.",
             "required": [
+                "id",
+                "consumerNumber",
                 "storageCapacityKWh",
                 "powerRatingKW",
                 "commissioningDate"
             ],
             "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "DID of the customer/credential subject (links to customer)"
+                },
+                "consumerNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Consumer account number assigned by the utility"
+                },
+                "fullName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "Consumer name (optional)"
+                },
+                "meterNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "Meter serial number associated with this storage asset (optional)"
+                },
                 "assetId": {
                     "type": "string",
                     "minLength": 1,
@@ -566,8 +639,8 @@
                 },
                 "commissioningDate": {
                     "type": "string",
-                    "format": "date-time",
-                    "description": "Date and time when the storage system was activated (with timezone offset)"
+                    "format": "date",
+                    "description": "Date when the storage system was activated"
                 },
                 "storageType": {
                     "type": "string",


### PR DESCRIPTION
## Summary
- `attributes.yaml` now composes ElectricityCredential from sibling credentials already published under `specification/schema/` — eliminating duplicated profile definitions:
  - `customerProfile` → `https://schema.beckn.io/EnergyCustomerProfile/v1.0`
  - `consumptionProfiles[]` → `ConsumptionProfileCredential/v2.0` (credentialSubject)
  - `generationProfiles[]` → `GenerationProfileCredential/v2.0` (credentialSubject)
  - `storageProfiles[]` → `StorageProfileCredential/v2.0` (credentialSubject)
- `customerDetails` kept inline because `installationAddress` here uses the rich beckn `Location` shape (broader than `UtilityCustomerCredential`'s flat address).
- `schema.json` stays bundled (no external `$ref`s) for self-contained distribution. Also fixed leftover renames so it matches the credential it describes:
  - title `Customer Credential Schema` → `ElectricityCredential Schema`
  - `type[]` contains `CustomerCredential` → `ElectricityCredential`
  - `credentialStatus.type` const `dedi` → `dediregistry` (matches `EnergyCredential`)
- `examples/example.json`:
  - adds top-level `@type: "ElectricityCredential"` (JSON-LD typed)
  - extends `@context` to include `ElectricityCredential` + sibling-credential contexts
  - populates `id`/`consumerNumber`/`fullName` on each profile entry as required by the referenced credentialSubject schemas
  - uses `date` (not `date-time`) for `commissioningDate` to match `{Generation,Storage}ProfileCredential`
- `scripts/validate_schema.py`: handle `@context` as a JSON-LD array (previously crashed with `unhashable type: 'list'` once a `@type` sat next to a list `@context`). New `select_context_url()` picks the URL that names `@type` and falls back past generic vocabularies (W3C VC, schema.org, Location).

## Test plan
- [x] `python3 -c "..."` validates `examples/example.json` against bundled `schema.json` (Draft 2020-12) — **VALID**.
- [x] `python3 scripts/validate_schema.py specification/schema/ElectricityCredential/v1.0/examples/example.json` — exit 0, no errors.
- [x] Regression: `python3 scripts/validate_schema.py` on `EnergyMeterDataCredential` + `EnergyBillingSummaryCredential` example.json — exit 0.
- [x] Audited refs: `schema.json` only has `#/$defs/...` internal refs; `attributes.yaml` has 5 canonical `https://schema.beckn.io/...` external refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)