### PR TITLE
fix(schema): remove role enum from RevenueFlow/v2.0 — enforced by network rego

### DIFF
--- a/specification/schema/RevenueFlow/v2.0/attributes.yaml
+++ b/specification/schema/RevenueFlow/v2.0/attributes.yaml
@@ -41,7 +41,6 @@ components:
             properties:
               role:
                 type: string
-                enum: [buyer, seller, buyerDiscom, sellerDiscom]
               value:
                 type: number
                 description: >


### PR DESCRIPTION
## Summary

- Remove `enum: [buyer, seller, buyerDiscom, sellerDiscom]` from `RevenueFlow/v2.0/attributes.yaml` `revenueFlows[].role` — same pattern as the DEGContract fix in #361
- Role values are validated at the policy layer (p2p-wave2 network rego N1 `_allowed_roles`) rather than the schema layer, keeping the schema generic

## Schema publication needed

`specification/schema/RevenueFlow/v2.0/attributes.yaml` must be published to schema.beckn.io — the schemav2validator fetches the live schema and will NACK `buyerPlatform`/`sellerPlatform` in `consideration[].considerationAttributes.revenueFlows` until the update is live.

## Test plan

- [ ] Publish `RevenueFlow/v2.0/attributes.yaml` to schema.beckn.io
- [ ] Restart wave2 Docker containers
- [ ] Run `./run-arazzo.sh` — expect 11/13 pass (publish-catalog and discover are known Redocly-limitation failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)