### PR TITLE
Fix the broken auto-routing in p2p wave2 devkit from buyer to buyer discom ledger

### DIFF
--- a/devkits/p2p-trading-ies-wave2/install/Caddyfile
+++ b/devkits/p2p-trading-ies-wave2/install/Caddyfile
@@ -29,15 +29,23 @@ http://sellerdiscom.example.com:9000 {
     reverse_proxy onix-sellerdiscom-actor:8086
 }
 
-# Catch-all on :9000 — used by the health check AND by public ingress
-# through an ngrok tunnel. ngrok rewrites the upstream Host header to the
-# ngrok hostname, so the per-participant host blocks above won't match for
-# tunneled traffic. To let a SINGLE ngrok tunnel disambiguate between
-# participants, route here by URL path prefix; the prefix is stripped before
-# proxying so each onix container still sees its standard Beckn paths
-# (/bap/receiver, /bpp/caller, etc.). Configure your Postman/payload host
-# variables as e.g. https://<ngrok>/<participant-slug> (no trailing slash).
+# Catch-all on :9000 — handles two routing modes:
+#
+# 1. Participant-slug mode (single ngrok tunnel, multi-participant devkit):
+#    Prefix the path with a participant slug so Caddy can disambiguate.
+#    The slug is stripped before proxying, so each onix still sees standard
+#    Beckn paths (/bap/receiver, /bpp/caller, etc.).
+#    e.g. https://<ngrok>/sellerapp/bpp/receiver/status
+#
+# 2. Direct-path mode (single-participant local or cloud deployment,
+#    or multi-tunnel ngrok where each participant has its own URL):
+#    Standard Beckn paths (/bap/* → buyerapp, /bpp/* → sellerapp) are
+#    forwarded as-is — no slug required.
+#    e.g. https://<ngrok>/bpp/receiver/status
+#
+# Slug routes are matched first; /bap/* and /bpp/* are the fallback.
 :9000 {
+    # --- Participant-slug routes (multi-participant devkit) ---
     @buyerapp path /buyerapp /buyerapp/*
     handle @buyerapp {
         uri strip_prefix /buyerapp
@@ -63,6 +71,20 @@ http://sellerdiscom.example.com:9000 {
         uri strip_prefix /sellerdiscom
         reverse_proxy onix-sellerdiscom-actor:8086
     }
+
+    # --- Standard Beckn paths (single-participant / direct-path mode) ---
+    # /bap/* → buyerapp onix; /bpp/* → sellerapp onix.
+    # In devkit: ledger participants need a slug above to avoid ambiguity
+    # since they also expose /bpp/* endpoints.
+    @bap path /bap /bap/*
+    handle @bap {
+        reverse_proxy onix-buyerapp:8081
+    }
+    @bpp path /bpp /bpp/*
+    handle @bpp {
+        reverse_proxy onix-sellerapp:8082
+    }
+
     handle {
         respond "beckn-router ok" 200
     }

--- a/plugins/degledgerrecorder/mapper_wave2.go
+++ b/plugins/degledgerrecorder/mapper_wave2.go
@@ -679,16 +679,24 @@ func ParticipantEndpointURI(participants []Wave2Participant, role, key string) s
 // SubTxContext describes one Beckn sub-transaction's party identifiers. Used
 // to rewrite context.bapId/bapUri/bppId/bppUri when a cascade leg crosses a
 // transaction boundary (e.g. seller→sellerdiscom is a fresh BAP↔BPP pair).
-// Subscriber IDs (BapID/BppID) follow the convention id = URL hostname.
+//
+// Set BapID/BppID explicitly from participants[role].participantId so that
+// the subscriber IDs are stable Beckn identities regardless of the routing
+// URI used (ngrok tunnel, internal Docker hostname, cloud hostname, etc.).
+// If BapID/BppID are empty the function falls back to the URI hostname
+// convention — acceptable when the URI hostname IS the subscriber ID.
 type SubTxContext struct {
 	BapURI string
 	BppURI string
+	BapID  string // explicit subscriber ID; if set, overrides hostname(BapURI)
+	BppID  string // explicit subscriber ID; if set, overrides hostname(BppURI)
 }
 
 // RewriteContextForSubTx rewrites context.bap*/bpp* fields in `body` to identify
-// the parties of the new sub-transaction. Subscriber IDs are derived from URL
-// hostnames. Returns the rewritten body. Other context fields (action, ids,
-// timestamps, networkId, version, schemaContext) are preserved.
+// the parties of the new sub-transaction. Subscriber IDs come from BapID/BppID
+// when set; otherwise they are derived from the URL hostname (the Beckn
+// convention for production nodes where hostname == subscriberId). Returns the
+// rewritten body. Other context fields are preserved verbatim.
 func RewriteContextForSubTx(body []byte, tx SubTxContext) ([]byte, error) {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -708,14 +716,22 @@ func RewriteContextForSubTx(body []byte, tx SubTxContext) ([]byte, error) {
 
 	if tx.BapURI != "" {
 		ctxRaw[bapKey] = tx.BapURI
-		if h := hostname(tx.BapURI); h != "" {
-			ctxRaw[bapIDKey] = h
+		id := tx.BapID
+		if id == "" {
+			id = hostname(tx.BapURI)
+		}
+		if id != "" {
+			ctxRaw[bapIDKey] = id
 		}
 	}
 	if tx.BppURI != "" {
 		ctxRaw[bppKey] = tx.BppURI
-		if h := hostname(tx.BppURI); h != "" {
-			ctxRaw[bppIDKey] = h
+		id := tx.BppID
+		if id == "" {
+			id = hostname(tx.BppURI)
+		}
+		if id != "" {
+			ctxRaw[bppIDKey] = id
 		}
 	}
 	raw["context"] = ctxRaw

--- a/plugins/degledgerrecorder/recorder.go
+++ b/plugins/degledgerrecorder/recorder.go
@@ -418,14 +418,22 @@ func (r *DEGLedgerRecorder) handleStatus(ctx *model.StepContext) error {
 	ledgerEndpoint := BppReceiverEndpoint(ledgerHostBase)
 
 	// platformUri comes from participants[<own-role>].participantAttributes.platformUri.
-	ownPlatformURI := ParticipantEndpointURI(payload.Message.Contract.Participants, strings.ToLower(r.config.Role), "platformUri")
+	parts := payload.Message.Contract.Participants
+	ownPlatformURI := ParticipantEndpointURI(parts, strings.ToLower(r.config.Role), "platformUri")
 	if ownPlatformURI == "" {
 		log.Warnf(ctx, "DEGLedgerRecorder: own platformUri not found in participants[%s]; skipping status forward (transaction_id=%s)", r.config.Role, payload.Context.TransactionID)
 		return nil
 	}
+	// Use participantId from the participants array for bapId/bppId so they are
+	// stable Beckn identities regardless of whether the routing URIs use ngrok
+	// tunnels, internal Docker hostnames, or production FQDNs.
+	ownParticipantID := participantID(findWave2Participant(parts, strings.ToLower(r.config.Role)))
+	discomParticipantID := participantID(findWave2Participant(parts, string(side)))
 	subTx := SubTxContext{
 		BapURI: BapReceiverEndpoint(ownPlatformURI),
 		BppURI: ledgerEndpoint,
+		BapID:  ownParticipantID,
+		BppID:  discomParticipantID,
 	}
 	rewritten, err := RewriteContextForSubTx(ctx.Body, subTx)
 	if err != nil {
@@ -496,6 +504,7 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 
 	var baseURL string
 	var subTx SubTxContext
+	ownParticipantID := participantID(findWave2Participant(parts, strings.ToLower(r.config.Role)))
 	if fromOwnDiscom {
 		// Rule 2a: forward to peer's /bap/receiver.
 		peerRole := "buyer"
@@ -507,9 +516,15 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 			log.Warnf(ctx, "DEGLedgerRecorder: peer platformUri not found in participants[%s] (transaction_id=%s)", peerRole, payload.Context.TransactionID)
 			return nil
 		}
+		peerParticipantID := participantID(findWave2Participant(parts, peerRole))
 		peerBapEndpoint := BapReceiverEndpoint(peerPlatformURI)
 		baseURL = peerBapEndpoint
-		subTx = SubTxContext{BapURI: peerBapEndpoint, BppURI: ownBppEndpoint}
+		subTx = SubTxContext{
+			BapURI: peerBapEndpoint,
+			BppURI: ownBppEndpoint,
+			BapID:  peerParticipantID,
+			BppID:  ownParticipantID,
+		}
 	} else {
 		// Rule 2b: cascade to own discom. Skip if no performance data.
 		if !Wave2OnStatusHasPerformanceData(payload) {
@@ -523,8 +538,14 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 		// Discom is the BAP-style sink for this on_status push; this handler's
 		// platform is the BPP-caller initiating it.
 		discomLedgerEndpoint := BapReceiverEndpoint(discomLedgerHost)
+		discomParticipantID := participantID(findWave2Participant(parts, ownDiscomRole))
 		baseURL = discomLedgerEndpoint
-		subTx = SubTxContext{BapURI: discomLedgerEndpoint, BppURI: ownBppEndpoint}
+		subTx = SubTxContext{
+			BapURI: discomLedgerEndpoint,
+			BppURI: ownBppEndpoint,
+			BapID:  discomParticipantID,
+			BppID:  ownParticipantID,
+		}
 	}
 
 	if baseURL == "" {


### PR DESCRIPTION
## Fix broken auto-routing in p2p wave2 devkit (buyer → buyer-discom ledger)

### Problem

Two related bugs caused the buyer → buyer-discom `status`/`on_status` cascade to fail when running the wave2 devkit without participant-slug prefixes (i.e. standard Beckn paths like `/bap/receiver`, `/bpp/caller`):

1. **Caddyfile had no `/bap/*` or `/bpp/*` routes in the catch-all block.** Requests on those paths fell through to the `"beckn-router ok"` response instead of being proxied to the correct onix container.

2. **`bapId`/`bppId` were derived from the routing URI's hostname.** In non-production environments the routing URI hostname is an ngrok subdomain or a Docker internal name — not the stable Beckn subscriber ID. This caused invalid Beckn context on sub-transaction legs forwarded to the discom ledger.

### Changes

**`Caddyfile`**
- Adds direct-path routing: `/bap/*` → `onix-buyerapp:8081`, `/bpp/*` → `onix-sellerapp:8082`.
- Slug routes (e.g. `/buyerapp/…`) are matched first so multi-participant devkit and single ngrok tunnel flows are unaffected.
- Expands the catch-all comment to document both routing modes clearly.

**`mapper_wave2.go`**
- Adds `BapID` / `BppID` fields to `SubTxContext`.
- `RewriteContextForSubTx` uses these explicit IDs when set, falling back to `hostname(URI)` only when they are empty (preserving the existing production behavior where hostname == subscriberId).

**`recorder.go`**
- `handleStatus` and `handleOnStatusWave2` now populate `BapID`/`BppID` from `participantID(findWave2Participant(parts, role))` so the Beckn context on every sub-transaction leg carries the correct, stable subscriber IDs regardless of how the node is reachable (ngrok tunnel, Docker hostname, or production FQDN).

### Test plan

- [x] Run the wave2 devkit with no slug prefix (`/bap/receiver`, `/bpp/caller` paths) and verify the full `search → init → confirm → status → on_status` flow reaches the buyer-discom ledger.
- [x] Verify slug-prefixed paths (`/buyerapp/…`, `/buyerdiscom/…`) still route correctly (no regression).
- [x] Confirm `context.bapId` / `context.bppId` on the discom-leg calls match `participantId` values from the contract payload, not the ngrok/Docker hostname.