### PR TITLE
feat(schema): ElectricityCredential v1.1 — unified energyResources, multi-meter topology, ConsumptionProfile

### DIFF
--- a/specification/schema/ElectricityCredential/v1.1/README.md
+++ b/specification/schema/ElectricityCredential/v1.1/README.md
@@ -1,0 +1,141 @@
+# ElectricityCredential v1.1
+
+W3C Verifiable Credential (VC Data Model 2.0) issued per meter by electricity distribution utilities.
+
+## Structure
+
+```
+credentialSubject
+├── id                         (optional — customer DID)
+├── customerProfile            (required — non-PII; shareable without customerDetails)
+│   ├── customerNumber         (required — CA number)
+│   ├── idRef                  (optional — external identity reference)
+│   ├── energyResources[]      (required — all physical assets, min 1)
+│   │   ├── METER              (grid connection point; resourceId = meter serial number)
+│   │   ├── SOLAR / WIND / …   (generation DERs; parentResources → meter)
+│   │   └── BATTERY / BESS / … (storage DERs; parentResources → meter)
+│   └── consumptionProfiles[]  (optional — tariff/load per meter, linked via meterId)
+└── customerDetails            (optional — PII)
+    ├── fullName               (PII — only here, never in energyResources)
+    ├── installationAddress
+    └── serviceConnectionDate
+```
+
+## Multiple topologies
+
+A single `customerNumber` can span arbitrary asset topologies. Examples:
+
+**Single meter, one DER:**
+```json
+"energyResources": [
+  {"resourceId": "MET001", "resourceType": "METER", ...},
+  {"resourceId": "der://solar/PV001", "resourceType": "SOLAR", "parentResources": ["MET001"]}
+]
+```
+
+**Two meters at different premises:**
+```json
+"energyResources": [
+  {"resourceId": "MET001", "resourceType": "METER", "resourceAttributes": {"meterType": "AMI", ...}},
+  {"resourceId": "MET002", "resourceType": "METER", "resourceAttributes": {"meterType": "NetMeter", ...}},
+  {"resourceId": "der://solar/PV001", "resourceType": "SOLAR", "parentResources": ["MET001"]},
+  {"resourceId": "der://battery/BAT001", "resourceType": "BATTERY", "parentResources": ["MET002"]}
+],
+"consumptionProfiles": [
+  {"meterId": "MET001", "sanctionedLoadKW": 5, "tariffCategoryCode": "RES-01"},
+  {"meterId": "MET002", "sanctionedLoadKW": 20, "tariffCategoryCode": "COM-03"}
+]
+```
+
+## customerProfile fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `customerNumber` | string | Yes | Utility CA number |
+| `idRef` | object | No | External identity linkage (`issuedBy` DID + `subjectId`) |
+| `energyResources` | array | Yes | EnergyResource/v2.0 entries (min 1) |
+| `consumptionProfiles` | array | No | Tariff/load profiles, one per meter |
+
+## energyResources entries
+
+Each entry follows [EnergyResource/v2.0](../../EnergyResource/v2.0/attributes.yaml).
+
+For **METER** entries:
+- `resourceId` = meter serial number (bare, no URI prefix)
+- `resourceAttributes` conforms to [MeterAttributes](../../EnergyResource/v2.0/attributes.yaml) — all fields optional: `meterType`, `gps`, `location`, `feeder`, `bus`
+
+For **DER** entries (SOLAR, WIND, BATTERY, …):
+- `parentResources[]` lists the meter serial number(s) this DER sits behind
+- `ratedPowerKw`, `make`, `model` from the EnergyResource base class
+- Type-specific fields in `resourceAttributes` (e.g., `commissioningDate`, `storageType`)
+
+## ConsumptionProfile
+
+Administrative tariff and load data for a meter connection. Kept separate from `MeterAttributes` because tariff data is regulatory and changes independently of physical assets.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `meterId` | string | Yes | Meter serial number — matches `resourceId` of a METER in `energyResources[]` |
+| `sanctionedLoadKW` | number | Yes | Utility-approved load in kW |
+| `tariffCategoryCode` | string | Yes | Utility billing/tariff category code |
+| `premisesType` | enum | No | Residential, Commercial, Industrial, Agricultural |
+| `connectionType` | enum | No | Single-phase, Three-phase |
+
+## customerDetails (PII)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fullName` | string | Yes | Full name as per ID proof — **only here** |
+| `installationAddress` | object | Yes | Beckn Location shape |
+| `serviceConnectionDate` | date-time | Yes | Connection activation date (with timezone) |
+
+## Minimal valid credential
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://schema.beckn.io/ElectricityCredential/v1.1/context.jsonld"],
+  "id": "urn:uuid:…",
+  "type": ["VerifiableCredential", "ElectricityCredential"],
+  "issuer": {"id": "did:web:bescom.karnataka.gov.in", "name": "BESCOM"},
+  "validFrom": "2025-01-13T10:30:00+05:30",
+  "credentialSubject": {
+    "customerProfile": {
+      "customerNumber": "UTIL-2025-001234567",
+      "energyResources": [
+        {"resourceId": "MET2025789456123", "resourceType": "METER"}
+      ]
+    }
+  }
+}
+```
+
+## v1.0 → v1.1 migration
+
+| v1.0 field | v1.1 location |
+|------------|---------------|
+| `customerProfile.meterNumber` | `energyResources[METER].resourceId` |
+| `customerProfile.meterType` | `energyResources[METER].resourceAttributes.meterType` |
+| `consumptionProfiles[].sanctionedLoadKW` | `consumptionProfiles[].sanctionedLoadKW` |
+| `consumptionProfiles[].tariffCategoryCode` | `consumptionProfiles[].tariffCategoryCode` |
+| `consumptionProfiles[].premisesType` | `consumptionProfiles[].premisesType` |
+| `consumptionProfiles[].connectionType` | `consumptionProfiles[].connectionType` |
+| `generationProfiles[].assetId` | `energyResources[DER].resourceId` |
+| `generationProfiles[].generationType` | `energyResources[DER].resourceType` (SOLAR, WIND, …) |
+| `generationProfiles[].capacityKW` | `energyResources[DER].ratedPowerKw` |
+| `generationProfiles[].manufacturer` | `energyResources[DER].make` |
+| `generationProfiles[].modelNumber` | `energyResources[DER].model` |
+| `storageProfiles[].storageCapacityKWh` | `energyResources[DER].energyCapacityKwh` |
+| `storageProfiles[].powerRatingKW` | `energyResources[DER].ratedPowerKw` |
+| `storageProfiles[].storageType` | `energyResources[DER].resourceAttributes.storageType` |
+| `fullName` (in each profile entry) | `customerDetails.fullName` (once, PII section) |
+| `consumerNumber` (in each profile entry) | `customerProfile.customerNumber` |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `attributes.yaml` | OpenAPI 3.1.1 schema |
+| `schema.json` | Bundled JSON Schema (draft 2020-12) — self-contained |
+| `context.jsonld` | JSON-LD context |
+| `vocab.jsonld` | RDF vocabulary |
+| `examples/example.json` | Full example: 1 meter + 2 generation + 2 storage DERs + 1 consumption profile |

--- a/specification/schema/ElectricityCredential/v1.1/README.md
+++ b/specification/schema/ElectricityCredential/v1.1/README.md
@@ -90,7 +90,6 @@ All non-topological fields go here.
 | Field | Type | Description |
 |-------|------|-------------|
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
-| `contractMaxDemandKw` | number ≥0 | Maximum demand contracted with the utility, kW |
 | `gps` | string | `"lat,lng"` coordinates of the meter |
 | `location` | object | Postal location (beckn Location shape) |
 
@@ -110,6 +109,7 @@ Grid topology (feeder, bus, DT) is expressed via `parentResources[]` — referen
 |-------|------|----------|-------------|
 | `meterId` | string | Yes | Matches `id` of a METER entry in `energyResources[]` |
 | `sanctionedLoadKW` | number | Yes | Utility-approved load in kW |
+| `contractMaxDemandKw` | number | No | Maximum demand contracted with the utility, kW |
 | `tariffCategoryCode` | string | Yes | Billing/tariff category code |
 | `premisesType` | enum | No | Residential, Commercial, Industrial, Agricultural |
 | `connectionType` | enum | No | Single-phase, Three-phase |

--- a/specification/schema/ElectricityCredential/v1.1/README.md
+++ b/specification/schema/ElectricityCredential/v1.1/README.md
@@ -90,6 +90,7 @@ All non-topological fields go here.
 | Field | Type | Description |
 |-------|------|-------------|
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
+| `contractMaxDemandKw` | number ≥0 | Maximum demand contracted with the utility, kW |
 | `gps` | string | `"lat,lng"` coordinates of the meter |
 | `location` | object | Postal location (beckn Location shape) |
 

--- a/specification/schema/ElectricityCredential/v1.1/README.md
+++ b/specification/schema/ElectricityCredential/v1.1/README.md
@@ -15,7 +15,7 @@ credentialSubject
 │   │   ├── type               (enum: METER, DT, BUS, FEEDER, SOLAR, WIND, BATTERY, BESS, EV_CHARGER, …)
 │   │   ├── attributes         (open bag — all non-topological properties)
 │   │   │   ├── CommonResourceAttributes: make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
-│   │   │   └── type-specific: meterType, gps, location, feeder, bus / commissioningDate / storageType / …
+│   │   │   └── type-specific: meterType, gps, location / commissioningDate / storageType / …
 │   │   ├── subResources[]     (child resource ids or inline objects)
 │   │   └── parentResources[]  (parent resource ids — e.g., the meter a DER sits behind)
 │   └── consumptionProfiles[]  (optional — tariff/load per meter, linked via meterId)
@@ -32,7 +32,7 @@ A single `customerNumber` can span arbitrary asset topologies.
 **Submetering** — building main meter + tenant sub-meters:
 ```json
 "energyResources": [
-  {"id": "MET-BLDG-001", "type": "METER", "attributes": {"meterType": "AMI", "feeder": "BAN-NR-F22"}},
+  {"id": "MET-BLDG-001", "type": "METER", "attributes": {"meterType": "AMI"}, "parentResources": ["BAN-NR-F22"]},
   {"id": "MET-UNIT-101", "type": "METER", "attributes": {"meterType": "AMR"}, "parentResources": ["MET-BLDG-001"]},
   {"id": "MET-UNIT-102", "type": "METER", "attributes": {"meterType": "AMR"}, "parentResources": ["MET-BLDG-001"]},
   {"id": "ROOFTOP-101",  "type": "SOLAR", "attributes": {"ratedPowerKw": 2},   "parentResources": ["MET-UNIT-101"]}
@@ -42,7 +42,7 @@ A single `customerNumber` can span arbitrary asset topologies.
 **Parallel metering** — import meter + export meter for solar FIT:
 ```json
 "energyResources": [
-  {"id": "MET-IMPORT", "type": "METER", "attributes": {"meterType": "AMI", "feeder": "DEL-F08"}},
+  {"id": "MET-IMPORT", "type": "METER", "attributes": {"meterType": "AMI"}, "parentResources": ["DEL-F08"]},
   {"id": "MET-EXPORT", "type": "METER", "attributes": {"meterType": "Reverse"}},
   {"id": "SOLAR-001",  "type": "SOLAR", "attributes": {"ratedPowerKw": 5}, "parentResources": ["MET-EXPORT"]}
 ],
@@ -92,8 +92,8 @@ All non-topological fields go here.
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
 | `gps` | string | `"lat,lng"` coordinates of the meter |
 | `location` | object | Postal location (beckn Location shape) |
-| `feeder` | string | Distribution feeder ID or name |
-| `bus` | string | Substation bus reference |
+
+Grid topology (feeder, bus, DT) is expressed via `parentResources[]` — reference the id of a `FEEDER`, `BUS`, or `DT` resource.
 
 **DER-specific examples** (open — any field can be added):
 

--- a/specification/schema/ElectricityCredential/v1.1/README.md
+++ b/specification/schema/ElectricityCredential/v1.1/README.md
@@ -7,47 +7,52 @@ W3C Verifiable Credential (VC Data Model 2.0) issued per meter by electricity di
 ```
 credentialSubject
 ├── id                         (optional — customer DID)
-├── customerProfile            (required — non-PII; shareable without customerDetails)
+├── customerProfile            (required — non-PII)
 │   ├── customerNumber         (required — CA number)
 │   ├── idRef                  (optional — external identity reference)
 │   ├── energyResources[]      (required — all physical assets, min 1)
-│   │   ├── METER              (grid connection point; resourceId = meter serial number)
-│   │   ├── SOLAR / WIND / …   (generation DERs; parentResources → meter)
-│   │   └── BATTERY / BESS / … (storage DERs; parentResources → meter)
+│   │   ├── id                 (meter serial number for METER; any stable id for DERs)
+│   │   ├── type               (METER, SOLAR, WIND, BATTERY, BESS, EV_CHARGER, …)
+│   │   ├── attributes         (open bag — all non-topological properties)
+│   │   │   ├── CommonResourceAttributes: make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
+│   │   │   └── type-specific: meterType, gps, location, feeder, bus / commissioningDate / storageType / …
+│   │   ├── subResources[]     (child resource ids or inline objects)
+│   │   └── parentResources[]  (parent resource ids — e.g., the meter a DER sits behind)
 │   └── consumptionProfiles[]  (optional — tariff/load per meter, linked via meterId)
 └── customerDetails            (optional — PII)
-    ├── fullName               (PII — only here, never in energyResources)
+    ├── fullName               (PII — only here)
     ├── installationAddress
     └── serviceConnectionDate
 ```
 
 ## Multiple topologies
 
-A single `customerNumber` can span arbitrary asset topologies. Examples:
+A single `customerNumber` can span arbitrary asset topologies.
 
-**Single meter, one DER:**
+**Submetering** — building main meter + tenant sub-meters:
 ```json
 "energyResources": [
-  {"resourceId": "MET001", "resourceType": "METER", ...},
-  {"resourceId": "der://solar/PV001", "resourceType": "SOLAR", "parentResources": ["MET001"]}
+  {"id": "MET-BLDG-001", "type": "METER", "attributes": {"meterType": "AMI", "feeder": "BAN-NR-F22"}},
+  {"id": "MET-UNIT-101", "type": "METER", "attributes": {"meterType": "AMR"}, "parentResources": ["MET-BLDG-001"]},
+  {"id": "MET-UNIT-102", "type": "METER", "attributes": {"meterType": "AMR"}, "parentResources": ["MET-BLDG-001"]},
+  {"id": "ROOFTOP-101",  "type": "SOLAR", "attributes": {"ratedPowerKw": 2},   "parentResources": ["MET-UNIT-101"]}
 ]
 ```
 
-**Two meters at different premises:**
+**Parallel metering** — import meter + export meter for solar FIT:
 ```json
 "energyResources": [
-  {"resourceId": "MET001", "resourceType": "METER", "resourceAttributes": {"meterType": "AMI", ...}},
-  {"resourceId": "MET002", "resourceType": "METER", "resourceAttributes": {"meterType": "NetMeter", ...}},
-  {"resourceId": "der://solar/PV001", "resourceType": "SOLAR", "parentResources": ["MET001"]},
-  {"resourceId": "der://battery/BAT001", "resourceType": "BATTERY", "parentResources": ["MET002"]}
+  {"id": "MET-IMPORT", "type": "METER", "attributes": {"meterType": "AMI", "feeder": "DEL-F08"}},
+  {"id": "MET-EXPORT", "type": "METER", "attributes": {"meterType": "Reverse"}},
+  {"id": "SOLAR-001",  "type": "SOLAR", "attributes": {"ratedPowerKw": 5}, "parentResources": ["MET-EXPORT"]}
 ],
 "consumptionProfiles": [
-  {"meterId": "MET001", "sanctionedLoadKW": 5, "tariffCategoryCode": "RES-01"},
-  {"meterId": "MET002", "sanctionedLoadKW": 20, "tariffCategoryCode": "COM-03"}
+  {"meterId": "MET-IMPORT", "sanctionedLoadKW": 10, "tariffCategoryCode": "DS-I"},
+  {"meterId": "MET-EXPORT", "sanctionedLoadKW": 5,  "tariffCategoryCode": "FIT-SOLAR-01"}
 ]
 ```
 
-## customerProfile fields
+## customerProfile
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -56,28 +61,55 @@ A single `customerNumber` can span arbitrary asset topologies. Examples:
 | `energyResources` | array | Yes | EnergyResource/v2.0 entries (min 1) |
 | `consumptionProfiles` | array | No | Tariff/load profiles, one per meter |
 
-## energyResources entries
+## EnergyResource — top-level fields
 
-Each entry follows [EnergyResource/v2.0](../../EnergyResource/v2.0/attributes.yaml).
+| Field | Description |
+|-------|-------------|
+| `id` | Stable identifier. For METER: meter serial number. For DERs: any stable scheme. |
+| `type` | Open-string asset class: `METER`, `SOLAR`, `WIND`, `BATTERY`, `BESS`, `EV_CHARGER`, … |
+| `attributes` | Open bag — all non-topological properties (see below) |
+| `subResources` | Child resource ids or inline EnergyResource objects |
+| `parentResources` | Parent resource ids — e.g., the meter a DER sits behind |
 
-For **METER** entries:
-- `resourceId` = meter serial number (bare, no URI prefix)
-- `resourceAttributes` conforms to [MeterAttributes](../../EnergyResource/v2.0/attributes.yaml) — all fields optional: `meterType`, `gps`, `location`, `feeder`, `bus`
+## EnergyResource.attributes
 
-For **DER** entries (SOLAR, WIND, BATTERY, …):
-- `parentResources[]` lists the meter serial number(s) this DER sits behind
-- `ratedPowerKw`, `make`, `model` from the EnergyResource base class
-- Type-specific fields in `resourceAttributes` (e.g., `commissioningDate`, `storageType`)
+All non-topological fields go here.
+
+**CommonResourceAttributes** (all resource types):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model |
+| `ratedPowerKw` | number | Rated peak power, kW |
+| `energyCapacityKwh` | number | Stored-energy capacity, kWh (storage-class only) |
+| `telemetryProvider` | string | Vendor API / data source for telemetry |
+
+**METER-specific** (`type: METER`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
+| `gps` | string | `"lat,lng"` coordinates of the meter |
+| `location` | object | Postal location (beckn Location shape) |
+| `feeder` | string | Distribution feeder ID or name |
+| `bus` | string | Substation bus reference |
+
+**DER-specific examples** (open — any field can be added):
+
+| Field | Applies to | Description |
+|-------|-----------|-------------|
+| `commissioningDate` | SOLAR, WIND, BATTERY | Date the asset was commissioned |
+| `storageType` | BATTERY, BESS | LithiumIon, LeadAcid, FlowBattery, … |
+| `vin` | EV_CHARGER, EV_V2G | Vehicle identification number |
 
 ## ConsumptionProfile
 
-Administrative tariff and load data for a meter connection. Kept separate from `MeterAttributes` because tariff data is regulatory and changes independently of physical assets.
-
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `meterId` | string | Yes | Meter serial number — matches `resourceId` of a METER in `energyResources[]` |
+| `meterId` | string | Yes | Matches `id` of a METER entry in `energyResources[]` |
 | `sanctionedLoadKW` | number | Yes | Utility-approved load in kW |
-| `tariffCategoryCode` | string | Yes | Utility billing/tariff category code |
+| `tariffCategoryCode` | string | Yes | Billing/tariff category code |
 | `premisesType` | enum | No | Residential, Commercial, Industrial, Agricultural |
 | `connectionType` | enum | No | Single-phase, Three-phase |
 
@@ -85,7 +117,7 @@ Administrative tariff and load data for a meter connection. Kept separate from `
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `fullName` | string | Yes | Full name as per ID proof — **only here** |
+| `fullName` | string | Yes | Full name — **only here** |
 | `installationAddress` | object | Yes | Beckn Location shape |
 | `serviceConnectionDate` | date-time | Yes | Connection activation date (with timezone) |
 
@@ -102,7 +134,7 @@ Administrative tariff and load data for a meter connection. Kept separate from `
     "customerProfile": {
       "customerNumber": "UTIL-2025-001234567",
       "energyResources": [
-        {"resourceId": "MET2025789456123", "resourceType": "METER"}
+        {"id": "MET2025789456123", "type": "METER", "attributes": {"meterType": "AMI"}}
       ]
     }
   }
@@ -113,22 +145,17 @@ Administrative tariff and load data for a meter connection. Kept separate from `
 
 | v1.0 field | v1.1 location |
 |------------|---------------|
-| `customerProfile.meterNumber` | `energyResources[METER].resourceId` |
-| `customerProfile.meterType` | `energyResources[METER].resourceAttributes.meterType` |
+| `customerProfile.meterNumber` | `energyResources[METER].id` |
+| `customerProfile.meterType` | `energyResources[METER].attributes.meterType` |
 | `consumptionProfiles[].sanctionedLoadKW` | `consumptionProfiles[].sanctionedLoadKW` |
 | `consumptionProfiles[].tariffCategoryCode` | `consumptionProfiles[].tariffCategoryCode` |
-| `consumptionProfiles[].premisesType` | `consumptionProfiles[].premisesType` |
-| `consumptionProfiles[].connectionType` | `consumptionProfiles[].connectionType` |
-| `generationProfiles[].assetId` | `energyResources[DER].resourceId` |
-| `generationProfiles[].generationType` | `energyResources[DER].resourceType` (SOLAR, WIND, …) |
-| `generationProfiles[].capacityKW` | `energyResources[DER].ratedPowerKw` |
-| `generationProfiles[].manufacturer` | `energyResources[DER].make` |
-| `generationProfiles[].modelNumber` | `energyResources[DER].model` |
-| `storageProfiles[].storageCapacityKWh` | `energyResources[DER].energyCapacityKwh` |
-| `storageProfiles[].powerRatingKW` | `energyResources[DER].ratedPowerKw` |
-| `storageProfiles[].storageType` | `energyResources[DER].resourceAttributes.storageType` |
-| `fullName` (in each profile entry) | `customerDetails.fullName` (once, PII section) |
-| `consumerNumber` (in each profile entry) | `customerProfile.customerNumber` |
+| `generationProfiles[].assetId` | `energyResources[DER].id` |
+| `generationProfiles[].capacityKW` | `energyResources[DER].attributes.ratedPowerKw` |
+| `generationProfiles[].manufacturer` | `energyResources[DER].attributes.make` |
+| `generationProfiles[].commissioningDate` | `energyResources[DER].attributes.commissioningDate` |
+| `storageProfiles[].storageCapacityKWh` | `energyResources[DER].attributes.energyCapacityKwh` |
+| `storageProfiles[].storageType` | `energyResources[DER].attributes.storageType` |
+| `fullName` (duplicated per entry) | `customerDetails.fullName` (once) |
 
 ## Files
 
@@ -138,4 +165,6 @@ Administrative tariff and load data for a meter connection. Kept separate from `
 | `schema.json` | Bundled JSON Schema (draft 2020-12) — self-contained |
 | `context.jsonld` | JSON-LD context |
 | `vocab.jsonld` | RDF vocabulary |
-| `examples/example.json` | Full example: 1 meter + 2 generation + 2 storage DERs + 1 consumption profile |
+| `examples/example.json` | Single meter + 2 generation + 2 storage DERs |
+| `examples/example-submetering.json` | Building main meter + 2 tenant sub-meters |
+| `examples/example-parallel-metering.json` | Import meter + export meter (solar FIT) |

--- a/specification/schema/ElectricityCredential/v1.1/README.md
+++ b/specification/schema/ElectricityCredential/v1.1/README.md
@@ -12,7 +12,7 @@ credentialSubject
 │   ├── idRef                  (optional — external identity reference)
 │   ├── energyResources[]      (required — all physical assets, min 1)
 │   │   ├── id                 (meter serial number for METER; any stable id for DERs)
-│   │   ├── type               (METER, SOLAR, WIND, BATTERY, BESS, EV_CHARGER, …)
+│   │   ├── type               (enum: METER, DT, BUS, FEEDER, SOLAR, WIND, BATTERY, BESS, EV_CHARGER, …)
 │   │   ├── attributes         (open bag — all non-topological properties)
 │   │   │   ├── CommonResourceAttributes: make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
 │   │   │   └── type-specific: meterType, gps, location, feeder, bus / commissioningDate / storageType / …
@@ -66,7 +66,7 @@ A single `customerNumber` can span arbitrary asset topologies.
 | Field | Description |
 |-------|-------------|
 | `id` | Stable identifier. For METER: meter serial number. For DERs: any stable scheme. |
-| `type` | Open-string asset class: `METER`, `SOLAR`, `WIND`, `BATTERY`, `BESS`, `EV_CHARGER`, … |
+| `type` | Enum asset class. Grid: `METER`, `DT`, `BUS`, `FEEDER`. Generation: `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL`. Storage: `BATTERY`, `BESS`. Loads: `EV_CHARGER`, `EV_V2G`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`. System: `MICROGRID`. |
 | `attributes` | Open bag — all non-topological properties (see below) |
 | `subResources` | Child resource ids or inline EnergyResource objects |
 | `parentResources` | Parent resource ids — e.g., the meter a DER sits behind |

--- a/specification/schema/ElectricityCredential/v1.1/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.1/attributes.yaml
@@ -181,6 +181,12 @@ components:
           description: Sanctioned/approved electrical load in kilowatts (kW).
           x-jsonld:
             "@id": deg:sanctionedLoadKW
+        contractMaxDemandKw:
+          type: number
+          minimum: 0
+          description: Maximum demand contracted with the utility for this connection, in kW.
+          x-jsonld:
+            "@id": deg:contractMaxDemandKw
         tariffCategoryCode:
           type: string
           minLength: 1

--- a/specification/schema/ElectricityCredential/v1.1/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.1/attributes.yaml
@@ -6,43 +6,39 @@ info:
     Unified W3C Verifiable Credential (VC Data Model 2.0) issued per meter by
     electricity distribution utilities.
 
-    v1.1 design
-    ───────────
     customerProfile holds only non-PII utility identity: customerNumber (CA
     number), optional idRef, energyResources[], and consumptionProfiles[].
 
-    energyResources[] uses EnergyResource/v2.0 as the canonical asset class.
-    Multiple topologies are supported — a single customer number may have
-    multiple meters (different premises, sub-meters at one site) each with
-    their own child DERs linked via parentResources[].
+    energyResources[] uses EnergyResource/v2.0. Each entry has id, type,
+    and all attributes directly on the object — no attribute-bag wrapper.
+    Multiple topologies are supported: a single CA number may span multiple
+    meters (different premises, sub-meters, parallel meters) each with their
+    own child DERs linked via parentResources[].
 
-    consumptionProfiles[] is a lightweight array linking tariff/load
-    characteristics to a specific meter (via meterId = the meter's resourceId).
-
-    MeterAttributes (the resourceAttributes shape for resourceType = "METER")
-    is defined in EnergyResource/v2.0 and referenced here.
+    consumptionProfiles[] links tariff/load characteristics to a specific
+    meter via meterId (= that meter's id in energyResources[]).
 
     PII (fullName) is exclusively in customerDetails.
 
     v1.0 → v1.1 field mapping (nothing lost)
     ─────────────────────────────────────────
-    customerProfile.meterNumber       → EnergyResource.resourceId         (for METER entries)
-    customerProfile.meterType         → MeterAttributes.meterType
-    consumptionProfiles[].premisesType      → ConsumptionProfile.premisesType
-    consumptionProfiles[].connectionType    → ConsumptionProfile.connectionType
-    consumptionProfiles[].sanctionedLoadKW  → ConsumptionProfile.sanctionedLoadKW
-    consumptionProfiles[].tariffCategoryCode → ConsumptionProfile.tariffCategoryCode
-    generationProfiles[].generationType  → EnergyResource.resourceType   (SOLAR, WIND, …)
-    generationProfiles[].capacityKW      → EnergyResource.ratedPowerKw
-    generationProfiles[].manufacturer    → EnergyResource.make
-    generationProfiles[].modelNumber     → EnergyResource.model
-    generationProfiles[].assetId         → EnergyResource.resourceId
-    generationProfiles[].commissioningDate → EnergyResource.resourceAttributes.commissioningDate
-    storageProfiles[].storageCapacityKWh → EnergyResource.energyCapacityKwh
-    storageProfiles[].powerRatingKW      → EnergyResource.ratedPowerKw
-    storageProfiles[].storageType        → EnergyResource.resourceAttributes.storageType
-    storageProfiles[].assetId            → EnergyResource.resourceId
-    storageProfiles[].commissioningDate  → EnergyResource.resourceAttributes.commissioningDate
+    customerProfile.meterNumber        → energyResources[METER].id
+    customerProfile.meterType          → energyResources[METER].meterType
+    consumptionProfiles[].premisesType       → consumptionProfiles[].premisesType
+    consumptionProfiles[].connectionType     → consumptionProfiles[].connectionType
+    consumptionProfiles[].sanctionedLoadKW   → consumptionProfiles[].sanctionedLoadKW
+    consumptionProfiles[].tariffCategoryCode → consumptionProfiles[].tariffCategoryCode
+    generationProfiles[].assetId         → energyResources[DER].id
+    generationProfiles[].generationType  → energyResources[DER].type  (SOLAR, WIND, …)
+    generationProfiles[].capacityKW      → energyResources[DER].ratedPowerKw
+    generationProfiles[].manufacturer    → energyResources[DER].make
+    generationProfiles[].modelNumber     → energyResources[DER].model
+    generationProfiles[].commissioningDate → energyResources[DER].commissioningDate
+    storageProfiles[].assetId            → energyResources[DER].id
+    storageProfiles[].storageCapacityKWh → energyResources[DER].energyCapacityKwh
+    storageProfiles[].powerRatingKW      → energyResources[DER].ratedPowerKw
+    storageProfiles[].storageType        → energyResources[DER].storageType
+    storageProfiles[].commissioningDate  → energyResources[DER].commissioningDate
 
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 servers:
@@ -55,11 +51,10 @@ components:
     ElectricityCredential:
       $id: https://schema.beckn.io/ElectricityCredential/v1.1
       title: ElectricityCredential
-      description: >
-        Unified W3C Verifiable Credential issued per meter by electricity
-        distribution utilities. v1.1 consolidates all asset profiles into
-        customerProfile.energyResources[] via EnergyResource/v2.0, and
-        separates tariff characteristics into customerProfile.consumptionProfiles[].
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyCredential/v2.0"
       x-tags:
         - energy
         - credential
@@ -67,10 +62,6 @@ components:
         - electricity
         - customer
         - deg
-      type: object
-      additionalProperties: true
-      allOf:
-        - $ref: "https://schema.beckn.io/EnergyCredential/v2.0"
       x-jsonld:
         "@context": ./context.jsonld
         "@type": ElectricityCredential
@@ -96,16 +87,10 @@ components:
     CustomerProfile:
       type: object
       description: >
-        Non-PII utility customer identity and asset list. Contains only
-        the CA number (customerNumber), optional external identity reference
-        (idRef), all physical assets (energyResources[]), and tariff/load
-        profiles (consumptionProfiles[]). No PII — safe to share without
-        customerDetails.
-
-        Multiple topologies: a single customerNumber may have multiple METER
-        entries (different premises, or sub-meters at one premises). Each DER
-        (SOLAR, WIND, BATTERY, …) declares its parent meter via parentResources[].
-        Each ConsumptionProfile links to its meter via meterId.
+        Non-PII customer identity and asset list. No PII — safe to share
+        without customerDetails. Supports arbitrary topologies: a single
+        customerNumber may have multiple METER entries (different premises,
+        sub-meters, parallel meters) each with their own child DERs.
       required:
         - customerNumber
         - energyResources
@@ -120,7 +105,7 @@ components:
             "@id": deg:customerNumber
         idRef:
           type: object
-          description: External identity reference for the customer (e.g., government-issued ID).
+          description: External identity reference for the customer.
           required:
             - issuedBy
             - subjectId
@@ -144,13 +129,14 @@ components:
           minItems: 1
           description: >
             All physical energy assets for this customer account as
-            EnergyResource/v2.0 entries. For METER entries, resourceId is
-            the meter serial number (utility-assigned; no URI prefix).
+            EnergyResource/v2.0 entries. Each entry has id, type,
+            attributes (open bag), subResources, and parentResources.
+            For METER entries, id is the meter serial number; type-specific
+            fields (meterType, gps, feeder, bus) live in attributes.
             DERs (SOLAR, WIND, BATTERY, …) declare their parent meter via
-            parentResources[].
-
-            Supports arbitrary topologies: multiple meters at one premises,
-            meters across multiple premises, shared DERs, microgrids.
+            parentResources[]; their dimensioning and type-specific fields
+            (ratedPowerKw, commissioningDate, storageType, …) also live in
+            attributes.
           x-jsonld:
             "@id": deg:energyResources
           items:
@@ -159,11 +145,10 @@ components:
           type: array
           minItems: 1
           description: >
-            Tariff and load characteristics per meter connection. Each entry
-            links to a specific meter via meterId (= that meter's resourceId
-            in energyResources[]). Kept separate from MeterAttributes because
-            tariff data is administrative and may change independently of the
-            physical asset.
+            Tariff and load characteristics per meter connection. Each
+            entry links to a specific meter via meterId. Separate from
+            physical asset data because tariff data is administrative and
+            changes independently.
           x-jsonld:
             "@id": deg:consumptionProfiles
           items:
@@ -172,10 +157,8 @@ components:
     ConsumptionProfile:
       type: object
       description: >
-        Tariff and regulatory load profile for one meter connection. meterId
-        links this entry to a METER entry in energyResources[]. sanctionedLoadKW
-        and tariffCategoryCode are required; premisesType and connectionType
-        are optional.
+        Tariff and regulatory load profile for one meter connection.
+        meterId links to a METER entry's id in energyResources[].
       required:
         - meterId
         - sanctionedLoadKW
@@ -187,8 +170,8 @@ components:
           type: string
           minLength: 1
           description: >
-            Meter serial number. Matches the resourceId of a METER entry
-            in customerProfile.energyResources[].
+            Meter identifier — matches the id of a METER entry in
+            customerProfile.energyResources[].
           x-jsonld:
             "@id": deg:meterId
         sanctionedLoadKW:
@@ -211,7 +194,6 @@ components:
             - Commercial
             - Industrial
             - Agricultural
-          description: Type of premises for this connection. Optional.
           x-jsonld:
             "@id": deg:premisesType
         connectionType:
@@ -219,7 +201,6 @@ components:
           enum:
             - Single-phase
             - Three-phase
-          description: Type of electrical connection. Optional.
           x-jsonld:
             "@id": deg:connectionType
 
@@ -227,8 +208,7 @@ components:
       type: object
       description: >
         PII section. fullName appears ONLY here — never in customerProfile
-        or any resource entry. Kept separate from customerProfile to allow
-        PII-stripped presentation of the credential.
+        or any resource entry.
       required:
         - fullName
         - installationAddress
@@ -247,15 +227,13 @@ components:
             - area_code
             - country
           properties:
-            address:
-              type: string
+            address: { type: string }
             city:
               type: object
               properties:
                 name: { type: string }
                 code: { type: string }
-            district:
-              type: string
+            district: { type: string }
             state:
               type: object
               properties:
@@ -269,16 +247,12 @@ components:
                 code:
                   type: string
                   pattern: "^[A-Z]{2}$"
-                  description: ISO 3166-1 alpha-2 country code.
-            area_code:
-              type: string
+            area_code: { type: string }
             gps:
               type: string
-              description: "GPS coordinates as 'lat,lng' string."
-            openLocationCode:
-              type: string
-              description: Open Location Code (OLC) for the installation.
+              description: "GPS coordinates as 'lat,lng'."
+            openLocationCode: { type: string }
         serviceConnectionDate:
           type: string
           format: date-time
-          description: Date and time the electricity connection was activated (with timezone offset).
+          description: Date and time the connection was activated (with timezone offset).

--- a/specification/schema/ElectricityCredential/v1.1/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.1/attributes.yaml
@@ -1,0 +1,284 @@
+openapi: 3.1.1
+info:
+  title: ElectricityCredential
+  version: 1.1.0
+  description: >
+    Unified W3C Verifiable Credential (VC Data Model 2.0) issued per meter by
+    electricity distribution utilities.
+
+    v1.1 design
+    ───────────
+    customerProfile holds only non-PII utility identity: customerNumber (CA
+    number), optional idRef, energyResources[], and consumptionProfiles[].
+
+    energyResources[] uses EnergyResource/v2.0 as the canonical asset class.
+    Multiple topologies are supported — a single customer number may have
+    multiple meters (different premises, sub-meters at one site) each with
+    their own child DERs linked via parentResources[].
+
+    consumptionProfiles[] is a lightweight array linking tariff/load
+    characteristics to a specific meter (via meterId = the meter's resourceId).
+
+    MeterAttributes (the resourceAttributes shape for resourceType = "METER")
+    is defined in EnergyResource/v2.0 and referenced here.
+
+    PII (fullName) is exclusively in customerDetails.
+
+    v1.0 → v1.1 field mapping (nothing lost)
+    ─────────────────────────────────────────
+    customerProfile.meterNumber       → EnergyResource.resourceId         (for METER entries)
+    customerProfile.meterType         → MeterAttributes.meterType
+    consumptionProfiles[].premisesType      → ConsumptionProfile.premisesType
+    consumptionProfiles[].connectionType    → ConsumptionProfile.connectionType
+    consumptionProfiles[].sanctionedLoadKW  → ConsumptionProfile.sanctionedLoadKW
+    consumptionProfiles[].tariffCategoryCode → ConsumptionProfile.tariffCategoryCode
+    generationProfiles[].generationType  → EnergyResource.resourceType   (SOLAR, WIND, …)
+    generationProfiles[].capacityKW      → EnergyResource.ratedPowerKw
+    generationProfiles[].manufacturer    → EnergyResource.make
+    generationProfiles[].modelNumber     → EnergyResource.model
+    generationProfiles[].assetId         → EnergyResource.resourceId
+    generationProfiles[].commissioningDate → EnergyResource.resourceAttributes.commissioningDate
+    storageProfiles[].storageCapacityKWh → EnergyResource.energyCapacityKwh
+    storageProfiles[].powerRatingKW      → EnergyResource.ratedPowerKw
+    storageProfiles[].storageType        → EnergyResource.resourceAttributes.storageType
+    storageProfiles[].assetId            → EnergyResource.resourceId
+    storageProfiles[].commissioningDate  → EnergyResource.resourceAttributes.commissioningDate
+
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+servers:
+  - url: https://schema.beckn.io
+    description: Canonical schema registry
+paths: {}
+components:
+  schemas:
+
+    ElectricityCredential:
+      $id: https://schema.beckn.io/ElectricityCredential/v1.1
+      title: ElectricityCredential
+      description: >
+        Unified W3C Verifiable Credential issued per meter by electricity
+        distribution utilities. v1.1 consolidates all asset profiles into
+        customerProfile.energyResources[] via EnergyResource/v2.0, and
+        separates tariff characteristics into customerProfile.consumptionProfiles[].
+      x-tags:
+        - energy
+        - credential
+        - verifiable-credential
+        - electricity
+        - customer
+        - deg
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyCredential/v2.0"
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": ElectricityCredential
+      properties:
+        credentialSubject:
+          type: object
+          required:
+            - customerProfile
+          x-jsonld:
+            "@id": deg:credentialSubject
+          properties:
+            id:
+              type: string
+              format: uri
+              description: Optional DID of the customer/credential subject.
+              x-jsonld:
+                "@id": "@id"
+            customerProfile:
+              $ref: "#/components/schemas/CustomerProfile"
+            customerDetails:
+              $ref: "#/components/schemas/CustomerDetails"
+
+    CustomerProfile:
+      type: object
+      description: >
+        Non-PII utility customer identity and asset list. Contains only
+        the CA number (customerNumber), optional external identity reference
+        (idRef), all physical assets (energyResources[]), and tariff/load
+        profiles (consumptionProfiles[]). No PII — safe to share without
+        customerDetails.
+
+        Multiple topologies: a single customerNumber may have multiple METER
+        entries (different premises, or sub-meters at one premises). Each DER
+        (SOLAR, WIND, BATTERY, …) declares its parent meter via parentResources[].
+        Each ConsumptionProfile links to its meter via meterId.
+      required:
+        - customerNumber
+        - energyResources
+      x-jsonld:
+        "@id": deg:customerProfile
+      properties:
+        customerNumber:
+          type: string
+          minLength: 1
+          description: Utility customer account number (CA number).
+          x-jsonld:
+            "@id": deg:customerNumber
+        idRef:
+          type: object
+          description: External identity reference for the customer (e.g., government-issued ID).
+          required:
+            - issuedBy
+            - subjectId
+          x-jsonld:
+            "@id": deg:idRef
+          properties:
+            issuedBy:
+              type: string
+              format: uri
+              description: DID of the authority that issued the identity.
+              x-jsonld:
+                "@id": deg:issuedBy
+            subjectId:
+              type: string
+              pattern: "^[A-Za-z0-9._-]+:[A-Za-z0-9X_-]+$"
+              description: Subject identifier in authority-domain:id-value format.
+              x-jsonld:
+                "@id": deg:subjectId
+        energyResources:
+          type: array
+          minItems: 1
+          description: >
+            All physical energy assets for this customer account as
+            EnergyResource/v2.0 entries. For METER entries, resourceId is
+            the meter serial number (utility-assigned; no URI prefix).
+            DERs (SOLAR, WIND, BATTERY, …) declare their parent meter via
+            parentResources[].
+
+            Supports arbitrary topologies: multiple meters at one premises,
+            meters across multiple premises, shared DERs, microgrids.
+          x-jsonld:
+            "@id": deg:energyResources
+          items:
+            $ref: "https://schema.beckn.io/EnergyResource/v2.0#/components/schemas/EnergyResource"
+        consumptionProfiles:
+          type: array
+          minItems: 1
+          description: >
+            Tariff and load characteristics per meter connection. Each entry
+            links to a specific meter via meterId (= that meter's resourceId
+            in energyResources[]). Kept separate from MeterAttributes because
+            tariff data is administrative and may change independently of the
+            physical asset.
+          x-jsonld:
+            "@id": deg:consumptionProfiles
+          items:
+            $ref: "#/components/schemas/ConsumptionProfile"
+
+    ConsumptionProfile:
+      type: object
+      description: >
+        Tariff and regulatory load profile for one meter connection. meterId
+        links this entry to a METER entry in energyResources[]. sanctionedLoadKW
+        and tariffCategoryCode are required; premisesType and connectionType
+        are optional.
+      required:
+        - meterId
+        - sanctionedLoadKW
+        - tariffCategoryCode
+      x-jsonld:
+        "@id": deg:ConsumptionProfile
+      properties:
+        meterId:
+          type: string
+          minLength: 1
+          description: >
+            Meter serial number. Matches the resourceId of a METER entry
+            in customerProfile.energyResources[].
+          x-jsonld:
+            "@id": deg:meterId
+        sanctionedLoadKW:
+          type: number
+          minimum: 0.5
+          maximum: 10000
+          description: Sanctioned/approved electrical load in kilowatts (kW).
+          x-jsonld:
+            "@id": deg:sanctionedLoadKW
+        tariffCategoryCode:
+          type: string
+          minLength: 1
+          description: Billing/tariff category code assigned by the utility.
+          x-jsonld:
+            "@id": deg:tariffCategoryCode
+        premisesType:
+          type: string
+          enum:
+            - Residential
+            - Commercial
+            - Industrial
+            - Agricultural
+          description: Type of premises for this connection. Optional.
+          x-jsonld:
+            "@id": deg:premisesType
+        connectionType:
+          type: string
+          enum:
+            - Single-phase
+            - Three-phase
+          description: Type of electrical connection. Optional.
+          x-jsonld:
+            "@id": deg:connectionType
+
+    CustomerDetails:
+      type: object
+      description: >
+        PII section. fullName appears ONLY here — never in customerProfile
+        or any resource entry. Kept separate from customerProfile to allow
+        PII-stripped presentation of the credential.
+      required:
+        - fullName
+        - installationAddress
+        - serviceConnectionDate
+      x-jsonld:
+        "@id": deg:customerDetails
+      properties:
+        fullName:
+          type: string
+          description: Full name of the customer as per ID proof.
+        installationAddress:
+          type: object
+          description: Physical location of the installation. Follows the beckn Location schema.
+          required:
+            - address
+            - area_code
+            - country
+          properties:
+            address:
+              type: string
+            city:
+              type: object
+              properties:
+                name: { type: string }
+                code: { type: string }
+            district:
+              type: string
+            state:
+              type: object
+              properties:
+                name: { type: string }
+                code: { type: string }
+            country:
+              type: object
+              required: [code]
+              properties:
+                name: { type: string }
+                code:
+                  type: string
+                  pattern: "^[A-Z]{2}$"
+                  description: ISO 3166-1 alpha-2 country code.
+            area_code:
+              type: string
+            gps:
+              type: string
+              description: "GPS coordinates as 'lat,lng' string."
+            openLocationCode:
+              type: string
+              description: Open Location Code (OLC) for the installation.
+        serviceConnectionDate:
+          type: string
+          format: date-time
+          description: Date and time the electricity connection was activated (with timezone offset).

--- a/specification/schema/ElectricityCredential/v1.1/context.jsonld
+++ b/specification/schema/ElectricityCredential/v1.1/context.jsonld
@@ -1,0 +1,160 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "schema": "https://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "deg": "https://schema.beckn.io/deg#",
+        "erDeg": "https://schema.beckn.io/deg/EnergyResource/v2.0/",
+        "ElectricityCredential": {
+            "@id": "deg:ElectricityCredential",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type"
+            }
+        },
+        "customerProfile": {
+            "@id": "deg:customerProfile",
+            "@type": "@id",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "customerNumber": { "@id": "deg:customerNumber", "@type": "xsd:string" },
+                "idRef": {
+                    "@id": "deg:idRef",
+                    "@type": "@id",
+                    "@context": {
+                        "issuedBy": { "@id": "deg:issuedBy", "@type": "@id" },
+                        "subjectId": { "@id": "deg:subjectId", "@type": "xsd:string" }
+                    }
+                },
+                "energyResources": {
+                    "@id": "deg:energyResources",
+                    "@type": "@id",
+                    "@container": "@set",
+                    "@context": {
+                        "@version": 1.1,
+                        "@protected": true,
+                        "resourceId":        { "@id": "erDeg:resourceId",        "@type": "xsd:string"  },
+                        "resourceType":      { "@id": "erDeg:resourceType",      "@type": "xsd:string"  },
+                        "make":              { "@id": "erDeg:make",              "@type": "xsd:string"  },
+                        "model":             { "@id": "erDeg:model",             "@type": "xsd:string"  },
+                        "ratedPowerKw":      { "@id": "erDeg:ratedPowerKw",      "@type": "xsd:decimal" },
+                        "energyCapacityKwh": { "@id": "erDeg:energyCapacityKwh", "@type": "xsd:decimal" },
+                        "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string"  },
+                        "resourceAttributes":{ "@id": "erDeg:resourceAttributes", "@container": "@graph" },
+                        "subResources":      { "@id": "erDeg:subResources",      "@container": "@list"  },
+                        "parentResources":   { "@id": "erDeg:parentResources",   "@container": "@list"  },
+                        "meterType":         { "@id": "erDeg:meterType",         "@type": "xsd:string"  },
+                        "meterGps":          { "@id": "erDeg:meterGps",          "@type": "xsd:string"  },
+                        "meterLocation":     { "@id": "erDeg:meterLocation",     "@type": "@id"         },
+                        "feeder":            { "@id": "erDeg:feeder",            "@type": "xsd:string"  },
+                        "bus":               { "@id": "erDeg:bus",               "@type": "xsd:string"  },
+                        "storageType":       { "@id": "deg:storageType",         "@type": "xsd:string"  },
+                        "commissioningDate": { "@id": "deg:commissioningDate",   "@type": "xsd:string"  }
+                    }
+                },
+                "consumptionProfiles": {
+                    "@id": "deg:consumptionProfiles",
+                    "@type": "@id",
+                    "@container": "@set",
+                    "@context": {
+                        "@version": 1.1,
+                        "@protected": true,
+                        "meterId":            { "@id": "deg:meterId",            "@type": "xsd:string"  },
+                        "sanctionedLoadKW":   { "@id": "deg:sanctionedLoadKW",   "@type": "xsd:decimal" },
+                        "tariffCategoryCode": { "@id": "deg:tariffCategoryCode", "@type": "xsd:string"  },
+                        "premisesType":       { "@id": "deg:premisesType",       "@type": "xsd:string"  },
+                        "connectionType":     { "@id": "deg:connectionType",     "@type": "xsd:string"  }
+                    }
+                }
+            }
+        },
+        "customerDetails": {
+            "@id": "deg:customerDetails",
+            "@type": "@id",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "fullName": {
+                    "@id": "schema:name",
+                    "@type": "xsd:string"
+                },
+                "serviceConnectionDate": {
+                    "@id": "deg:serviceConnectionDate",
+                    "@type": "xsd:dateTime"
+                },
+                "installationAddress": {
+                    "@id": "beckn:Location",
+                    "@type": "@id",
+                    "@context": {
+                        "beckn": "https://schema.beckn.io/",
+                        "descriptor": {
+                            "@id": "beckn:descriptor",
+                            "@type": "@id",
+                            "@context": {
+                                "name":       { "@id": "beckn:name",       "@type": "xsd:string" },
+                                "code":       { "@id": "beckn:code",       "@type": "xsd:string" },
+                                "short_desc": { "@id": "beckn:short_desc", "@type": "xsd:string" },
+                                "long_desc":  { "@id": "beckn:long_desc",  "@type": "xsd:string" }
+                            }
+                        },
+                        "map_url":  { "@id": "beckn:map_url",  "@type": "@id"        },
+                        "gps":      { "@id": "beckn:gps",      "@type": "xsd:string" },
+                        "address":  { "@id": "beckn:address",  "@type": "xsd:string" },
+                        "city": {
+                            "@id": "beckn:city",
+                            "@type": "@id",
+                            "@context": {
+                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
+                                "code": { "@id": "beckn:code", "@type": "xsd:string" }
+                            }
+                        },
+                        "district": { "@id": "beckn:district", "@type": "xsd:string" },
+                        "state": {
+                            "@id": "beckn:state",
+                            "@type": "@id",
+                            "@context": {
+                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
+                                "code": { "@id": "beckn:code", "@type": "xsd:string" }
+                            }
+                        },
+                        "country": {
+                            "@id": "beckn:country",
+                            "@type": "@id",
+                            "@context": {
+                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
+                                "code": { "@id": "beckn:code", "@type": "xsd:string" }
+                            }
+                        },
+                        "area_code":        { "@id": "beckn:area_code",        "@type": "xsd:string" },
+                        "circle": {
+                            "@id": "beckn:circle",
+                            "@type": "@id",
+                            "@context": {
+                                "gps":    { "@id": "beckn:gps",    "@type": "xsd:string" },
+                                "radius": { "@id": "beckn:radius", "@type": "@id"        }
+                            }
+                        },
+                        "polygon":          { "@id": "beckn:polygon",          "@type": "xsd:string" },
+                        "3dspace":          { "@id": "beckn:3dspace",          "@type": "xsd:string" },
+                        "rating":           { "@id": "beckn:rating",           "@type": "xsd:string" },
+                        "openLocationCode": { "@id": "deg:openLocationCode",   "@type": "xsd:string" }
+                    }
+                }
+            }
+        },
+        "credentialStatus": {
+            "@id": "deg:credentialStatus",
+            "@type": "@id",
+            "@context": {
+                "statusPurpose":        { "@id": "deg:statusPurpose",        "@type": "xsd:string" },
+                "statusListCredential": { "@id": "deg:statusListCredential", "@type": "@id"        }
+            }
+        }
+    }
+}

--- a/specification/schema/ElectricityCredential/v1.1/context.jsonld
+++ b/specification/schema/ElectricityCredential/v1.1/context.jsonld
@@ -39,23 +39,28 @@
                     "@context": {
                         "@version": 1.1,
                         "@protected": true,
-                        "resourceId":        { "@id": "erDeg:resourceId",        "@type": "xsd:string"  },
-                        "resourceType":      { "@id": "erDeg:resourceType",      "@type": "xsd:string"  },
-                        "make":              { "@id": "erDeg:make",              "@type": "xsd:string"  },
-                        "model":             { "@id": "erDeg:model",             "@type": "xsd:string"  },
-                        "ratedPowerKw":      { "@id": "erDeg:ratedPowerKw",      "@type": "xsd:decimal" },
-                        "energyCapacityKwh": { "@id": "erDeg:energyCapacityKwh", "@type": "xsd:decimal" },
-                        "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string"  },
-                        "resourceAttributes":{ "@id": "erDeg:resourceAttributes", "@container": "@graph" },
-                        "subResources":      { "@id": "erDeg:subResources",      "@container": "@list"  },
-                        "parentResources":   { "@id": "erDeg:parentResources",   "@container": "@list"  },
-                        "meterType":         { "@id": "erDeg:meterType",         "@type": "xsd:string"  },
-                        "meterGps":          { "@id": "erDeg:meterGps",          "@type": "xsd:string"  },
-                        "meterLocation":     { "@id": "erDeg:meterLocation",     "@type": "@id"         },
-                        "feeder":            { "@id": "erDeg:feeder",            "@type": "xsd:string"  },
-                        "bus":               { "@id": "erDeg:bus",               "@type": "xsd:string"  },
-                        "storageType":       { "@id": "deg:storageType",         "@type": "xsd:string"  },
-                        "commissioningDate": { "@id": "deg:commissioningDate",   "@type": "xsd:string"  }
+                        "id":              "@id",
+                        "type":            { "@id": "erDeg:resourceType", "@type": "xsd:string" },
+                        "attributes": {
+                            "@id": "erDeg:attributes",
+                            "@type": "@id",
+                            "@context": {
+                                "make":              { "@id": "erDeg:make",              "@type": "xsd:string"  },
+                                "model":             { "@id": "erDeg:model",             "@type": "xsd:string"  },
+                                "ratedPowerKw":      { "@id": "erDeg:ratedPowerKw",      "@type": "xsd:decimal" },
+                                "energyCapacityKwh": { "@id": "erDeg:energyCapacityKwh", "@type": "xsd:decimal" },
+                                "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string"  },
+                                "meterType":         { "@id": "erDeg:meterType",         "@type": "xsd:string"  },
+                                "gps":               { "@id": "erDeg:gps",               "@type": "xsd:string"  },
+                                "meterLocation":     { "@id": "erDeg:meterLocation",     "@type": "@id"         },
+                                "feeder":            { "@id": "erDeg:feeder",            "@type": "xsd:string"  },
+                                "bus":               { "@id": "erDeg:bus",               "@type": "xsd:string"  },
+                                "commissioningDate": { "@id": "deg:commissioningDate",   "@type": "xsd:string"  },
+                                "storageType":       { "@id": "deg:storageType",         "@type": "xsd:string"  }
+                            }
+                        },
+                        "subResources":    { "@id": "erDeg:subResources",    "@container": "@list" },
+                        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
                     }
                 },
                 "consumptionProfiles": {
@@ -80,25 +85,18 @@
             "@context": {
                 "@version": 1.1,
                 "@protected": true,
-                "fullName": {
-                    "@id": "schema:name",
-                    "@type": "xsd:string"
-                },
-                "serviceConnectionDate": {
-                    "@id": "deg:serviceConnectionDate",
-                    "@type": "xsd:dateTime"
-                },
+                "fullName": { "@id": "schema:name", "@type": "xsd:string" },
+                "serviceConnectionDate": { "@id": "deg:serviceConnectionDate", "@type": "xsd:dateTime" },
                 "installationAddress": {
                     "@id": "beckn:Location",
                     "@type": "@id",
                     "@context": {
                         "beckn": "https://schema.beckn.io/",
                         "descriptor": {
-                            "@id": "beckn:descriptor",
-                            "@type": "@id",
+                            "@id": "beckn:descriptor", "@type": "@id",
                             "@context": {
-                                "name":       { "@id": "beckn:name",       "@type": "xsd:string" },
-                                "code":       { "@id": "beckn:code",       "@type": "xsd:string" },
+                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
+                                "code": { "@id": "beckn:code", "@type": "xsd:string" },
                                 "short_desc": { "@id": "beckn:short_desc", "@type": "xsd:string" },
                                 "long_desc":  { "@id": "beckn:long_desc",  "@type": "xsd:string" }
                             }
@@ -106,40 +104,12 @@
                         "map_url":  { "@id": "beckn:map_url",  "@type": "@id"        },
                         "gps":      { "@id": "beckn:gps",      "@type": "xsd:string" },
                         "address":  { "@id": "beckn:address",  "@type": "xsd:string" },
-                        "city": {
-                            "@id": "beckn:city",
-                            "@type": "@id",
-                            "@context": {
-                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
-                                "code": { "@id": "beckn:code", "@type": "xsd:string" }
-                            }
-                        },
+                        "city":     { "@id": "beckn:city", "@type": "@id", "@context": { "name": { "@id": "beckn:name", "@type": "xsd:string" }, "code": { "@id": "beckn:code", "@type": "xsd:string" } } },
                         "district": { "@id": "beckn:district", "@type": "xsd:string" },
-                        "state": {
-                            "@id": "beckn:state",
-                            "@type": "@id",
-                            "@context": {
-                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
-                                "code": { "@id": "beckn:code", "@type": "xsd:string" }
-                            }
-                        },
-                        "country": {
-                            "@id": "beckn:country",
-                            "@type": "@id",
-                            "@context": {
-                                "name": { "@id": "beckn:name", "@type": "xsd:string" },
-                                "code": { "@id": "beckn:code", "@type": "xsd:string" }
-                            }
-                        },
+                        "state":    { "@id": "beckn:state", "@type": "@id", "@context": { "name": { "@id": "beckn:name", "@type": "xsd:string" }, "code": { "@id": "beckn:code", "@type": "xsd:string" } } },
+                        "country":  { "@id": "beckn:country", "@type": "@id", "@context": { "name": { "@id": "beckn:name", "@type": "xsd:string" }, "code": { "@id": "beckn:code", "@type": "xsd:string" } } },
                         "area_code":        { "@id": "beckn:area_code",        "@type": "xsd:string" },
-                        "circle": {
-                            "@id": "beckn:circle",
-                            "@type": "@id",
-                            "@context": {
-                                "gps":    { "@id": "beckn:gps",    "@type": "xsd:string" },
-                                "radius": { "@id": "beckn:radius", "@type": "@id"        }
-                            }
-                        },
+                        "circle":           { "@id": "beckn:circle", "@type": "@id", "@context": { "gps": { "@id": "beckn:gps", "@type": "xsd:string" }, "radius": { "@id": "beckn:radius", "@type": "@id" } } },
                         "polygon":          { "@id": "beckn:polygon",          "@type": "xsd:string" },
                         "3dspace":          { "@id": "beckn:3dspace",          "@type": "xsd:string" },
                         "rating":           { "@id": "beckn:rating",           "@type": "xsd:string" },

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
@@ -43,6 +43,7 @@
         {
           "meterId": "MET-IMPORT-001",
           "sanctionedLoadKW": 10,
+          "contractMaxDemandKw": 8,
           "tariffCategoryCode": "DS-I",
           "premisesType": "Residential",
           "connectionType": "Single-phase"

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
@@ -24,7 +24,8 @@
         {
           "id": "MET-IMPORT-001",
           "type": "METER",
-          "attributes": {"meterType": "AMI", "gps": "28.6139,77.2090", "feeder": "DEL-SB-F08", "bus": "BUS-33kV-012"}
+          "attributes": {"meterType": "AMI", "gps": "28.6139,77.2090"},
+          "parentResources": ["DEL-SB-F08"]
         },
         {
           "id": "MET-EXPORT-001",

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Parallel metering topology: two meters installed at the same premises serving distinct measurement purposes. MET-IMPORT-001 (Forward/AMI) measures grid consumption; MET-EXPORT-001 (Reverse) measures gross solar export under a feed-in tariff arrangement. Both meters are siblings — neither is a parent of the other. Solar DER hangs behind the export meter. Consumption profile links to the import meter; export meter carries its own tariff code.",
+  "_comment": "Parallel metering: two meters at the same premises. MET-IMPORT-001 (Forward/AMI) measures grid consumption; MET-EXPORT-001 (Reverse) measures gross solar export under a feed-in tariff. Both meters are siblings. Solar DER hangs behind the export meter. Each meter has its own consumption profile.",
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://schema.org/",
@@ -22,30 +22,19 @@
       "customerNumber": "TPDDL-2025-00987654",
       "energyResources": [
         {
-          "resourceId": "MET-IMPORT-001",
-          "resourceType": "METER",
-          "resourceAttributes": {
-            "meterType": "AMI",
-            "gps": "28.6139,77.2090",
-            "feeder": "DEL-SB-F08",
-            "bus": "BUS-33kV-012"
-          }
+          "id": "MET-IMPORT-001",
+          "type": "METER",
+          "attributes": {"meterType": "AMI", "gps": "28.6139,77.2090", "feeder": "DEL-SB-F08", "bus": "BUS-33kV-012"}
         },
         {
-          "resourceId": "MET-EXPORT-001",
-          "resourceType": "METER",
-          "resourceAttributes": {
-            "meterType": "Reverse",
-            "gps": "28.6139,77.2090"
-          }
+          "id": "MET-EXPORT-001",
+          "type": "METER",
+          "attributes": {"meterType": "Reverse", "gps": "28.6139,77.2090"}
         },
         {
-          "resourceId": "der://solar/ROOFTOP-SOLAR-001",
-          "resourceType": "SOLAR",
-          "ratedPowerKw": 5,
-          "make": "Adani Solar",
-          "model": "ASPM-400M",
-          "resourceAttributes": {"commissioningDate": "2025-02-10"},
+          "id": "ROOFTOP-SOLAR-001",
+          "type": "SOLAR",
+          "attributes": {"ratedPowerKw": 5, "make": "Adani Solar", "model": "ASPM-400M", "commissioningDate": "2025-02-10"},
           "parentResources": ["MET-EXPORT-001"]
         }
       ],

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-parallel-metering.json
@@ -1,0 +1,87 @@
+{
+  "_comment": "Parallel metering topology: two meters installed at the same premises serving distinct measurement purposes. MET-IMPORT-001 (Forward/AMI) measures grid consumption; MET-EXPORT-001 (Reverse) measures gross solar export under a feed-in tariff arrangement. Both meters are siblings — neither is a parent of the other. Solar DER hangs behind the export meter. Consumption profile links to the import meter; export meter carries its own tariff code.",
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://schema.org/",
+    "https://schema.beckn.io/Location/2.0/context.jsonld",
+    "https://schema.beckn.io/ElectricityCredential/v1.1/context.jsonld",
+    "https://schema.beckn.io/EnergyResource/v2.0/context.jsonld"
+  ],
+  "id": "urn:uuid:b2c3d4e5-0000-0000-0000-aabbccdd0001",
+  "type": ["VerifiableCredential", "ElectricityCredential"],
+  "issuer": {
+    "id": "did:web:tpddl.delhi.gov.in",
+    "name": "TPDDL - Tata Power Delhi Distribution Ltd",
+    "idRef": {"issuedBy": "did:web:derc.delhi.gov.in", "subjectId": "derc.delhi.gov.in:TPDDL-REG-0042"}
+  },
+  "validFrom": "2025-03-01T00:00:00+05:30",
+  "validUntil": "2026-03-01T00:00:00+05:30",
+  "credentialSubject": {
+    "id": "did:example:customer:delhi-solar-001",
+    "customerProfile": {
+      "customerNumber": "TPDDL-2025-00987654",
+      "energyResources": [
+        {
+          "resourceId": "MET-IMPORT-001",
+          "resourceType": "METER",
+          "resourceAttributes": {
+            "meterType": "AMI",
+            "gps": "28.6139,77.2090",
+            "feeder": "DEL-SB-F08",
+            "bus": "BUS-33kV-012"
+          }
+        },
+        {
+          "resourceId": "MET-EXPORT-001",
+          "resourceType": "METER",
+          "resourceAttributes": {
+            "meterType": "Reverse",
+            "gps": "28.6139,77.2090"
+          }
+        },
+        {
+          "resourceId": "der://solar/ROOFTOP-SOLAR-001",
+          "resourceType": "SOLAR",
+          "ratedPowerKw": 5,
+          "make": "Adani Solar",
+          "model": "ASPM-400M",
+          "resourceAttributes": {"commissioningDate": "2025-02-10"},
+          "parentResources": ["MET-EXPORT-001"]
+        }
+      ],
+      "consumptionProfiles": [
+        {
+          "meterId": "MET-IMPORT-001",
+          "sanctionedLoadKW": 10,
+          "tariffCategoryCode": "DS-I",
+          "premisesType": "Residential",
+          "connectionType": "Single-phase"
+        },
+        {
+          "meterId": "MET-EXPORT-001",
+          "sanctionedLoadKW": 5,
+          "tariffCategoryCode": "FIT-SOLAR-01"
+        }
+      ]
+    },
+    "customerDetails": {
+      "fullName": "Arjun Mehra",
+      "installationAddress": {
+        "address": "45 Rohini Sector 9",
+        "city": {"name": "Delhi", "code": "DEL"},
+        "state": {"name": "Delhi", "code": "DL"},
+        "country": {"name": "India", "code": "IN"},
+        "area_code": "110085",
+        "gps": "28.6139,77.2090"
+      },
+      "serviceConnectionDate": "2018-07-15T00:00:00+05:30"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2025-03-01T00:00:00+05:30",
+    "verificationMethod": "did:web:tpddl.delhi.gov.in#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTaXoT..."
+  }
+}

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
@@ -50,6 +50,7 @@
         {
           "meterId": "MET-UNIT-101",
           "sanctionedLoadKW": 3,
+          "contractMaxDemandKw": 2.5,
           "tariffCategoryCode": "LT-2A",
           "premisesType": "Residential",
           "connectionType": "Single-phase"
@@ -57,6 +58,7 @@
         {
           "meterId": "MET-UNIT-102",
           "sanctionedLoadKW": 3,
+          "contractMaxDemandKw": 2.5,
           "tariffCategoryCode": "LT-2A",
           "premisesType": "Residential",
           "connectionType": "Single-phase"

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
@@ -1,0 +1,100 @@
+{
+  "_comment": "Submetering topology: apartment building with one utility main meter (MET-BLDG-001) and two tenant sub-meters (MET-UNIT-101, MET-UNIT-102). Sub-meters declare parentResources → main meter. Tenant 101 has a rooftop solar DER behind their sub-meter. Each sub-meter has its own consumption profile with its own tariff.",
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://schema.org/",
+    "https://schema.beckn.io/Location/2.0/context.jsonld",
+    "https://schema.beckn.io/ElectricityCredential/v1.1/context.jsonld",
+    "https://schema.beckn.io/EnergyResource/v2.0/context.jsonld"
+  ],
+  "id": "urn:uuid:a1b2c3d4-0000-0000-0000-111122223333",
+  "type": ["VerifiableCredential", "ElectricityCredential"],
+  "issuer": {
+    "id": "did:web:bescom.karnataka.gov.in",
+    "name": "BESCOM - Bangalore Electricity Supply Company",
+    "idRef": {"issuedBy": "did:web:kerc.karnataka.gov.in", "subjectId": "kerc.karnataka.gov.in:AABPC12345"}
+  },
+  "validFrom": "2025-01-13T10:30:00+05:30",
+  "validUntil": "2026-01-13T10:30:00+05:30",
+  "credentialSubject": {
+    "id": "did:example:customer:building-owner-001",
+    "customerProfile": {
+      "customerNumber": "BESCOM-2025-BLDG-001",
+      "energyResources": [
+        {
+          "resourceId": "MET-BLDG-001",
+          "resourceType": "METER",
+          "resourceAttributes": {
+            "meterType": "AMI",
+            "gps": "12.9716,77.5946",
+            "feeder": "BAN-NR-F22",
+            "bus": "BUS-11kV-007"
+          }
+        },
+        {
+          "resourceId": "MET-UNIT-101",
+          "resourceType": "METER",
+          "resourceAttributes": {
+            "meterType": "AMR",
+            "gps": "12.9716,77.5946"
+          },
+          "parentResources": ["MET-BLDG-001"]
+        },
+        {
+          "resourceId": "MET-UNIT-102",
+          "resourceType": "METER",
+          "resourceAttributes": {
+            "meterType": "AMR",
+            "gps": "12.9716,77.5946"
+          },
+          "parentResources": ["MET-BLDG-001"]
+        },
+        {
+          "resourceId": "der://solar/ROOFTOP-UNIT-101",
+          "resourceType": "SOLAR",
+          "ratedPowerKw": 2,
+          "make": "Waaree",
+          "model": "WS-200",
+          "resourceAttributes": {"commissioningDate": "2024-06-15"},
+          "parentResources": ["MET-UNIT-101"]
+        }
+      ],
+      "consumptionProfiles": [
+        {
+          "meterId": "MET-UNIT-101",
+          "sanctionedLoadKW": 3,
+          "tariffCategoryCode": "LT-2A",
+          "premisesType": "Residential",
+          "connectionType": "Single-phase"
+        },
+        {
+          "meterId": "MET-UNIT-102",
+          "sanctionedLoadKW": 3,
+          "tariffCategoryCode": "LT-2A",
+          "premisesType": "Residential",
+          "connectionType": "Single-phase"
+        }
+      ]
+    },
+    "customerDetails": {
+      "fullName": "Sunita Rao",
+      "installationAddress": {
+        "address": "12 Residency Road, Flat 101",
+        "city": {"name": "Bengaluru", "code": "BLR"},
+        "district": "Bengaluru Urban",
+        "state": {"name": "Karnataka", "code": "KA"},
+        "country": {"name": "India", "code": "IN"},
+        "area_code": "560025",
+        "gps": "12.9716,77.5946"
+      },
+      "serviceConnectionDate": "2020-03-01T00:00:00+05:30"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2025-01-13T10:30:00+05:30",
+    "verificationMethod": "did:web:bescom.karnataka.gov.in#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTaXoT..."
+  }
+}

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Submetering topology: apartment building with one utility main meter (MET-BLDG-001) and two tenant sub-meters (MET-UNIT-101, MET-UNIT-102). Sub-meters declare parentResources → main meter. Tenant 101 has a rooftop solar DER behind their sub-meter. Each sub-meter has its own consumption profile with its own tariff.",
+  "_comment": "Submetering topology: apartment building with one utility main meter (MET-BLDG-001) and two tenant sub-meters (MET-UNIT-101, MET-UNIT-102). Sub-meters declare parentResources → main meter. Tenant 101 has a rooftop solar DER behind their sub-meter. Each sub-meter has its own consumption profile.",
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://schema.org/",
@@ -22,40 +22,26 @@
       "customerNumber": "BESCOM-2025-BLDG-001",
       "energyResources": [
         {
-          "resourceId": "MET-BLDG-001",
-          "resourceType": "METER",
-          "resourceAttributes": {
-            "meterType": "AMI",
-            "gps": "12.9716,77.5946",
-            "feeder": "BAN-NR-F22",
-            "bus": "BUS-11kV-007"
-          }
+          "id": "MET-BLDG-001",
+          "type": "METER",
+          "attributes": {"meterType": "AMI", "gps": "12.9716,77.5946", "feeder": "BAN-NR-F22", "bus": "BUS-11kV-007"}
         },
         {
-          "resourceId": "MET-UNIT-101",
-          "resourceType": "METER",
-          "resourceAttributes": {
-            "meterType": "AMR",
-            "gps": "12.9716,77.5946"
-          },
+          "id": "MET-UNIT-101",
+          "type": "METER",
+          "attributes": {"meterType": "AMR", "gps": "12.9716,77.5946"},
           "parentResources": ["MET-BLDG-001"]
         },
         {
-          "resourceId": "MET-UNIT-102",
-          "resourceType": "METER",
-          "resourceAttributes": {
-            "meterType": "AMR",
-            "gps": "12.9716,77.5946"
-          },
+          "id": "MET-UNIT-102",
+          "type": "METER",
+          "attributes": {"meterType": "AMR", "gps": "12.9716,77.5946"},
           "parentResources": ["MET-BLDG-001"]
         },
         {
-          "resourceId": "der://solar/ROOFTOP-UNIT-101",
-          "resourceType": "SOLAR",
-          "ratedPowerKw": 2,
-          "make": "Waaree",
-          "model": "WS-200",
-          "resourceAttributes": {"commissioningDate": "2024-06-15"},
+          "id": "ROOFTOP-UNIT-101",
+          "type": "SOLAR",
+          "attributes": {"ratedPowerKw": 2, "make": "Waaree", "model": "WS-200", "commissioningDate": "2024-06-15"},
           "parentResources": ["MET-UNIT-101"]
         }
       ],

--- a/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example-submetering.json
@@ -24,7 +24,8 @@
         {
           "id": "MET-BLDG-001",
           "type": "METER",
-          "attributes": {"meterType": "AMI", "gps": "12.9716,77.5946", "feeder": "BAN-NR-F22", "bus": "BUS-11kV-007"}
+          "attributes": {"meterType": "AMI", "gps": "12.9716,77.5946"},
+          "parentResources": ["BAN-NR-F22"]
         },
         {
           "id": "MET-UNIT-101",

--- a/specification/schema/ElectricityCredential/v1.1/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example.json
@@ -28,9 +28,9 @@
       "idRef": {"issuedBy": "did:web:ssa.gov", "subjectId": "ssa.gov:XXX-XX-1234"},
       "energyResources": [
         {
-          "resourceId": "MET2025789456123",
-          "resourceType": "METER",
-          "resourceAttributes": {
+          "id": "MET2025789456123",
+          "type": "METER",
+          "attributes": {
             "meterType": "AMI",
             "gps": "37.7749,-122.4194",
             "feeder": "FEEDER-A1",
@@ -38,37 +38,27 @@
           }
         },
         {
-          "resourceId": "der://solar/DER-SOLAR-001",
-          "resourceType": "SOLAR",
-          "ratedPowerKw": 3,
-          "make": "SunPower Corporation",
-          "model": "SPR-X22-360",
-          "resourceAttributes": {"commissioningDate": "2025-01-12"},
+          "id": "DER-SOLAR-001",
+          "type": "SOLAR",
+          "attributes": {"ratedPowerKw": 3, "make": "SunPower Corporation", "model": "SPR-X22-360", "commissioningDate": "2025-01-12"},
           "parentResources": ["MET2025789456123"]
         },
         {
-          "resourceId": "der://wind/DER-WIND-001",
-          "resourceType": "WIND",
-          "ratedPowerKw": 1.5,
-          "make": "Windmill Co.",
-          "model": "WM-MICRO-150",
-          "resourceAttributes": {"commissioningDate": "2025-03-01"},
+          "id": "DER-WIND-001",
+          "type": "WIND",
+          "attributes": {"ratedPowerKw": 1.5, "make": "Windmill Co.", "model": "WM-MICRO-150", "commissioningDate": "2025-03-01"},
           "parentResources": ["MET2025789456123"]
         },
         {
-          "resourceId": "der://battery/BESS-001",
-          "resourceType": "BATTERY",
-          "ratedPowerKw": 5,
-          "energyCapacityKwh": 10,
-          "resourceAttributes": {"storageType": "LithiumIon", "commissioningDate": "2025-01-12"},
+          "id": "BESS-001",
+          "type": "BATTERY",
+          "attributes": {"ratedPowerKw": 5, "energyCapacityKwh": 10, "storageType": "LithiumIon", "commissioningDate": "2025-01-12"},
           "parentResources": ["MET2025789456123"]
         },
         {
-          "resourceId": "der://battery/BESS-002",
-          "resourceType": "BATTERY",
-          "ratedPowerKw": 2.5,
-          "energyCapacityKwh": 5,
-          "resourceAttributes": {"storageType": "LithiumIon", "commissioningDate": "2025-06-01"},
+          "id": "BESS-002",
+          "type": "BATTERY",
+          "attributes": {"ratedPowerKw": 2.5, "energyCapacityKwh": 5, "storageType": "LithiumIon", "commissioningDate": "2025-06-01"},
           "parentResources": ["MET2025789456123"]
         }
       ],

--- a/specification/schema/ElectricityCredential/v1.1/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example.json
@@ -28,14 +28,15 @@
       "idRef": {"issuedBy": "did:web:ssa.gov", "subjectId": "ssa.gov:XXX-XX-1234"},
       "energyResources": [
         {
+          "id": "DT-FEEDER-A1-001",
+          "type": "DT",
+          "attributes": {"ratedPowerKw": 250, "feeder": "FEEDER-A1", "bus": "BUS-11kV-001"}
+        },
+        {
           "id": "MET2025789456123",
           "type": "METER",
-          "attributes": {
-            "meterType": "AMI",
-            "gps": "37.7749,-122.4194",
-            "feeder": "FEEDER-A1",
-            "bus": "BUS-11kV-001"
-          }
+          "attributes": {"meterType": "AMI", "gps": "37.7749,-122.4194"},
+          "parentResources": ["DT-FEEDER-A1-001"]
         },
         {
           "id": "DER-SOLAR-001",

--- a/specification/schema/ElectricityCredential/v1.1/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example.json
@@ -62,6 +62,7 @@
         {
           "meterId": "MET2025789456123",
           "sanctionedLoadKW": 5,
+          "contractMaxDemandKw": 4,
           "tariffCategoryCode": "RES-01",
           "premisesType": "Residential",
           "connectionType": "Single-phase"

--- a/specification/schema/ElectricityCredential/v1.1/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example.json
@@ -30,7 +30,7 @@
         {
           "id": "MET2025789456123",
           "type": "METER",
-          "attributes": {"meterType": "AMI", "gps": "37.7749,-122.4194", "feeder": "FEEDER-A1", "bus": "BUS-11kV-001"},
+          "attributes": {"meterType": "AMI", "gps": "37.7749,-122.4194"},
           "parentResources": ["DT-FEEDER-A1-001"]
         },
         {

--- a/specification/schema/ElectricityCredential/v1.1/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example.json
@@ -1,0 +1,107 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://schema.org/",
+    "https://schema.beckn.io/Location/2.0/context.jsonld",
+    "https://schema.beckn.io/ElectricityCredential/v1.1/context.jsonld",
+    "https://schema.beckn.io/EnergyResource/v2.0/context.jsonld"
+  ],
+  "id": "urn:uuid:e5f6a7b8-9012-34ab-cdef-567890123456",
+  "type": ["VerifiableCredential", "ElectricityCredential"],
+  "issuer": {
+    "id": "https://example-utility.com/issuers/energy-dept",
+    "name": "Example Energy Utility",
+    "idRef": {"issuedBy": "did:web:exreg.gov", "subjectId": "exreg.gov:AABPC00001"}
+  },
+  "validFrom": "2025-01-13T10:30:00-05:00",
+  "validUntil": "2026-01-13T10:30:00-05:00",
+  "credentialStatus": {
+    "id": "https://dedi.global/dedi/lookup/example-utility.com/vc-revocation-registry/e5f6a7b8-9012-34ab-cdef-567890123456",
+    "type": "dediregistry",
+    "statusPurpose": "revocation",
+    "statusListCredential": "https://dedi.global/dedi/query/example-utility.com/vc-revocation-registry"
+  },
+  "credentialSubject": {
+    "id": "did:example:customer:abc123",
+    "customerProfile": {
+      "customerNumber": "UTIL-2025-001234567",
+      "idRef": {"issuedBy": "did:web:ssa.gov", "subjectId": "ssa.gov:XXX-XX-1234"},
+      "energyResources": [
+        {
+          "resourceId": "MET2025789456123",
+          "resourceType": "METER",
+          "resourceAttributes": {
+            "meterType": "AMI",
+            "gps": "37.7749,-122.4194",
+            "feeder": "FEEDER-A1",
+            "bus": "BUS-11kV-001"
+          }
+        },
+        {
+          "resourceId": "der://solar/DER-SOLAR-001",
+          "resourceType": "SOLAR",
+          "ratedPowerKw": 3,
+          "make": "SunPower Corporation",
+          "model": "SPR-X22-360",
+          "resourceAttributes": {"commissioningDate": "2025-01-12"},
+          "parentResources": ["MET2025789456123"]
+        },
+        {
+          "resourceId": "der://wind/DER-WIND-001",
+          "resourceType": "WIND",
+          "ratedPowerKw": 1.5,
+          "make": "Windmill Co.",
+          "model": "WM-MICRO-150",
+          "resourceAttributes": {"commissioningDate": "2025-03-01"},
+          "parentResources": ["MET2025789456123"]
+        },
+        {
+          "resourceId": "der://battery/BESS-001",
+          "resourceType": "BATTERY",
+          "ratedPowerKw": 5,
+          "energyCapacityKwh": 10,
+          "resourceAttributes": {"storageType": "LithiumIon", "commissioningDate": "2025-01-12"},
+          "parentResources": ["MET2025789456123"]
+        },
+        {
+          "resourceId": "der://battery/BESS-002",
+          "resourceType": "BATTERY",
+          "ratedPowerKw": 2.5,
+          "energyCapacityKwh": 5,
+          "resourceAttributes": {"storageType": "LithiumIon", "commissioningDate": "2025-06-01"},
+          "parentResources": ["MET2025789456123"]
+        }
+      ],
+      "consumptionProfiles": [
+        {
+          "meterId": "MET2025789456123",
+          "sanctionedLoadKW": 5,
+          "tariffCategoryCode": "RES-01",
+          "premisesType": "Residential",
+          "connectionType": "Single-phase"
+        }
+      ]
+    },
+    "customerDetails": {
+      "fullName": "Jane Doe",
+      "installationAddress": {
+        "address": "123 Energy Street, Unit 4",
+        "city": {"name": "Metro City", "code": "METRO"},
+        "district": "Metro District",
+        "state": {"name": "Example State", "code": "EX"},
+        "country": {"name": "United States", "code": "US"},
+        "area_code": "12345",
+        "gps": "37.7749,-122.4194",
+        "openLocationCode": "849VCWC8+R9"
+      },
+      "serviceConnectionDate": "2025-01-10T00:00:00-05:00"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2025-01-13T10:30:00-05:00",
+    "verificationMethod": "https://example-utility.com/issuers/energy-dept#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTaXoT..."
+  }
+}

--- a/specification/schema/ElectricityCredential/v1.1/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.1/examples/example.json
@@ -28,14 +28,9 @@
       "idRef": {"issuedBy": "did:web:ssa.gov", "subjectId": "ssa.gov:XXX-XX-1234"},
       "energyResources": [
         {
-          "id": "DT-FEEDER-A1-001",
-          "type": "DT",
-          "attributes": {"ratedPowerKw": 250, "feeder": "FEEDER-A1", "bus": "BUS-11kV-001"}
-        },
-        {
           "id": "MET2025789456123",
           "type": "METER",
-          "attributes": {"meterType": "AMI", "gps": "37.7749,-122.4194"},
+          "attributes": {"meterType": "AMI", "gps": "37.7749,-122.4194", "feeder": "FEEDER-A1", "bus": "BUS-11kV-001"},
           "parentResources": ["DT-FEEDER-A1-001"]
         },
         {

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -121,7 +121,10 @@
             "additionalProperties": false,
             "properties": {
                 "id": { "type": "string" },
-                "type": { "type": "string" },
+                "type": {
+                    "type": "string",
+                    "enum": ["METER","DT","BUS","FEEDER","SOLAR","SOLAR_PV","WIND","HYDRO","BIOGAS","CHP","FUEL_CELL","BATTERY","BESS","EV_CHARGER","EV_V2G","SMART_HVAC","SMART_WATER_HEATER","CONTROLLABLE_LOAD","MICROGRID"]
+                },
                 "attributes": {
                     "type": "object",
                     "additionalProperties": true,

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -144,8 +144,6 @@
                             "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
                         },
                         "location": { "$ref": "#/$defs/Location" },
-                        "feeder": { "type": "string" },
-                        "bus": { "type": "string" },
                         "commissioningDate": { "type": "string" },
                         "storageType": { "type": "string" }
                     }

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -135,6 +135,7 @@
                         "ratedPowerKw": { "type": "number", "minimum": 0 },
                         "energyCapacityKwh": { "type": "number", "minimum": 0 },
                         "telemetryProvider": { "type": "string" },
+                        "contractMaxDemandKw": { "type": "number", "minimum": 0 },
                         "meterType": {
                             "type": "string",
                             "enum": ["AMR", "AMI", "Electromechanical", "Forward", "Reverse", "Bidirectional", "Prepaid", "NetMeter", "Other"]

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -100,6 +100,7 @@
             "properties": {
                 "meterId": { "type": "string", "minLength": 1 },
                 "sanctionedLoadKW": { "type": "number", "minimum": 0.5, "maximum": 10000 },
+                "contractMaxDemandKw": { "type": "number", "minimum": 0 },
                 "tariffCategoryCode": { "type": "string", "minLength": 1 },
                 "premisesType": { "type": "string", "enum": ["Residential", "Commercial", "Industrial", "Agricultural"] },
                 "connectionType": { "type": "string", "enum": ["Single-phase", "Three-phase"] }
@@ -135,7 +136,6 @@
                         "ratedPowerKw": { "type": "number", "minimum": 0 },
                         "energyCapacityKwh": { "type": "number", "minimum": 0 },
                         "telemetryProvider": { "type": "string" },
-                        "contractMaxDemandKw": { "type": "number", "minimum": 0 },
                         "meterType": {
                             "type": "string",
                             "enum": ["AMR", "AMI", "Electromechanical", "Forward", "Reverse", "Bidirectional", "Prepaid", "NetMeter", "Other"]

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -1,0 +1,249 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/beckn/DEG/blob/main/specification/schema/ElectricityCredential/v1.1/schema.json",
+    "title": "ElectricityCredential v1.1",
+    "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.1. consumptionProfiles/generationProfiles/storageProfiles from v1.0 are superseded by customerProfile.energyResources[] and customerProfile.consumptionProfiles[].",
+    "type": "object",
+    "required": ["@context", "id", "type", "issuer", "validFrom", "credentialSubject"],
+    "properties": {
+        "@context": {
+            "type": "array",
+            "items": { "type": "string" },
+            "contains": { "const": "https://www.w3.org/ns/credentials/v2" },
+            "minItems": 2
+        },
+        "id": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        },
+        "type": {
+            "type": "array",
+            "items": { "type": "string" },
+            "contains": { "const": "ElectricityCredential" },
+            "minItems": 2
+        },
+        "issuer": {
+            "type": "object",
+            "required": ["id", "name"],
+            "properties": {
+                "id": { "type": "string", "format": "uri" },
+                "name": { "type": "string", "minLength": 1 },
+                "idRef": { "$ref": "#/$defs/IdRef" }
+            }
+        },
+        "validFrom": { "type": "string", "format": "date-time" },
+        "validUntil": { "type": "string", "format": "date-time" },
+        "credentialStatus": {
+            "type": "object",
+            "required": ["id", "type", "statusPurpose", "statusListCredential"],
+            "properties": {
+                "id": { "type": "string", "format": "uri" },
+                "type": { "type": "string", "const": "dediregistry" },
+                "statusPurpose": { "type": "string", "enum": ["revocation", "suspension"] },
+                "statusListCredential": { "type": "string", "format": "uri" }
+            }
+        },
+        "credentialSubject": {
+            "type": "object",
+            "required": ["customerProfile"],
+            "properties": {
+                "id": { "type": "string", "format": "uri" },
+                "customerProfile": { "$ref": "#/$defs/CustomerProfile" },
+                "customerDetails": { "$ref": "#/$defs/CustomerDetails" }
+            }
+        },
+        "proof": {
+            "type": "object",
+            "required": ["type", "created", "verificationMethod", "proofPurpose", "proofValue"],
+            "properties": {
+                "type": { "type": "string" },
+                "created": { "type": "string", "format": "date-time" },
+                "verificationMethod": { "type": "string", "format": "uri" },
+                "proofPurpose": { "type": "string", "enum": ["assertionMethod", "authentication"] },
+                "proofValue": { "type": "string", "minLength": 1 }
+            }
+        }
+    },
+    "$defs": {
+        "IdRef": {
+            "type": "object",
+            "required": ["issuedBy", "subjectId"],
+            "properties": {
+                "issuedBy": { "type": "string", "format": "uri" },
+                "subjectId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+:[A-Za-z0-9X_-]+$" }
+            }
+        },
+        "CustomerProfile": {
+            "type": "object",
+            "description": "Non-PII customer identity, physical assets, and tariff profiles.",
+            "required": ["customerNumber", "energyResources"],
+            "properties": {
+                "customerNumber": { "type": "string", "minLength": 1 },
+                "idRef": { "$ref": "#/$defs/IdRef" },
+                "energyResources": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/EnergyResource" }
+                },
+                "consumptionProfiles": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/ConsumptionProfile" }
+                }
+            }
+        },
+        "ConsumptionProfile": {
+            "type": "object",
+            "description": "Tariff and load characteristics for one meter connection. meterId matches resourceId of a METER entry in energyResources[].",
+            "required": ["meterId", "sanctionedLoadKW", "tariffCategoryCode"],
+            "properties": {
+                "meterId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Meter serial number — matches resourceId of the METER entry in energyResources[]."
+                },
+                "sanctionedLoadKW": {
+                    "type": "number",
+                    "minimum": 0.5,
+                    "maximum": 10000
+                },
+                "tariffCategoryCode": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "premisesType": {
+                    "type": "string",
+                    "enum": ["Residential", "Commercial", "Industrial", "Agricultural"]
+                },
+                "connectionType": {
+                    "type": "string",
+                    "enum": ["Single-phase", "Three-phase"]
+                }
+            }
+        },
+        "CustomerDetails": {
+            "type": "object",
+            "description": "PII section. fullName is only here.",
+            "required": ["fullName", "installationAddress", "serviceConnectionDate"],
+            "properties": {
+                "fullName": { "type": "string", "minLength": 1, "maxLength": 200 },
+                "installationAddress": { "$ref": "#/$defs/Location" },
+                "serviceConnectionDate": { "type": "string", "format": "date-time" }
+            }
+        },
+        "EnergyResource": {
+            "type": "object",
+            "description": "Inlined from EnergyResource/v2.0. For METER resources, resourceId is the meter serial number. When resourceType is METER, resourceAttributes conforms to MeterAttributes.",
+            "additionalProperties": false,
+            "properties": {
+                "@type": { "type": "string", "enum": ["EnergyResource"] },
+                "resourceId": { "type": "string", "description": "Meter serial number (for METER) or der://<type>/<id> (for DERs)." },
+                "resourceType": { "type": "string", "description": "Open-string asset class: METER, SOLAR, WIND, BATTERY, BESS, EV_CHARGER, …" },
+                "make": { "type": "string" },
+                "model": { "type": "string" },
+                "ratedPowerKw": { "type": "number", "minimum": 0 },
+                "energyCapacityKwh": { "type": "number", "minimum": 0 },
+                "telemetryProvider": { "type": "string" },
+                "resourceAttributes": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "subResources": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            { "type": "string" },
+                            { "$ref": "#/$defs/EnergyResource" }
+                        ]
+                    }
+                },
+                "parentResources": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            },
+            "if": {
+                "required": ["resourceType"],
+                "properties": { "resourceType": { "const": "METER" } }
+            },
+            "then": {
+                "properties": {
+                    "resourceAttributes": { "$ref": "#/$defs/MeterAttributes" }
+                }
+            }
+        },
+        "MeterAttributes": {
+            "type": "object",
+            "description": "resourceAttributes shape for resourceType = METER. All fields optional. resourceId of the containing EnergyResource is the meter serial number.",
+            "additionalProperties": true,
+            "properties": {
+                "meterType": {
+                    "type": "string",
+                    "enum": ["AMR", "AMI", "Electromechanical", "Forward", "Reverse", "Bidirectional", "Prepaid", "NetMeter", "Other"]
+                },
+                "gps": {
+                    "type": "string",
+                    "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+                },
+                "location": { "$ref": "#/$defs/Location" },
+                "feeder": { "type": "string" },
+                "bus": { "type": "string" }
+            }
+        },
+        "Location": {
+            "type": "object",
+            "description": "Physical location following the beckn Location schema.",
+            "required": ["address", "area_code", "country"],
+            "properties": {
+                "address": { "type": "string", "minLength": 1 },
+                "city": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "code": { "type": "string" }
+                    }
+                },
+                "district": { "type": "string" },
+                "state": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "code": { "type": "string" }
+                    }
+                },
+                "country": {
+                    "type": "object",
+                    "required": ["code"],
+                    "properties": {
+                        "name": { "type": "string" },
+                        "code": { "type": "string", "pattern": "^[A-Z]{2}$" }
+                    }
+                },
+                "area_code": { "type": "string", "minLength": 1 },
+                "gps": {
+                    "type": "string",
+                    "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+                },
+                "openLocationCode": {
+                    "type": "string",
+                    "pattern": "^[23456789CFGHJMPQRVWX]{4,8}\\+[23456789CFGHJMPQRVWX]{0,4}$"
+                },
+                "descriptor": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "code": { "type": "string" },
+                        "short_desc": { "type": "string" },
+                        "long_desc": { "type": "string" }
+                    }
+                },
+                "map_url": { "type": "string", "format": "uri" },
+                "circle": { "type": "object" },
+                "polygon": { "type": "string" },
+                "3dspace": { "type": "string" },
+                "rating": { "type": "string" }
+            }
+        }
+    }
+}

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/beckn/DEG/blob/main/specification/schema/ElectricityCredential/v1.1/schema.json",
     "title": "ElectricityCredential v1.1",
-    "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.1. consumptionProfiles/generationProfiles/storageProfiles from v1.0 are superseded by customerProfile.energyResources[] and customerProfile.consumptionProfiles[].",
+    "description": "Bundled JSON Schema for ElectricityCredential v1.1. EnergyResource has top-level id/type/subResources/parentResources; all other attributes live in the 'attributes' bag.",
     "type": "object",
     "required": ["@context", "id", "type", "issuer", "validFrom", "credentialSubject"],
     "properties": {
@@ -95,36 +95,19 @@
         },
         "ConsumptionProfile": {
             "type": "object",
-            "description": "Tariff and load characteristics for one meter connection. meterId matches resourceId of a METER entry in energyResources[].",
+            "description": "Tariff and load characteristics for one meter. meterId matches the id of a METER entry in energyResources[].",
             "required": ["meterId", "sanctionedLoadKW", "tariffCategoryCode"],
             "properties": {
-                "meterId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Meter serial number — matches resourceId of the METER entry in energyResources[]."
-                },
-                "sanctionedLoadKW": {
-                    "type": "number",
-                    "minimum": 0.5,
-                    "maximum": 10000
-                },
-                "tariffCategoryCode": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "premisesType": {
-                    "type": "string",
-                    "enum": ["Residential", "Commercial", "Industrial", "Agricultural"]
-                },
-                "connectionType": {
-                    "type": "string",
-                    "enum": ["Single-phase", "Three-phase"]
-                }
+                "meterId": { "type": "string", "minLength": 1 },
+                "sanctionedLoadKW": { "type": "number", "minimum": 0.5, "maximum": 10000 },
+                "tariffCategoryCode": { "type": "string", "minLength": 1 },
+                "premisesType": { "type": "string", "enum": ["Residential", "Commercial", "Industrial", "Agricultural"] },
+                "connectionType": { "type": "string", "enum": ["Single-phase", "Three-phase"] }
             }
         },
         "CustomerDetails": {
             "type": "object",
-            "description": "PII section. fullName is only here.",
+            "description": "PII — fullName is only here.",
             "required": ["fullName", "installationAddress", "serviceConnectionDate"],
             "properties": {
                 "fullName": { "type": "string", "minLength": 1, "maxLength": 200 },
@@ -134,20 +117,35 @@
         },
         "EnergyResource": {
             "type": "object",
-            "description": "Inlined from EnergyResource/v2.0. For METER resources, resourceId is the meter serial number. When resourceType is METER, resourceAttributes conforms to MeterAttributes.",
+            "description": "Inlined from EnergyResource/v2.0. Top-level: id, type, attributes, subResources, parentResources.",
             "additionalProperties": false,
             "properties": {
-                "@type": { "type": "string", "enum": ["EnergyResource"] },
-                "resourceId": { "type": "string", "description": "Meter serial number (for METER) or der://<type>/<id> (for DERs)." },
-                "resourceType": { "type": "string", "description": "Open-string asset class: METER, SOLAR, WIND, BATTERY, BESS, EV_CHARGER, …" },
-                "make": { "type": "string" },
-                "model": { "type": "string" },
-                "ratedPowerKw": { "type": "number", "minimum": 0 },
-                "energyCapacityKwh": { "type": "number", "minimum": 0 },
-                "telemetryProvider": { "type": "string" },
-                "resourceAttributes": {
+                "id": { "type": "string" },
+                "type": { "type": "string" },
+                "attributes": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": true,
+                    "description": "All non-topological attributes. CommonResourceAttributes (make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider) plus type-specific fields (meterType, gps, location, feeder, bus, commissioningDate, storageType, …).",
+                    "properties": {
+                        "make": { "type": "string" },
+                        "model": { "type": "string" },
+                        "ratedPowerKw": { "type": "number", "minimum": 0 },
+                        "energyCapacityKwh": { "type": "number", "minimum": 0 },
+                        "telemetryProvider": { "type": "string" },
+                        "meterType": {
+                            "type": "string",
+                            "enum": ["AMR", "AMI", "Electromechanical", "Forward", "Reverse", "Bidirectional", "Prepaid", "NetMeter", "Other"]
+                        },
+                        "gps": {
+                            "type": "string",
+                            "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+                        },
+                        "location": { "$ref": "#/$defs/Location" },
+                        "feeder": { "type": "string" },
+                        "bus": { "type": "string" },
+                        "commissioningDate": { "type": "string" },
+                        "storageType": { "type": "string" }
+                    }
                 },
                 "subResources": {
                     "type": "array",
@@ -162,33 +160,6 @@
                     "type": "array",
                     "items": { "type": "string" }
                 }
-            },
-            "if": {
-                "required": ["resourceType"],
-                "properties": { "resourceType": { "const": "METER" } }
-            },
-            "then": {
-                "properties": {
-                    "resourceAttributes": { "$ref": "#/$defs/MeterAttributes" }
-                }
-            }
-        },
-        "MeterAttributes": {
-            "type": "object",
-            "description": "resourceAttributes shape for resourceType = METER. All fields optional. resourceId of the containing EnergyResource is the meter serial number.",
-            "additionalProperties": true,
-            "properties": {
-                "meterType": {
-                    "type": "string",
-                    "enum": ["AMR", "AMI", "Electromechanical", "Forward", "Reverse", "Bidirectional", "Prepaid", "NetMeter", "Other"]
-                },
-                "gps": {
-                    "type": "string",
-                    "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-                },
-                "location": { "$ref": "#/$defs/Location" },
-                "feeder": { "type": "string" },
-                "bus": { "type": "string" }
             }
         },
         "Location": {
@@ -197,21 +168,9 @@
             "required": ["address", "area_code", "country"],
             "properties": {
                 "address": { "type": "string", "minLength": 1 },
-                "city": {
-                    "type": "object",
-                    "properties": {
-                        "name": { "type": "string" },
-                        "code": { "type": "string" }
-                    }
-                },
+                "city": { "type": "object", "properties": { "name": { "type": "string" }, "code": { "type": "string" } } },
                 "district": { "type": "string" },
-                "state": {
-                    "type": "object",
-                    "properties": {
-                        "name": { "type": "string" },
-                        "code": { "type": "string" }
-                    }
-                },
+                "state": { "type": "object", "properties": { "name": { "type": "string" }, "code": { "type": "string" } } },
                 "country": {
                     "type": "object",
                     "required": ["code"],
@@ -221,23 +180,9 @@
                     }
                 },
                 "area_code": { "type": "string", "minLength": 1 },
-                "gps": {
-                    "type": "string",
-                    "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-                },
-                "openLocationCode": {
-                    "type": "string",
-                    "pattern": "^[23456789CFGHJMPQRVWX]{4,8}\\+[23456789CFGHJMPQRVWX]{0,4}$"
-                },
-                "descriptor": {
-                    "type": "object",
-                    "properties": {
-                        "name": { "type": "string" },
-                        "code": { "type": "string" },
-                        "short_desc": { "type": "string" },
-                        "long_desc": { "type": "string" }
-                    }
-                },
+                "gps": { "type": "string", "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$" },
+                "openLocationCode": { "type": "string", "pattern": "^[23456789CFGHJMPQRVWX]{4,8}\\+[23456789CFGHJMPQRVWX]{0,4}$" },
+                "descriptor": { "type": "object" },
                 "map_url": { "type": "string", "format": "uri" },
                 "circle": { "type": "object" },
                 "polygon": { "type": "string" },

--- a/specification/schema/ElectricityCredential/v1.1/vocab.jsonld
+++ b/specification/schema/ElectricityCredential/v1.1/vocab.jsonld
@@ -1,0 +1,73 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "deg": "https://schema.beckn.io/deg/",
+        "energyCred": "https://schema.beckn.io/deg/EnergyCredential/v2.0/",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "deg:ElectricityCredential",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Electricity Credential",
+            "rdfs:comment": "W3C Verifiable Credential issued per meter by electricity distribution utilities. v1.1: customerProfile holds non-PII identity (customerNumber, idRef, energyResources[], consumptionProfiles[]); customerDetails holds PII.",
+            "rdfs:subClassOf": { "@id": "energyCred:EnergyCredential" }
+        },
+        {
+            "@id": "deg:customerProfile",
+            "@type": "rdf:Property",
+            "rdfs:label": "Customer Profile",
+            "rdfs:comment": "Non-PII utility customer identity: customerNumber, optional idRef, energyResources array, and consumptionProfiles array."
+        },
+        {
+            "@id": "deg:customerDetails",
+            "@type": "rdf:Property",
+            "rdfs:label": "Customer Details",
+            "rdfs:comment": "PII: full name, installation address, service connection date."
+        },
+        {
+            "@id": "deg:energyResources",
+            "@type": "rdf:Property",
+            "rdfs:label": "Energy Resources",
+            "rdfs:comment": "Array of EnergyResource/v2.0 entries. Covers all topologies: multiple meters, multiple premises, DERs linked via parentResources[]."
+        },
+        {
+            "@id": "deg:ConsumptionProfile",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Consumption Profile",
+            "rdfs:comment": "Tariff and load characteristics for one meter connection. Linked to a METER entry in energyResources[] via meterId."
+        },
+        {
+            "@id": "deg:consumptionProfiles",
+            "@type": "rdf:Property",
+            "rdfs:label": "Consumption Profiles",
+            "rdfs:comment": "Array of ConsumptionProfile entries — one per meter connection with tariff data."
+        },
+        {
+            "@id": "deg:meterId",
+            "@type": "rdf:Property",
+            "rdfs:label": "Meter ID",
+            "rdfs:comment": "Meter serial number. Matches resourceId of the corresponding METER entry in energyResources[].",
+            "rdfs:domain": { "@id": "deg:ConsumptionProfile" },
+            "rdfs:range": "xsd:string"
+        },
+        {
+            "@id": "deg:sanctionedLoadKW",
+            "@type": "rdf:Property",
+            "rdfs:label": "Sanctioned Load (kW)",
+            "rdfs:comment": "Utility-approved maximum electrical load in kilowatts.",
+            "rdfs:domain": { "@id": "deg:ConsumptionProfile" },
+            "rdfs:range": "xsd:decimal"
+        },
+        {
+            "@id": "deg:tariffCategoryCode",
+            "@type": "rdf:Property",
+            "rdfs:label": "Tariff Category Code",
+            "rdfs:comment": "Billing/tariff category code assigned by the utility.",
+            "rdfs:domain": { "@id": "deg:ConsumptionProfile" },
+            "rdfs:range": "xsd:string"
+        }
+    ]
+}

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -1,6 +1,6 @@
 # EnergyResource — v2.0
 
-Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by **P2P-trading** (`{resourceId, resourceType}` for the asset being sold), **demand-flex** (richer identity + dimensioning + topology to enumerate the assets behind a contract), and reused by every future DEG domain.
+Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by **P2P-trading** (`{id, type}` for the asset being sold), **demand-flex** (richer identity + dimensioning + topology), and **ElectricityCredential/v1.1** (`customerProfile.energyResources[]`).
 
 Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 
@@ -8,106 +8,55 @@ Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 
 | File | Description |
 |------|-------------|
-| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 `components.schemas.EnergyResource` |
-| [context.jsonld](./context.jsonld) | JSON-LD context — `EnergyResource` → `deg:EnergyResource` |
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 — `EnergyResource` and `CommonResourceAttributes` |
+| [context.jsonld](./context.jsonld) | JSON-LD context |
 | [vocab.jsonld](./vocab.jsonld) | RDF vocabulary |
 
-## Properties
+## Structure
 
-No field is `required` at the schema level — domain profiles (demand-flex's network rego, p2p-trading's item gates) enforce their own cross-field expectations.
-
-### Identity + rated dimensioning
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `resourceId` | string | Stable identifier. For `METER` resources: the bare meter serial number (e.g., `"MET001"`). For DERs: recommended scheme `der://<type>/<id>`. |
-| `resourceType` | string (open) | Open-string asset class — `METER`, `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `EV_CHARGER`, `EV_V2G`, `BATTERY`, `BESS`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`, … |
-| `make` / `model` | string | Manufacturer info. |
-| `ratedPowerKw` | number ≥0 | Manufacturer-rated peak dispatchable power, kW. |
-| `energyCapacityKwh` | number ≥0 | Rated stored-energy capacity, kWh — populated for storage-class resources, omitted for pure-flow. |
-| `telemetryProvider` | string | Identifier of the vendor API / data source supplying telemetry (e.g. `tata-evp-telematics`). |
-| `resourceAttributes` | object (open) | Type-specific extensible bag (EV VIN/chargingProtocol; battery chemistry/cycleCount; …). |
-
-### Topology
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `subResources` | array | Child resources. Each item is **either** a bare `resourceId` string (FK to a sibling EnergyResource in the same payload) **or** an inline-nested EnergyResource. |
-| `parentResources` | array of strings | Parent resources — `resourceId`s of EnergyResources this one sits behind (typically a meter or aggregation point). **String form only** — parents are enumerated elsewhere; inlining them inside a child would be a definitional cycle. |
-
-## P2P-trading payload (wave2)
-
-```jsonc
-{
-  "@type": "EnergyResource",
-  "resourceId": "der://meter/TEST_METER_SELLER_001",
-  "resourceType": "SOLAR"
-}
+```
+EnergyResource
+├── id                  — stable identifier (meter serial number for METER resources)
+├── type                — open-string asset class (METER, SOLAR, BATTERY, …)
+├── attributes          — all other properties (open bag)
+│   ├── CommonResourceAttributes: make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
+│   └── type-specific:  meterType, gps, location, feeder, bus, commissioningDate, storageType, VIN, …
+├── subResources[]      — child resource ids or inline objects (topology)
+└── parentResources[]   — parent resource ids (topology)
 ```
 
-## Demand-flex DR payload (richer identity + parent linkage)
+All fields are optional at the schema level.
 
-```jsonc
-{
-  "@type": "EnergyResource",
-  "resourceId": "der://ev/VIN001",
-  "resourceType": "EV_CHARGER",
-  "parentResources": ["der://meter/001"],
-  "make": "Tata",
-  "model": "Nexon EV",
-  "ratedPowerKw": 7.0,
-  "energyCapacityKwh": 30.0,
-  "telemetryProvider": "tata-evp-telematics",
-  "resourceAttributes": {
-    "vin": "MAT123456789012345",
-    "chargingProtocol": "OCPP_2_0_1"
-  }
-}
-```
+## CommonResourceAttributes
 
-`parentResources: ["der://meter/001"]` declares this EV sits behind grid meter `der://meter/001`, which is enumerated separately in the contract's `participatingMeters[*]`. The schema does not enforce that the FK resolves — domain profiles do.
+Dimensioning fields shared across all resource types. Live inside `attributes`.
 
-## Topology example — microgrid with mixed inline + reference children
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model |
+| `ratedPowerKw` | number ≥0 | Rated peak power, kW |
+| `energyCapacityKwh` | number ≥0 | Stored-energy capacity, kWh (storage-class only) |
+| `telemetryProvider` | string | Vendor API / data source for telemetry |
 
-```jsonc
-{
-  "@type": "EnergyResource",
-  "resourceId": "der://site/MICROGRID01",
-  "resourceType": "MICROGRID",
-  "subResources": [
-    "der://solar/PV001",
-    "der://battery/BAT001",
-    {
-      "@type": "EnergyResource",
-      "resourceId": "der://ev/VIN001",
-      "resourceType": "EV_CHARGER",
-      "parentResources": ["der://site/MICROGRID01"],
-      "ratedPowerKw": 7.0
-    }
-  ]
-}
-```
-
-`subResources` (string or inline) and `parentResources` (string only) together form the directed graph. Inline children may also carry an explicit `parentResources` back-pointer if the consumer needs symmetry.
-
-## MeterAttributes (`resourceType: METER`)
-
-`resourceAttributes` shape for grid connection points. All fields are optional — the bag is open-ended. `resourceId` of the EnergyResource **is** the meter serial number.
+## Meter attributes (`type: METER`, inside `attributes`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
-| `gps` | string | `"lat,lng"` coordinates of the physical meter |
+| `gps` | string | `"lat,lng"` coordinates |
 | `location` | object | Postal location (beckn Location shape) |
 | `feeder` | string | Distribution feeder ID or name |
 | `bus` | string | Substation bus reference |
 
-```jsonc
+## Examples
+
+**METER:**
+```json
 {
-  "@type": "EnergyResource",
-  "resourceId": "MET2025789456123",
-  "resourceType": "METER",
-  "resourceAttributes": {
+  "id": "MET2025789456123",
+  "type": "METER",
+  "attributes": {
     "meterType": "AMI",
     "gps": "12.9716,77.5946",
     "feeder": "BAN-NR-F22",
@@ -116,11 +65,64 @@ No field is `required` at the schema level — domain profiles (demand-flex's ne
 }
 ```
 
+**SOLAR DER behind a meter:**
+```json
+{
+  "id": "DER-SOLAR-001",
+  "type": "SOLAR",
+  "attributes": {"ratedPowerKw": 3, "make": "Waaree", "model": "WS-300", "commissioningDate": "2025-01-12"},
+  "parentResources": ["MET2025789456123"]
+}
+```
+
+**P2P-trading (minimal):**
+```json
+{"id": "MET001", "type": "SOLAR"}
+```
+
+**Demand-flex (EV with parent meter):**
+```json
+{
+  "id": "VIN001",
+  "type": "EV_CHARGER",
+  "attributes": {
+    "make": "Tata", "model": "Nexon EV",
+    "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0,
+    "telemetryProvider": "tata-evp-telematics",
+    "vin": "MAT123456789012345",
+    "chargingProtocol": "OCPP_2_0_1"
+  },
+  "parentResources": ["MET001"]
+}
+```
+
+**Topology — microgrid:**
+```json
+{
+  "id": "MICROGRID01",
+  "type": "MICROGRID",
+  "subResources": [
+    "PV001",
+    "BAT001",
+    {
+      "id": "VIN001",
+      "type": "EV_CHARGER",
+      "attributes": {"ratedPowerKw": 7.0},
+      "parentResources": ["MICROGRID01"]
+    }
+  ]
+}
+```
+
+## Topology
+
+`subResources` and `parentResources` reference other EnergyResources by `id`. `subResources` items may also be inline-nested EnergyResource objects. `parentResources` items are always strings (FK references — inlining parents would create a cycle).
+
 ## Changes from earlier v2.0 (breaking)
 
-- **`sourceType` removed** — use `resourceType` (open string, accepts every value the enum did and more).
-- **`meterId` removed** — split into:
-  - `resourceId` for the resource's own identifier (P2P-trading wave2 used `meterId` here),
-  - `parentResources[]` for upward topology (demand-flex used `meterId` for the meter-FK semantic).
-
-Wave2 P2P-trading + demand-flex devkit fixtures migrated alongside this schema revision.
+- **`resourceId` → `id`**, **`resourceType` → `type`** — simpler names.
+- **`resourceAttributes` → `attributes`** — renamed; still the open attribute bag.
+- **`CommonResourceAttributes` added** — named sub-schema for make/model/ratedPowerKw/energyCapacityKwh/telemetryProvider; all live inside `attributes`.
+- **Meter fields absorbed into `attributes`** — meterType, gps, location, feeder, bus are documented properties within the `attributes` bag for METER resources.
+- **`@type` discriminator field removed** — no longer needed.
+- **`sourceType` / `meterId`** — removed in the previous revision; still absent.

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -17,7 +17,7 @@ Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 ```
 EnergyResource
 ├── id                  — stable identifier (meter serial number for METER resources)
-├── type                — open-string asset class (METER, SOLAR, BATTERY, …)
+├── type                — asset class enum (METER, DT, BUS, FEEDER, SOLAR, BATTERY, …)
 ├── attributes          — all other properties (open bag)
 │   ├── CommonResourceAttributes: make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
 │   └── type-specific:  meterType, gps, location, feeder, bus, commissioningDate, storageType, VIN, …
@@ -38,6 +38,16 @@ Dimensioning fields shared across all resource types. Live inside `attributes`.
 | `ratedPowerKw` | number ≥0 | Rated peak power, kW |
 | `energyCapacityKwh` | number ≥0 | Stored-energy capacity, kWh (storage-class only) |
 | `telemetryProvider` | string | Vendor API / data source for telemetry |
+
+## `type` enum
+
+| Category | Values |
+|----------|--------|
+| Grid infrastructure | `METER`, `DT`, `BUS`, `FEEDER` |
+| Generation DERs | `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` |
+| Storage | `BATTERY`, `BESS` |
+| Flexible loads | `EV_CHARGER`, `EV_V2G`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` |
+| System | `MICROGRID` |
 
 ## Meter attributes (`type: METER`, inside `attributes`)
 

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -54,6 +54,7 @@ Dimensioning fields shared across all resource types. Live inside `attributes`.
 | Field | Type | Description |
 |-------|------|-------------|
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
+| `contractMaxDemandKw` | number ≥0 | Maximum demand contracted with the utility, kW |
 | `gps` | string | `"lat,lng"` coordinates |
 | `location` | object | Postal location (beckn Location shape) |
 

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -54,7 +54,6 @@ Dimensioning fields shared across all resource types. Live inside `attributes`.
 | Field | Type | Description |
 |-------|------|-------------|
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
-| `contractMaxDemandKw` | number ≥0 | Maximum demand contracted with the utility, kW |
 | `gps` | string | `"lat,lng"` coordinates |
 | `location` | object | Postal location (beckn Location shape) |
 

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -20,8 +20,8 @@ No field is `required` at the schema level — domain profiles (demand-flex's ne
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `resourceId` | string | Stable identifier; recommended URI scheme `der://<type>/<id>`. |
-| `resourceType` | string (open) | Open-string asset class — `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `EV_CHARGER`, `EV_V2G`, `BATTERY`, `BESS`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`, `GRID`, `GRID_METER`, … |
+| `resourceId` | string | Stable identifier. For `METER` resources: the bare meter serial number (e.g., `"MET001"`). For DERs: recommended scheme `der://<type>/<id>`. |
+| `resourceType` | string (open) | Open-string asset class — `METER`, `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `EV_CHARGER`, `EV_V2G`, `BATTERY`, `BESS`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`, … |
 | `make` / `model` | string | Manufacturer info. |
 | `ratedPowerKw` | number ≥0 | Manufacturer-rated peak dispatchable power, kW. |
 | `energyCapacityKwh` | number ≥0 | Rated stored-energy capacity, kWh — populated for storage-class resources, omitted for pure-flow. |
@@ -89,6 +89,32 @@ No field is `required` at the schema level — domain profiles (demand-flex's ne
 ```
 
 `subResources` (string or inline) and `parentResources` (string only) together form the directed graph. Inline children may also carry an explicit `parentResources` back-pointer if the consumer needs symmetry.
+
+## MeterAttributes (`resourceType: METER`)
+
+`resourceAttributes` shape for grid connection points. All fields are optional — the bag is open-ended. `resourceId` of the EnergyResource **is** the meter serial number.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
+| `gps` | string | `"lat,lng"` coordinates of the physical meter |
+| `location` | object | Postal location (beckn Location shape) |
+| `feeder` | string | Distribution feeder ID or name |
+| `bus` | string | Substation bus reference |
+
+```jsonc
+{
+  "@type": "EnergyResource",
+  "resourceId": "MET2025789456123",
+  "resourceType": "METER",
+  "resourceAttributes": {
+    "meterType": "AMI",
+    "gps": "12.9716,77.5946",
+    "feeder": "BAN-NR-F22",
+    "bus": "BUS-11kV-001"
+  }
+}
+```
 
 ## Changes from earlier v2.0 (breaking)
 

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -56,8 +56,8 @@ Dimensioning fields shared across all resource types. Live inside `attributes`.
 | `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
 | `gps` | string | `"lat,lng"` coordinates |
 | `location` | object | Postal location (beckn Location shape) |
-| `feeder` | string | Distribution feeder ID or name |
-| `bus` | string | Substation bus reference |
+
+Grid topology (feeder, bus, DT) is expressed via `parentResources[]` — reference the id of a `FEEDER`, `BUS`, or `DT` resource.
 
 ## Examples
 
@@ -66,12 +66,8 @@ Dimensioning fields shared across all resource types. Live inside `attributes`.
 {
   "id": "MET2025789456123",
   "type": "METER",
-  "attributes": {
-    "meterType": "AMI",
-    "gps": "12.9716,77.5946",
-    "feeder": "BAN-NR-F22",
-    "bus": "BUS-11kV-001"
-  }
+  "attributes": {"meterType": "AMI", "gps": "12.9716,77.5946"},
+  "parentResources": ["BAN-NR-F22"]
 }
 ```
 

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -201,6 +201,15 @@ components:
               x-jsonld:
                 "@id": deg:gps
 
+            contractMaxDemandKw:
+              type: number
+              minimum: 0
+              description: >
+                Maximum demand contracted with the utility for this meter, in kW.
+                Used for demand-charge billing and flex-program eligibility.
+              x-jsonld:
+                "@id": deg:contractMaxDemandKw
+
             location:
               type: object
               description: >

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -9,45 +9,78 @@ info:
     controllable loads (HVAC, water heaters, …), and the metering
     points / connection points / feeders that anchor them.
 
-    Used today by:
+    Structure
+    ─────────
+    EnergyResource has exactly four top-level fields:
+      id            — stable identifier (meter serial number for METER resources)
+      type          — open-string asset class (METER, SOLAR, BATTERY, …)
+      subResources  — child resource ids or inline objects (topology)
+      parentResources — parent resource ids (topology)
 
-      • P2P-trading: attached to Item.itemAttributes (or
-        Resource.resourceAttributes in inter-DISCOM flows). Wave2
-        payloads carry `{resourceId, resourceType}` to identify the
-        resource being sold.
-
-      • Demand-flex: attached as objects in the seller's
-        `offerAttributes.inputs[seller].inputs.energyResources[]` to
-        enumerate the assets behind a contract. Uses the richer
-        identity + dimensioning fields, plus `parentResources[]` to
-        link DERs back to the grid meter they sit behind.
-
-    This v2.0 revision drops the original two-field `{sourceType,
-    meterId}` surface in favour of a single canonical class
-    (`resourceId` + `resourceType`) that every DEG domain can
-    converge on, per beckn/DEG#119 "DEG Hourglass" architecture.
-    `sourceType`-style enumeration values (`SOLAR`, `BATTERY`,
-    `GRID`, …) live in `resourceType` (open string); the meter
-    linkage formerly carried by `meterId` now rides on
-    `parentResources[]`.
-
-    Breaking change vs. previous v2.0 surface:
-      • `sourceType` removed — use `resourceType` (open-string,
-        accepts every value the enum did).
-      • `meterId` removed — use `resourceId` for the resource's own
-        identifier and `parentResources[]` for upward topology.
+    Everything else — dimensioning, physical location, type-specific data —
+    lives in the `attributes` bag. CommonResourceAttributes defines the
+    sub-schema for the fields shared across all resource types
+    (make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider).
+    The bag is open-ended; any domain may add further fields.
 
 components:
   schemas:
+
+    CommonResourceAttributes:
+      type: object
+      description: >
+        Dimensioning fields common to all EnergyResource types.
+        These live inside EnergyResource.attributes alongside any
+        type-specific fields. No field is required.
+      additionalProperties: true
+      x-tags:
+        - energy-resource
+      properties:
+
+        make:
+          type: string
+          description: Manufacturer (free text).
+          x-jsonld:
+            "@id": deg:make
+
+        model:
+          type: string
+          description: Model (free text).
+          x-jsonld:
+            "@id": deg:model
+
+        ratedPowerKw:
+          type: number
+          minimum: 0
+          description: Manufacturer-rated peak dispatchable power, kW.
+          x-jsonld:
+            "@id": deg:ratedPowerKw
+
+        energyCapacityKwh:
+          type: number
+          minimum: 0
+          description: >
+            Rated stored-energy capacity, kWh. Populated for storage-class
+            resources (BATTERY, BESS, EV). Omit for pure-flow resources.
+          x-jsonld:
+            "@id": deg:energyCapacityKwh
+
+        telemetryProvider:
+          type: string
+          description: Vendor API / data source identifier for telemetry.
+          x-jsonld:
+            "@id": deg:telemetryProvider
+
     EnergyResource:
       type: object
       additionalProperties: false
       description: >
-        Canonical energy-asset class. NO fields are required at the
-        schema level — domains profile this class via their own
-        cross-field checks (e.g. demand-flex's network rego requires
-        resourceId + resourceType + meterId on every entry in the
-        seller's energyResources[]).
+        Canonical energy-asset class. Exactly four top-level fields:
+        id, type, subResources, parentResources. All other attributes
+        — dimensioning, location, type-specific data — live in `attributes`.
+
+        No field is required at the schema level. Domain profiles enforce
+        their own cross-field rules.
       x-tags:
         - energy-trade
         - p2p-trading
@@ -59,255 +92,165 @@ components:
         "@type": EnergyResource
       properties:
 
-        "@type":
-          type: string
-          enum: ["EnergyResource"]
-          description: >
-            Optional JSON-LD type discriminator. Present when the
-            embedder wants to surface the type in the payload; the
-            parent schema's `$ref` to EnergyResource is what drives
-            validation.
-
-        # ─── Core identity + dimensioning ───
-
-        resourceId:
+        id:
           type: string
           description: >
-            Stable identifier for this resource. Recommended URI
-            scheme `der://<type>/<id>` — type-discriminated and
-            distinct from `meterId`. Required by domain profiles that
-            enumerate multiple resources per contract (demand-flex's
-            seller-side `energyResources[]`); optional in single-
-            resource P2P-trading payloads where the meter URI alone
-            is sufficient.
-          example: "der://ev/VIN001"
+            Stable identifier for this resource. For METER resources the
+            meter serial number is conventional. Any stable scheme that
+            is locally unique within the payload works.
+          example: "MET2025789456123"
           x-jsonld:
-            "@id": resourceId
+            "@id": "@id"
 
-        resourceType:
+        type:
           type: string
           description: >
-            Open-string asset class. Common values include `METER`,
-            `EV_CHARGER`, `EV_V2G`, `BATTERY`, `BESS`, `SOLAR`,
-            `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL`,
-            `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`.
-            For grid connection points use `METER`; when resourceType
-            is `METER`, resourceId carries the meter serial number
-            directly (no URI prefix), and resourceAttributes SHOULD
-            conform to MeterAttributes. Consumers SHOULD treat unknown
-            values as informational. Open-ended so new asset classes
-            can be added without a schema bump.
+            Open-string asset class. Common values: METER, SOLAR, SOLAR_PV,
+            WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, BATTERY, BESS, EV_CHARGER,
+            EV_V2G, SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD,
+            MICROGRID. Open-ended — new classes can be added without a schema
+            bump. Consumers SHOULD treat unknown values as informational.
           example: "METER"
           x-jsonld:
-            "@id": resourceType
+            "@id": deg:resourceType
 
-        make:
-          type: string
-          description: Manufacturer (free text).
-          example: "Tata"
-          x-jsonld:
-            "@id": make
-
-        model:
-          type: string
-          description: Model (free text).
-          example: "Nexon EV"
-          x-jsonld:
-            "@id": model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
+        attributes:
           description: >
-            Manufacturer-rated peak dispatchable power, kW. For
-            chargers / inverters this is the device's rated AC power;
-            for thermal loads it's the rated electrical draw.
-          x-jsonld:
-            "@id": ratedPowerKw
+            Attribute bag containing all non-topological properties of this
+            resource. CommonResourceAttributes (make, model, ratedPowerKw,
+            energyCapacityKwh, telemetryProvider) are the common fields
+            present across all resource types. Additional type-specific
+            fields (meterType, feeder, commissioningDate, storageType, VIN,
+            …) are placed here alongside them.
 
-        energyCapacityKwh:
-          type: number
-          minimum: 0
-          description: >
-            Rated stored-energy capacity, kWh. Populated for
-            storage-class resources (BATTERY, BESS, EV with onboard
-            battery). Omit for pure-flow resources (SOLAR_PV,
-            SMART_HVAC). Used by reconciliation/proof-of-performance
-            consumers to interpret SOC_END telemetry values as a
-            fraction of capacity.
-          x-jsonld:
-            "@id": energyCapacityKwh
-
-        telemetryProvider:
-          type: string
-          description: >
-            Identifier of the vendor API / data source that supplies
-            telemetry for this resource (e.g. `tata-evp-telematics`,
-            `mg-imotion`, `tesla-fleet-api`). Free text; consumers MAY
-            use it to route data-quality complaints. Not a Beckn
-            participant ID.
-          x-jsonld:
-            "@id": telemetryProvider
-
-        resourceAttributes:
+            For METER resources: meterType, gps, location, feeder, bus.
+            For generation DERs: commissioningDate, and generation-type info.
+            For storage DERs: storageType, commissioningDate.
+            For EV resources: vin, chargingProtocol.
           type: object
           additionalProperties: true
-          description: >
-            Type-specific attribute bag. The core EnergyResource
-            class fixes the shape common to all energy assets;
-            type-specific fields ride here. Examples: EV → VIN,
-            chargingProtocol; battery → chemistry, cycleCount;
-            solar → panelCount, inverterMake. Consumers that don't
-            recognise the `resourceType` SHOULD pass this bag through
-            unchanged.
-          example:
-            vin: "MAT123456789012345"
-            chargingProtocol: "OCPP_2_0_1"
+          allOf:
+            - $ref: "#/components/schemas/CommonResourceAttributes"
+          properties:
+
+            # ── Common (from CommonResourceAttributes) ────────────────
+            make:
+              type: string
+              x-jsonld:
+                "@id": deg:make
+            model:
+              type: string
+              x-jsonld:
+                "@id": deg:model
+            ratedPowerKw:
+              type: number
+              minimum: 0
+              x-jsonld:
+                "@id": deg:ratedPowerKw
+            energyCapacityKwh:
+              type: number
+              minimum: 0
+              x-jsonld:
+                "@id": deg:energyCapacityKwh
+            telemetryProvider:
+              type: string
+              x-jsonld:
+                "@id": deg:telemetryProvider
+
+            # ── Meter-specific (type = METER) ─────────────────────────
+            meterType:
+              type: string
+              enum:
+                - AMR
+                - AMI
+                - Electromechanical
+                - Forward
+                - Reverse
+                - Bidirectional
+                - Prepaid
+                - NetMeter
+                - Other
+              description: Meter kind classification (Green Button / ESPI).
+              x-jsonld:
+                "@id": deg:meterType
+
+            gps:
+              type: string
+              pattern: "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+              description: GPS coordinates of the asset as 'lat,lng'.
+              x-jsonld:
+                "@id": deg:gps
+
+            location:
+              type: object
+              description: >
+                Postal location of the meter (beckn Location shape).
+                Use when the physical location differs from the customer's
+                registered installation address.
+              additionalProperties: true
+              properties:
+                address: { type: string }
+                city:
+                  type: object
+                  properties:
+                    name: { type: string }
+                    code: { type: string }
+                district: { type: string }
+                state:
+                  type: object
+                  properties:
+                    name: { type: string }
+                    code: { type: string }
+                country:
+                  type: object
+                  properties:
+                    name: { type: string }
+                    code: { type: string, pattern: "^[A-Z]{2}$" }
+                area_code: { type: string }
+                gps: { type: string }
+                openLocationCode: { type: string }
+              x-jsonld:
+                "@id": deg:meterLocation
+
+            feeder:
+              type: string
+              description: Distribution feeder ID or name serving this meter.
+              x-jsonld:
+                "@id": deg:feeder
+
+            bus:
+              type: string
+              description: Substation bus reference (HV/LV bus node).
+              x-jsonld:
+                "@id": deg:bus
+
           x-jsonld:
-            "@id": resourceAttributes
+            "@id": deg:attributes
 
         subResources:
           type: array
           description: >
-            Topology — child resources of this one. Each item is
-            EITHER a bare `resourceId` (foreign-key reference to an
-            EnergyResource defined elsewhere in the same offer /
-            contract) OR an inline-nested EnergyResource object.
-
-              • String form (resourceId) — prefer when the child is
-                already enumerated as a peer of this resource in the
-                same payload; avoids duplication.
-              • Inline form — prefer when the child only exists in
-                this topological context (e.g. a virtual aggregation
-                of leaf devices that aren't independently addressable).
-
-            Schema does NOT enforce cycle-detection or recursion
-            depth — left to implementations. The settlement rego does
-            not traverse this tree.
+            Topology — child resources. Each item is EITHER a bare `id`
+            string (reference to a sibling EnergyResource in the same
+            payload) OR an inline-nested EnergyResource object.
           items:
             oneOf:
               - type: string
-                description: >
-                  resourceId of a sibling EnergyResource. Resolution
-                  is local to the enclosing offer/contract payload.
+                description: id of a sibling EnergyResource.
               - $ref: "#/components/schemas/EnergyResource"
                 description: Inline-nested EnergyResource.
           x-jsonld:
-            "@id": subResources
+            "@id": deg:subResources
 
         parentResources:
           type: array
           description: >
-            Upward topology — `resourceId`s of parent resources (e.g.
-            a meter, an aggregation point, a virtual plant) that this
-            resource sits behind. Each item is a string (resourceId
-            reference) — NOT an inline EnergyResource. Parents are
-            always enumerated elsewhere in the same payload
-            (`participatingMeters[*]` for demand-flex; a peer entry
-            in `energyResources[*]` for general topology); inlining
-            them inside a child would be a definitional cycle.
-
-            Inverse of `subResources` for the reference form.
-            Permits many-to-many: a DER may sit behind multiple
-            meters (rare — dual-feed setups), and a meter typically
-            has many child resources expressed via the inverse
-            relationship.
+            Upward topology — `id`s of parent resources (e.g. the meter
+            this DER sits behind). String references only — parents are
+            always enumerated elsewhere in the same payload; inlining
+            them here would create a definitional cycle.
           items:
             type: string
-            description: >
-              `resourceId` of a parent EnergyResource defined
-              elsewhere in the same payload.
+            description: id of a parent EnergyResource.
           x-jsonld:
-            "@id": parentResources
-
-    MeterAttributes:
-      type: object
-      description: >
-        resourceAttributes shape for EnergyResource entries with
-        resourceType = "METER". The containing EnergyResource's
-        resourceId IS the meter serial number (utility-assigned;
-        no URI prefix required).
-
-        No field is required — the bag is open-ended
-        (additionalProperties: true). Domains that need specific
-        fields SHOULD declare them in their own profile.
-      additionalProperties: true
-      x-tags:
-        - meter
-        - energy-resource
-        - electricity
-      x-jsonld:
-        "@context": ./context.jsonld
-        "@type": MeterAttributes
-      properties:
-
-        meterType:
-          type: string
-          enum:
-            - AMR
-            - AMI
-            - Electromechanical
-            - Forward
-            - Reverse
-            - Bidirectional
-            - Prepaid
-            - NetMeter
-            - Other
-          description: >
-            Meter kind classification (Green Button / ESPI). Optional.
-          x-jsonld:
-            "@id": deg:meterType
-
-        gps:
-          type: string
-          pattern: "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-          description: GPS coordinates of the physical meter as 'lat,lng'. Optional.
-          x-jsonld:
-            "@id": deg:meterGps
-
-        location:
-          type: object
-          description: >
-            Postal location of the meter (beckn Location shape).
-            Use when the meter's physical location is distinct from
-            the customer's registered installation address. Optional.
-          additionalProperties: true
-          properties:
-            address: { type: string }
-            city:
-              type: object
-              properties:
-                name: { type: string }
-                code: { type: string }
-            district: { type: string }
-            state:
-              type: object
-              properties:
-                name: { type: string }
-                code: { type: string }
-            country:
-              type: object
-              properties:
-                name: { type: string }
-                code: { type: string, pattern: "^[A-Z]{2}$" }
-            area_code: { type: string }
-            gps: { type: string }
-            openLocationCode: { type: string }
-          x-jsonld:
-            "@id": deg:meterLocation
-
-        feeder:
-          type: string
-          description: >
-            Distribution feeder ID or name serving this meter
-            (e.g., "BAN-NR-F22"). Optional.
-          x-jsonld:
-            "@id": deg:feeder
-
-        bus:
-          type: string
-          description: >
-            Substation bus reference — the HV/LV bus node from which
-            the feeder originates (e.g., "BUS-11kV-001"). Optional.
-          x-jsonld:
-            "@id": deg:bus
+            "@id": deg:parentResources

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -201,15 +201,6 @@ components:
               x-jsonld:
                 "@id": deg:gps
 
-            contractMaxDemandKw:
-              type: number
-              minimum: 0
-              description: >
-                Maximum demand contracted with the utility for this meter, in kW.
-                Used for demand-charge billing and flex-program eligibility.
-              x-jsonld:
-                "@id": deg:contractMaxDemandKw
-
             location:
               type: object
               description: >

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -87,15 +87,17 @@ components:
         resourceType:
           type: string
           description: >
-            Open-string asset class. Common values include
+            Open-string asset class. Common values include `METER`,
             `EV_CHARGER`, `EV_V2G`, `BATTERY`, `BESS`, `SOLAR`,
             `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL`,
-            `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`,
-            `GRID`, `GRID_METER`. Consumers SHOULD treat unknown values
-            as informational and skip type-specific handling. Open-
-            ended so new asset classes can be added without a schema
-            bump.
-          example: "EV_CHARGER"
+            `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD`.
+            For grid connection points use `METER`; when resourceType
+            is `METER`, resourceId carries the meter serial number
+            directly (no URI prefix), and resourceAttributes SHOULD
+            conform to MeterAttributes. Consumers SHOULD treat unknown
+            values as informational. Open-ended so new asset classes
+            can be added without a schema bump.
+          example: "METER"
           x-jsonld:
             "@id": resourceType
 
@@ -217,3 +219,95 @@ components:
               elsewhere in the same payload.
           x-jsonld:
             "@id": parentResources
+
+    MeterAttributes:
+      type: object
+      description: >
+        resourceAttributes shape for EnergyResource entries with
+        resourceType = "METER". The containing EnergyResource's
+        resourceId IS the meter serial number (utility-assigned;
+        no URI prefix required).
+
+        No field is required — the bag is open-ended
+        (additionalProperties: true). Domains that need specific
+        fields SHOULD declare them in their own profile.
+      additionalProperties: true
+      x-tags:
+        - meter
+        - energy-resource
+        - electricity
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": MeterAttributes
+      properties:
+
+        meterType:
+          type: string
+          enum:
+            - AMR
+            - AMI
+            - Electromechanical
+            - Forward
+            - Reverse
+            - Bidirectional
+            - Prepaid
+            - NetMeter
+            - Other
+          description: >
+            Meter kind classification (Green Button / ESPI). Optional.
+          x-jsonld:
+            "@id": deg:meterType
+
+        gps:
+          type: string
+          pattern: "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+          description: GPS coordinates of the physical meter as 'lat,lng'. Optional.
+          x-jsonld:
+            "@id": deg:meterGps
+
+        location:
+          type: object
+          description: >
+            Postal location of the meter (beckn Location shape).
+            Use when the meter's physical location is distinct from
+            the customer's registered installation address. Optional.
+          additionalProperties: true
+          properties:
+            address: { type: string }
+            city:
+              type: object
+              properties:
+                name: { type: string }
+                code: { type: string }
+            district: { type: string }
+            state:
+              type: object
+              properties:
+                name: { type: string }
+                code: { type: string }
+            country:
+              type: object
+              properties:
+                name: { type: string }
+                code: { type: string, pattern: "^[A-Z]{2}$" }
+            area_code: { type: string }
+            gps: { type: string }
+            openLocationCode: { type: string }
+          x-jsonld:
+            "@id": deg:meterLocation
+
+        feeder:
+          type: string
+          description: >
+            Distribution feeder ID or name serving this meter
+            (e.g., "BAN-NR-F22"). Optional.
+          x-jsonld:
+            "@id": deg:feeder
+
+        bus:
+          type: string
+          description: >
+            Substation bus reference — the HV/LV bus node from which
+            the feeder originates (e.g., "BUS-11kV-001"). Optional.
+          x-jsonld:
+            "@id": deg:bus

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -105,11 +105,31 @@ components:
         type:
           type: string
           description: >
-            Open-string asset class. Common values: METER, SOLAR, SOLAR_PV,
-            WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, BATTERY, BESS, EV_CHARGER,
-            EV_V2G, SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD,
-            MICROGRID. Open-ended — new classes can be added without a schema
-            bump. Consumers SHOULD treat unknown values as informational.
+            Asset class. Grid infrastructure: METER, DT (distribution
+            transformer), BUS, FEEDER. Generation DERs: SOLAR, SOLAR_PV,
+            WIND, HYDRO, BIOGAS, CHP, FUEL_CELL. Storage: BATTERY, BESS.
+            Flexible loads: EV_CHARGER, EV_V2G, SMART_HVAC,
+            SMART_WATER_HEATER, CONTROLLABLE_LOAD. System: MICROGRID.
+          enum:
+            - METER
+            - DT
+            - BUS
+            - FEEDER
+            - SOLAR
+            - SOLAR_PV
+            - WIND
+            - HYDRO
+            - BIOGAS
+            - CHP
+            - FUEL_CELL
+            - BATTERY
+            - BESS
+            - EV_CHARGER
+            - EV_V2G
+            - SMART_HVAC
+            - SMART_WATER_HEATER
+            - CONTROLLABLE_LOAD
+            - MICROGRID
           example: "METER"
           x-jsonld:
             "@id": deg:resourceType

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -232,18 +232,6 @@ components:
               x-jsonld:
                 "@id": deg:meterLocation
 
-            feeder:
-              type: string
-              description: Distribution feeder ID or name serving this meter.
-              x-jsonld:
-                "@id": deg:feeder
-
-            bus:
-              type: string
-              description: Substation bus reference (HV/LV bus node).
-              x-jsonld:
-                "@id": deg:bus
-
           x-jsonld:
             "@id": deg:attributes
 

--- a/specification/schema/EnergyResource/v2.0/context.jsonld
+++ b/specification/schema/EnergyResource/v2.0/context.jsonld
@@ -7,25 +7,33 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "beckn": "https://schema.beckn.io/core/v2.0/",
     "deg": "https://schema.beckn.io/deg/EnergyResource/v2.0/",
+
     "EnergyResource": "deg:EnergyResource",
 
-    "resourceId":         { "@id": "deg:resourceId",         "@type": "xsd:string"  },
-    "resourceType":       { "@id": "deg:resourceType",       "@type": "xsd:string"  },
-    "make":               { "@id": "deg:make",               "@type": "xsd:string"  },
-    "model":              { "@id": "deg:model",              "@type": "xsd:string"  },
-    "ratedPowerKw":       { "@id": "deg:ratedPowerKw",       "@type": "xsd:decimal" },
-    "energyCapacityKwh":  { "@id": "deg:energyCapacityKwh",  "@type": "xsd:decimal" },
-    "telemetryProvider":  { "@id": "deg:telemetryProvider",  "@type": "xsd:string"  },
-    "resourceAttributes": { "@id": "deg:resourceAttributes", "@container": "@graph" },
-    "subResources":       { "@id": "deg:subResources",       "@container": "@list"  },
-    "parentResources":    { "@id": "deg:parentResources",    "@container": "@list"  },
+    "id":   "@id",
+    "type": { "@id": "deg:resourceType", "@type": "xsd:string" },
 
-    "MeterAttributes":    "deg:MeterAttributes",
-    "meterType":          { "@id": "deg:meterType",          "@type": "xsd:string"  },
-    "meterGps":           { "@id": "deg:meterGps",           "@type": "xsd:string"  },
-    "meterLocation":      { "@id": "deg:meterLocation",      "@type": "@id"         },
-    "feeder":             { "@id": "deg:feeder",             "@type": "xsd:string"  },
-    "bus":                { "@id": "deg:bus",                "@type": "xsd:string"  }
+    "attributes": {
+      "@id": "deg:attributes",
+      "@type": "@id",
+      "@context": {
+        "make":              { "@id": "deg:make",              "@type": "xsd:string"  },
+        "model":             { "@id": "deg:model",             "@type": "xsd:string"  },
+        "ratedPowerKw":      { "@id": "deg:ratedPowerKw",      "@type": "xsd:decimal" },
+        "energyCapacityKwh": { "@id": "deg:energyCapacityKwh", "@type": "xsd:decimal" },
+        "telemetryProvider": { "@id": "deg:telemetryProvider", "@type": "xsd:string"  },
+        "meterType":         { "@id": "deg:meterType",         "@type": "xsd:string"  },
+        "gps":               { "@id": "deg:gps",               "@type": "xsd:string"  },
+        "meterLocation":     { "@id": "deg:meterLocation",     "@type": "@id"         },
+        "feeder":            { "@id": "deg:feeder",            "@type": "xsd:string"  },
+        "bus":               { "@id": "deg:bus",               "@type": "xsd:string"  },
+        "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:string"  },
+        "storageType":       { "@id": "deg:storageType",       "@type": "xsd:string"  }
+      }
+    },
+
+    "subResources":    { "@id": "deg:subResources",    "@container": "@list" },
+    "parentResources": { "@id": "deg:parentResources", "@container": "@list" }
   },
   "@graph": []
 }

--- a/specification/schema/EnergyResource/v2.0/context.jsonld
+++ b/specification/schema/EnergyResource/v2.0/context.jsonld
@@ -18,7 +18,14 @@
     "telemetryProvider":  { "@id": "deg:telemetryProvider",  "@type": "xsd:string"  },
     "resourceAttributes": { "@id": "deg:resourceAttributes", "@container": "@graph" },
     "subResources":       { "@id": "deg:subResources",       "@container": "@list"  },
-    "parentResources":    { "@id": "deg:parentResources",    "@container": "@list"  }
+    "parentResources":    { "@id": "deg:parentResources",    "@container": "@list"  },
+
+    "MeterAttributes":    "deg:MeterAttributes",
+    "meterType":          { "@id": "deg:meterType",          "@type": "xsd:string"  },
+    "meterGps":           { "@id": "deg:meterGps",           "@type": "xsd:string"  },
+    "meterLocation":      { "@id": "deg:meterLocation",      "@type": "@id"         },
+    "feeder":             { "@id": "deg:feeder",             "@type": "xsd:string"  },
+    "bus":                { "@id": "deg:bus",                "@type": "xsd:string"  }
   },
   "@graph": []
 }

--- a/specification/schema/EnergyResource/v2.0/vocab.jsonld
+++ b/specification/schema/EnergyResource/v2.0/vocab.jsonld
@@ -13,88 +13,115 @@
       "@id": "deg:EnergyResource",
       "@type": "rdfs:Class",
       "rdfs:label": "Energy Resource",
-      "rdfs:comment": "Canonical energy-asset class. Any asset that produces, consumes, stores, or modulates energy — meters, DERs, storage, controllable loads."
+      "rdfs:comment": "Canonical energy-asset class. Top-level: id, type, attributes, subResources, parentResources."
     },
     {
-      "@id": "deg:resourceId",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource ID",
-      "rdfs:comment": "Stable identifier for this resource. For METER resources, this is the meter serial number (no URI prefix). For DERs, recommended scheme is der://<type>/<id>.",
-      "rdfs:domain": { "@id": "deg:EnergyResource" },
-      "rdfs:range": "xsd:string"
+      "@id": "deg:CommonResourceAttributes",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Common Resource Attributes",
+      "rdfs:comment": "Dimensioning fields shared across all resource types. Live inside EnergyResource.attributes."
     },
     {
       "@id": "deg:resourceType",
       "@type": "rdf:Property",
       "rdfs:label": "Resource Type",
-      "rdfs:comment": "Open-string asset class. Common values: METER, SOLAR, SOLAR_PV, WIND, HYDRO, BATTERY, BESS, EV_CHARGER, EV_V2G, CONTROLLABLE_LOAD.",
+      "rdfs:comment": "Open-string asset class: METER, SOLAR, SOLAR_PV, WIND, HYDRO, BATTERY, BESS, EV_CHARGER, EV_V2G, CONTROLLABLE_LOAD, …",
       "rdfs:domain": { "@id": "deg:EnergyResource" },
       "rdfs:range": "xsd:string"
     },
     {
-      "@id": "deg:resourceAttributes",
+      "@id": "deg:attributes",
       "@type": "rdf:Property",
-      "rdfs:label": "Resource Attributes",
-      "rdfs:comment": "Type-specific extensible attribute bag. For METER resources, conforms to MeterAttributes.",
+      "rdfs:label": "Attributes",
+      "rdfs:comment": "Open attribute bag. Contains CommonResourceAttributes fields plus any type-specific fields.",
       "rdfs:domain": { "@id": "deg:EnergyResource" }
+    },
+    {
+      "@id": "deg:make",
+      "@type": "rdf:Property",
+      "rdfs:label": "Make",
+      "rdfs:comment": "Manufacturer (free text).",
+      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:model",
+      "@type": "rdf:Property",
+      "rdfs:label": "Model",
+      "rdfs:comment": "Model (free text).",
+      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:ratedPowerKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Rated Power (kW)",
+      "rdfs:comment": "Manufacturer-rated peak dispatchable power, kW.",
+      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:range": "xsd:decimal"
+    },
+    {
+      "@id": "deg:energyCapacityKwh",
+      "@type": "rdf:Property",
+      "rdfs:label": "Energy Capacity (kWh)",
+      "rdfs:comment": "Rated stored-energy capacity, kWh. For storage-class resources.",
+      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:range": "xsd:decimal"
+    },
+    {
+      "@id": "deg:telemetryProvider",
+      "@type": "rdf:Property",
+      "rdfs:label": "Telemetry Provider",
+      "rdfs:comment": "Vendor API / data source identifier for telemetry.",
+      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:range": "xsd:string"
     },
     {
       "@id": "deg:subResources",
       "@type": "rdf:Property",
       "rdfs:label": "Sub Resources",
-      "rdfs:comment": "Child resources (topology: downward). Each item is a resourceId string or an inline EnergyResource.",
+      "rdfs:comment": "Child resources (topology: downward). Each item is an id string or inline EnergyResource.",
       "rdfs:domain": { "@id": "deg:EnergyResource" }
     },
     {
       "@id": "deg:parentResources",
       "@type": "rdf:Property",
       "rdfs:label": "Parent Resources",
-      "rdfs:comment": "Parent resource IDs (topology: upward). String references only — the meter or aggregation point this resource sits behind.",
+      "rdfs:comment": "Parent resource ids (topology: upward). String references only.",
       "rdfs:domain": { "@id": "deg:EnergyResource" }
-    },
-    {
-      "@id": "deg:MeterAttributes",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Meter Attributes",
-      "rdfs:comment": "resourceAttributes shape for EnergyResource entries with resourceType = METER. Carries grid topology and physical location of the meter."
     },
     {
       "@id": "deg:meterType",
       "@type": "rdf:Property",
       "rdfs:label": "Meter Type",
-      "rdfs:comment": "Meter kind classification (Green Button / ESPI). One of: AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other.",
-      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:comment": "Meter kind (Green Button / ESPI): AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other.",
       "rdfs:range": "xsd:string"
     },
     {
-      "@id": "deg:meterGps",
+      "@id": "deg:gps",
       "@type": "rdf:Property",
-      "rdfs:label": "Meter GPS",
-      "rdfs:comment": "GPS coordinates of the physical meter as 'lat,lng'.",
-      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:label": "GPS",
+      "rdfs:comment": "GPS coordinates of the asset as 'lat,lng'.",
       "rdfs:range": "xsd:string"
     },
     {
       "@id": "deg:meterLocation",
       "@type": "rdf:Property",
       "rdfs:label": "Meter Location",
-      "rdfs:comment": "Postal location of the meter (beckn Location shape).",
-      "rdfs:domain": { "@id": "deg:MeterAttributes" }
+      "rdfs:comment": "Postal location of the meter (beckn Location shape)."
     },
     {
       "@id": "deg:feeder",
       "@type": "rdf:Property",
       "rdfs:label": "Feeder",
       "rdfs:comment": "Distribution feeder ID or name serving this meter.",
-      "rdfs:domain": { "@id": "deg:MeterAttributes" },
       "rdfs:range": "xsd:string"
     },
     {
       "@id": "deg:bus",
       "@type": "rdf:Property",
       "rdfs:label": "Bus",
-      "rdfs:comment": "Substation bus reference (HV/LV bus node) from which the feeder originates.",
-      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:comment": "Substation bus reference (HV/LV bus node).",
       "rdfs:range": "xsd:string"
     }
   ]

--- a/specification/schema/EnergyResource/v2.0/vocab.jsonld
+++ b/specification/schema/EnergyResource/v2.0/vocab.jsonld
@@ -13,59 +13,89 @@
       "@id": "deg:EnergyResource",
       "@type": "rdfs:Class",
       "rdfs:label": "Energy Resource",
-      "rdfs:comment": "Item attributes for energy resources, attached to Item.itemAttributes."
+      "rdfs:comment": "Canonical energy-asset class. Any asset that produces, consumes, stores, or modulates energy — meters, DERs, storage, controllable loads."
     },
     {
-      "@id": "deg:sourceType",
+      "@id": "deg:resourceId",
       "@type": "rdf:Property",
-      "rdfs:label": "Source type",
-      "rdfs:comment": "Type of energy source (SOLAR, BATTERY, GRID, HYBRID, RENEWABLE).",
-      "rdfs:domain": "deg:EnergyResource",
-      "schema:rangeIncludes": "deg:SourceType"
-    },
-    {
-      "@id": "deg:meterId",
-      "@type": "rdf:Property",
-      "rdfs:label": "Meter ID",
-      "rdfs:comment": "Meter identifier in DER address format (der://meter/{id}).",
-      "rdfs:domain": "deg:EnergyResource",
+      "rdfs:label": "Resource ID",
+      "rdfs:comment": "Stable identifier for this resource. For METER resources, this is the meter serial number (no URI prefix). For DERs, recommended scheme is der://<type>/<id>.",
+      "rdfs:domain": { "@id": "deg:EnergyResource" },
       "rdfs:range": "xsd:string"
     },
     {
-      "@id": "deg:SourceType",
-      "@type": "schema:Enumeration",
-      "schema:name": "Source Type",
-      "rdfs:comment": "Enumeration of energy source types."
+      "@id": "deg:resourceType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Resource Type",
+      "rdfs:comment": "Open-string asset class. Common values: METER, SOLAR, SOLAR_PV, WIND, HYDRO, BATTERY, BESS, EV_CHARGER, EV_V2G, CONTROLLABLE_LOAD.",
+      "rdfs:domain": { "@id": "deg:EnergyResource" },
+      "rdfs:range": "xsd:string"
     },
     {
-      "@id": "deg:SourceTypeSolar",
-      "@type": "deg:SourceType",
-      "schema:name": "SOLAR",
-      "schema:identifier": "SOLAR"
+      "@id": "deg:resourceAttributes",
+      "@type": "rdf:Property",
+      "rdfs:label": "Resource Attributes",
+      "rdfs:comment": "Type-specific extensible attribute bag. For METER resources, conforms to MeterAttributes.",
+      "rdfs:domain": { "@id": "deg:EnergyResource" }
     },
     {
-      "@id": "deg:SourceTypeBattery",
-      "@type": "deg:SourceType",
-      "schema:name": "BATTERY",
-      "schema:identifier": "BATTERY"
+      "@id": "deg:subResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "Sub Resources",
+      "rdfs:comment": "Child resources (topology: downward). Each item is a resourceId string or an inline EnergyResource.",
+      "rdfs:domain": { "@id": "deg:EnergyResource" }
     },
     {
-      "@id": "deg:SourceTypeGrid",
-      "@type": "deg:SourceType",
-      "schema:name": "GRID",
-      "schema:identifier": "GRID"
+      "@id": "deg:parentResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "Parent Resources",
+      "rdfs:comment": "Parent resource IDs (topology: upward). String references only — the meter or aggregation point this resource sits behind.",
+      "rdfs:domain": { "@id": "deg:EnergyResource" }
     },
     {
-      "@id": "deg:SourceTypeHybrid",
-      "@type": "deg:SourceType",
-      "schema:name": "HYBRID",
-      "schema:identifier": "HYBRID"
+      "@id": "deg:MeterAttributes",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Meter Attributes",
+      "rdfs:comment": "resourceAttributes shape for EnergyResource entries with resourceType = METER. Carries grid topology and physical location of the meter."
     },
     {
-      "@id": "deg:SourceTypeRenewable",
-      "@type": "deg:SourceType",
-      "schema:name": "RENEWABLE",
-      "schema:identifier": "RENEWABLE"
+      "@id": "deg:meterType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Meter Type",
+      "rdfs:comment": "Meter kind classification (Green Button / ESPI). One of: AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other.",
+      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:meterGps",
+      "@type": "rdf:Property",
+      "rdfs:label": "Meter GPS",
+      "rdfs:comment": "GPS coordinates of the physical meter as 'lat,lng'.",
+      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:meterLocation",
+      "@type": "rdf:Property",
+      "rdfs:label": "Meter Location",
+      "rdfs:comment": "Postal location of the meter (beckn Location shape).",
+      "rdfs:domain": { "@id": "deg:MeterAttributes" }
+    },
+    {
+      "@id": "deg:feeder",
+      "@type": "rdf:Property",
+      "rdfs:label": "Feeder",
+      "rdfs:comment": "Distribution feeder ID or name serving this meter.",
+      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:bus",
+      "@type": "rdf:Property",
+      "rdfs:label": "Bus",
+      "rdfs:comment": "Substation bus reference (HV/LV bus node) from which the feeder originates.",
+      "rdfs:domain": { "@id": "deg:MeterAttributes" },
+      "rdfs:range": "xsd:string"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **ElectricityCredential v1.1** replaces the three separate v1.0 profile arrays (`consumptionProfiles`, `generationProfiles`, `storageProfiles`) with a single `customerProfile.energyResources[]` using `EnergyResource/v2.0` as the canonical asset class. No v1.0 field is lost — every field maps to an EnergyResource `id`, `type`, or `attributes` property.
- **`ConsumptionProfile`** links tariff/load data (`sanctionedLoadKW`, `tariffCategoryCode`) to a specific meter via `meterId`. Kept separate from physical asset data because tariff info is administrative and changes independently.
- **Multi-topology support**: a single `customerNumber` can have multiple `METER` entries (different premises, sub-meters, parallel meters). DERs link to their parent meter via `parentResources[]`; consumption profiles link via `meterId`.
- **`EnergyResource/v2.0` updated**: fields renamed (`resourceId → id`, `resourceType → type`, `resourceAttributes → attributes`); `CommonResourceAttributes` (make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider) extracted as a component nested inside the `attributes` bag. `type` promoted to a closed enum — grid infrastructure types `DT`, `BUS`, `FEEDER` added alongside generation, storage and load types. Stale `vocab.jsonld` entries (`sourceType`, `meterId`) removed.
- **PII isolation**: `fullName` exclusively in `customerDetails` — never in profile entries.

## `EnergyResource.type` enum

| Category | Values |
|----------|--------|
| Grid infrastructure | `METER`, `DT`, `BUS`, `FEEDER` |
| Generation DERs | `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` |
| Storage | `BATTERY`, `BESS` |
| Flexible loads | `EV_CHARGER`, `EV_V2G`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` |
| System | `MICROGRID` |

## `EnergyResource` structure

```
EnergyResource
├── id                — stable identifier (meter serial number for METER)
├── type              — enum (see table above)
├── attributes        — open bag; CommonResourceAttributes + type-specific fields
│   ├── make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
│   └── meterType, gps, location, feeder, bus / commissioningDate / storageType / …
├── subResources[]    — child resource ids or inline objects
└── parentResources[] — parent resource ids (e.g. DT id for a meter)
```

## Files changed

| File | Change |
|------|--------|
| `ElectricityCredential/v1.1/attributes.yaml` | New — ElectricityCredential, CustomerProfile, ConsumptionProfile, CustomerDetails |
| `ElectricityCredential/v1.1/schema.json` | New — self-contained bundled JSON Schema |
| `ElectricityCredential/v1.1/context.jsonld` | New — JSON-LD context |
| `ElectricityCredential/v1.1/vocab.jsonld` | New — RDF vocabulary |
| `ElectricityCredential/v1.1/README.md` | New — full documentation |
| `ElectricityCredential/v1.1/examples/example.json` | Single meter (parentResources → DT) + 2 generation + 2 storage DERs |
| `ElectricityCredential/v1.1/examples/example-submetering.json` | Building main meter + 2 tenant sub-meters + solar DER |
| `ElectricityCredential/v1.1/examples/example-parallel-metering.json` | Dual parallel meters (import/export) + solar DER + FIT tariff |
| `EnergyResource/v2.0/attributes.yaml` | Rename id/type/attributes; add CommonResourceAttributes; type → enum with DT/BUS/FEEDER |
| `EnergyResource/v2.0/context.jsonld` | Updated for new field names and attributes nested context |
| `EnergyResource/v2.0/vocab.jsonld` | Rewrite: fix stale entries, add CommonResourceAttributes class and properties |
| `EnergyResource/v2.0/README.md` | Add CommonResourceAttributes section, type enum table, updated examples |

## v1.0 → v1.1 field mapping

| v1.0 | v1.1 |
|------|------|
| `customerProfile.meterNumber` | `energyResources[METER].id` |
| `customerProfile.meterType` | `energyResources[METER].attributes.meterType` |
| `consumptionProfiles[].sanctionedLoadKW` | `consumptionProfiles[].sanctionedLoadKW` |
| `consumptionProfiles[].tariffCategoryCode` | `consumptionProfiles[].tariffCategoryCode` |
| `generationProfiles[].assetId` | `energyResources[DER].id` |
| `generationProfiles[].capacityKW` | `energyResources[DER].attributes.ratedPowerKw` |
| `generationProfiles[].manufacturer` | `energyResources[DER].attributes.make` |
| `generationProfiles[].commissioningDate` | `energyResources[DER].attributes.commissioningDate` |
| `storageProfiles[].storageCapacityKWh` | `energyResources[DER].attributes.energyCapacityKwh` |
| `storageProfiles[].storageType` | `energyResources[DER].attributes.storageType` |
| `fullName` (duplicated per entry) | `customerDetails.fullName` (once) |

## Test plan

- [ ] Validate `examples/example.json` against `schema.json`
- [ ] Validate `examples/example-submetering.json` against `schema.json`
- [ ] Validate `examples/example-parallel-metering.json` against `schema.json`
- [ ] Confirm all v1.0 credential fields have a documented v1.1 destination (mapping table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)