### PR TITLE
fix(wave2): single-tunnel ngrok routing via Caddy path prefixes

### DIFF
--- a/devkits/p2p-trading-ies-wave2/install/Caddyfile
+++ b/devkits/p2p-trading-ies-wave2/install/Caddyfile
@@ -29,7 +29,41 @@ http://sellerdiscom.example.com:9000 {
     reverse_proxy onix-sellerdiscom-actor:8086
 }
 
-# Fallback for the bare beckn-router hostname (used by the health check).
+# Catch-all on :9000 — used by the health check AND by public ingress
+# through an ngrok tunnel. ngrok rewrites the upstream Host header to the
+# ngrok hostname, so the per-participant host blocks above won't match for
+# tunneled traffic. To let a SINGLE ngrok tunnel disambiguate between
+# participants, route here by URL path prefix; the prefix is stripped before
+# proxying so each onix container still sees its standard Beckn paths
+# (/bap/receiver, /bpp/caller, etc.). Configure your Postman/payload host
+# variables as e.g. https://<ngrok>/<participant-slug> (no trailing slash).
 :9000 {
-    respond "beckn-router ok" 200
+    @buyerapp path /buyerapp /buyerapp/*
+    handle @buyerapp {
+        uri strip_prefix /buyerapp
+        reverse_proxy onix-buyerapp:8081
+    }
+    @sellerapp path /sellerapp /sellerapp/*
+    handle @sellerapp {
+        uri strip_prefix /sellerapp
+        reverse_proxy onix-sellerapp:8082
+    }
+    @sellerDiscomLedger path /seller-discom-ledger /seller-discom-ledger/*
+    handle @sellerDiscomLedger {
+        uri strip_prefix /seller-discom-ledger
+        reverse_proxy onix-ledger-sellerdiscom:8083
+    }
+    @buyerDiscomLedger path /buyer-discom-ledger /buyer-discom-ledger/*
+    handle @buyerDiscomLedger {
+        uri strip_prefix /buyer-discom-ledger
+        reverse_proxy onix-ledger-buyerdiscom:8084
+    }
+    @sellerDiscomActor path /sellerdiscom /sellerdiscom/*
+    handle @sellerDiscomActor {
+        uri strip_prefix /sellerdiscom
+        reverse_proxy onix-sellerdiscom-actor:8086
+    }
+    handle {
+        respond "beckn-router ok" 200
+    }
 }


### PR DESCRIPTION
## Summary

- **Problem:** With a single ngrok tunnel fronting `beckn-router`, every request fell through to the `:9000` fallback and returned `beckn-router ok` 200 — never reaching any onix. Caddy was routing by Host header (`sellerapp.example.com`, `buyerapp.example.com`, …), but ngrok rewrites the upstream Host to its own hostname, so none of the per-participant blocks matched.
- **Fix:** Add path-prefix handlers on the `:9000` catch-all (`/buyerapp`, `/sellerapp`, `/seller-discom-ledger`, `/buyer-discom-ledger`, `/sellerdiscom`). Caddy strips the prefix before proxying, so each onix still sees standard Beckn paths (`/bap/receiver`, `/bpp/caller`, etc.). Inside-docker traffic continues to use the per-host blocks above — wave2 split-discom cascade semantics unchanged.

## Why path-prefix instead of multi-tunnel

The "production-shape" answer is multi-tunnel: one ngrok tunnel per participant with `host_header` rewrite, which preserves the host-based routing exactly. That needs paid ngrok (free plan = 1 simultaneous tunnel). Path-prefix gives the same disambiguation through a single free tunnel; the trade-off is that public URLs carry a `/<participant-slug>` segment that doesn't exist in a real Beckn deployment. Internal docker callers are unaffected.

## Required Postman variable updates

Set host roots to `https://<ngrok>/<slug>` (no trailing slash):

| Variable | Value |
|---|---|
| `bap_host_root` | `https://<ngrok>/buyerapp` |
| `bpp_host_root` | `https://<ngrok>/sellerapp` |
| `ledger_host_buyer` | `https://<ngrok>/buyer-discom-ledger` |
| `ledger_host_seller` | `https://<ngrok>/seller-discom-ledger` |

## Test plan

- [x] `docker exec beckn-router caddy reload` succeeds (warns only on formatting)
- [x] `curl https://<ngrok>/sellerapp/health` → 200 (was: 200 `beckn-router ok` fallback)
- [x] `POST https://<ngrok>/sellerapp/bpp/receiver/status` → 200 (was: 200 `beckn-router ok` fallback)
- [ ] End-to-end /status from Postman: buyer → seller → seller-discom-ledger → on_status cascade back to buyer

🤖 Generated with [Claude Code](https://claude.com/claude-code)