### PR TITLE
feat(wave2): add payment/settlement flows to p2p-trading-ies-wave2 examples

### DIFF
--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
@@ -16,21 +16,22 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "ACTIVE"
+        "code": "SETTLED"
       },
       "commitments": [
         {
           "id": "commitment-p2p-001",
           "status": {
             "descriptor": {
-              "code": "ACTIVE"
+              "code": "SETTLED"
             }
           },
           "resources": [
@@ -277,6 +278,45 @@
             "@type": "DiscomLedgerProvider",
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
+          }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 450.26},
+          "settlementStatus": "COMPLETE",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"],
+          "settlementTermAttributes": {
+            "energyValue": 437.15,
+            "sellerPlatformFee": 13.11,
+            "buyerPlatformFee": 8.74,
+            "totalPayable": 459.0,
+            "paidAt": "2026-04-26T07:30:00Z",
+            "txnRef": "TXN-P2P-001-SETTLED"
+          }
+        }
+      ],
+      "consideration": [
+        {
+          "id": "consideration-p2p-001",
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
+            "@type": "RevenueFlow",
+            "revenueFlows": [
+              {"role": "sellerPlatform", "value": 450.26, "currency": "INR", "description": "Energy sale proceeds + seller platform fee (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5 + 3%)"},
+              {"role": "buyerPlatform", "value": -450.26, "currency": "INR", "description": "Energy purchase net of retained buyer platform fee (2%)"}
+            ]
           }
         }
       ]

--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
@@ -24,7 +24,7 @@
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "CLOSED"
+        "code": "COMPLETE"
       },
       "commitments": [
         {
@@ -289,7 +289,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "COMPLETE",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"],
             "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}

--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
@@ -24,14 +24,14 @@
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "SETTLED"
+        "code": "CLOSED"
       },
       "commitments": [
         {
           "id": "commitment-p2p-001",
           "status": {
             "descriptor": {
-              "code": "SETTLED"
+              "code": "CLOSED"
             }
           },
           "resources": [
@@ -281,33 +281,20 @@
           }
         }
       ],
-      "paymentTerms": [
-        {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
-          "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 450.26},
-          "settlementStatus": "COMPLETE",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"],
-          "settlementTermAttributes": {
-            "energyValue": 437.15,
-            "sellerPlatformFee": 13.11,
-            "buyerPlatformFee": 8.74,
-            "totalPayable": 459.0,
-            "paidAt": "2026-04-26T07:30:00Z",
-            "txnRef": "TXN-P2P-001-SETTLED"
-          }
-        }
-      ],
       "consideration": [
+        {
+          "id": "payment-term-p2p-001",
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 450.26},
+            "settlementStatus": "COMPLETE",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"],
+            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+          }
+        },
         {
           "id": "consideration-p2p-001",
           "considerationAttributes": {

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
@@ -16,21 +16,22 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "ACTIVE"
+        "code": "SETTLED"
       },
       "commitments": [
         {
           "id": "commitment-p2p-001",
           "status": {
             "descriptor": {
-              "code": "ACTIVE"
+              "code": "SETTLED"
             }
           },
           "resources": [
@@ -277,6 +278,45 @@
             "@type": "DiscomLedgerProvider",
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
+          }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 450.26},
+          "settlementStatus": "COMPLETE",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"],
+          "settlementTermAttributes": {
+            "energyValue": 437.15,
+            "sellerPlatformFee": 13.11,
+            "buyerPlatformFee": 8.74,
+            "totalPayable": 459.0,
+            "paidAt": "2026-04-26T07:30:00Z",
+            "txnRef": "TXN-P2P-001-SETTLED"
+          }
+        }
+      ],
+      "consideration": [
+        {
+          "id": "consideration-p2p-001",
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
+            "@type": "RevenueFlow",
+            "revenueFlows": [
+              {"role": "sellerPlatform", "value": 450.26, "currency": "INR", "description": "Energy sale proceeds + seller platform fee (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5 + 3%)"},
+              {"role": "buyerPlatform", "value": -450.26, "currency": "INR", "description": "Energy purchase net of retained buyer platform fee (2%)"}
+            ]
           }
         }
       ]

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
@@ -24,7 +24,7 @@
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "CLOSED"
+        "code": "COMPLETE"
       },
       "commitments": [
         {
@@ -289,7 +289,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "COMPLETE",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"],
             "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
@@ -24,14 +24,14 @@
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "SETTLED"
+        "code": "CLOSED"
       },
       "commitments": [
         {
           "id": "commitment-p2p-001",
           "status": {
             "descriptor": {
-              "code": "SETTLED"
+              "code": "CLOSED"
             }
           },
           "resources": [
@@ -281,33 +281,20 @@
           }
         }
       ],
-      "paymentTerms": [
-        {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
-          "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 450.26},
-          "settlementStatus": "COMPLETE",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"],
-          "settlementTermAttributes": {
-            "energyValue": 437.15,
-            "sellerPlatformFee": 13.11,
-            "buyerPlatformFee": 8.74,
-            "totalPayable": 459.0,
-            "paidAt": "2026-04-26T07:30:00Z",
-            "txnRef": "TXN-P2P-001-SETTLED"
-          }
-        }
-      ],
       "consideration": [
+        {
+          "id": "payment-term-p2p-001",
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 450.26},
+            "settlementStatus": "COMPLETE",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"],
+            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+          }
+        },
         {
           "id": "consideration-p2p-001",
           "considerationAttributes": {

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
@@ -190,22 +190,18 @@
           }
         }
       ],
-      "paymentTerms": [
+      "consideration": [
         {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
           "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 481.0},
-          "settlementStatus": "PENDING",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 481.0},
+            "settlementStatus": "PENDING",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
@@ -198,7 +198,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/confirm-request.json
@@ -16,7 +16,8 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
@@ -187,6 +188,24 @@
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
           }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 481.0},
+          "settlementStatus": "PENDING",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"]
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/init-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/init-request.json
@@ -16,7 +16,8 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
@@ -205,6 +206,17 @@
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
           }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 481.0},
+          "settlementStatus": "PENDING",
+          "acceptedPaymentMethods": ["BANK_TRANSFER"]
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/init-request.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/init-request.json
@@ -208,15 +208,16 @@
           }
         }
       ],
-      "paymentTerms": [
+      "consideration": [
         {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
           "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 481.0},
-          "settlementStatus": "PENDING",
-          "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 481.0},
+            "settlementStatus": "PENDING",
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
@@ -199,7 +199,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
@@ -16,7 +16,8 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
@@ -189,7 +190,25 @@
           }
         }
       ],
-      "id": "contract-p2p-001"
+      "id": "contract-p2p-001",
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 481.0},
+          "settlementStatus": "PENDING",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"]
+        }
+      ]
     }
   }
 }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
@@ -191,22 +191,18 @@
         }
       ],
       "id": "contract-p2p-001",
-      "paymentTerms": [
+      "consideration": [
         {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
           "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 481.0},
-          "settlementStatus": "PENDING",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 481.0},
+            "settlementStatus": "PENDING",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
@@ -190,22 +190,18 @@
           }
         }
       ],
-      "paymentTerms": [
+      "consideration": [
         {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
           "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 481.0},
-          "settlementStatus": "PENDING",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 481.0},
+            "settlementStatus": "PENDING",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
@@ -198,7 +198,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
@@ -16,7 +16,8 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
@@ -187,6 +188,24 @@
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
           }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 481.0},
+          "settlementStatus": "PENDING",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"]
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
@@ -16,21 +16,22 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "ACTIVE"
+        "code": "SETTLED"
       },
       "commitments": [
         {
           "id": "commitment-p2p-001",
           "status": {
             "descriptor": {
-              "code": "ACTIVE"
+              "code": "SETTLED"
             }
           },
           "resources": [
@@ -277,6 +278,45 @@
             "@type": "DiscomLedgerProvider",
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
+          }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 450.26},
+          "settlementStatus": "COMPLETE",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"],
+          "settlementTermAttributes": {
+            "energyValue": 437.15,
+            "sellerPlatformFee": 13.11,
+            "buyerPlatformFee": 8.74,
+            "totalPayable": 459.0,
+            "paidAt": "2026-04-26T07:30:00Z",
+            "txnRef": "TXN-P2P-001-SETTLED"
+          }
+        }
+      ],
+      "consideration": [
+        {
+          "id": "consideration-p2p-001",
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
+            "@type": "RevenueFlow",
+            "revenueFlows": [
+              {"role": "sellerPlatform", "value": 450.26, "currency": "INR", "description": "Energy sale proceeds + seller platform fee (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5 + 3%)"},
+              {"role": "buyerPlatform", "value": -450.26, "currency": "INR", "description": "Energy purchase net of retained buyer platform fee (2%)"}
+            ]
           }
         }
       ]

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
@@ -24,7 +24,7 @@
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "CLOSED"
+        "code": "COMPLETE"
       },
       "commitments": [
         {
@@ -289,7 +289,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "COMPLETE",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"],
             "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
@@ -24,14 +24,14 @@
     "contract": {
       "id": "contract-p2p-001",
       "status": {
-        "code": "SETTLED"
+        "code": "CLOSED"
       },
       "commitments": [
         {
           "id": "commitment-p2p-001",
           "status": {
             "descriptor": {
-              "code": "SETTLED"
+              "code": "CLOSED"
             }
           },
           "resources": [
@@ -281,33 +281,20 @@
           }
         }
       ],
-      "paymentTerms": [
-        {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
-          "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 450.26},
-          "settlementStatus": "COMPLETE",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"],
-          "settlementTermAttributes": {
-            "energyValue": 437.15,
-            "sellerPlatformFee": 13.11,
-            "buyerPlatformFee": 8.74,
-            "totalPayable": 459.0,
-            "paidAt": "2026-04-26T07:30:00Z",
-            "txnRef": "TXN-P2P-001-SETTLED"
-          }
-        }
-      ],
       "consideration": [
+        {
+          "id": "payment-term-p2p-001",
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 450.26},
+            "settlementStatus": "COMPLETE",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"],
+            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+          }
+        },
         {
           "id": "consideration-p2p-001",
           "considerationAttributes": {

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
@@ -281,27 +281,18 @@
           }
         }
       ],
-      "paymentTerms": [
+      "consideration": [
         {
-          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
-          "@type": "SettlementTerm",
           "id": "payment-term-p2p-001",
-          "settlementFor": "sellerPlatform",
-          "amount": {"currency": "INR", "value": 450.26},
-          "settlementStatus": "PENDING",
-          "paymentTrigger": {"code": "ON_FULFILLMENT"},
-          "payTo": {
-            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
-            "accountNumber": "9876543210",
-            "branchCode": "ICICI0005678",
-            "bankName": "ICICI Bank"
-          },
-          "acceptedPaymentMethods": ["BANK_TRANSFER"],
-          "settlementTermAttributes": {
-            "energyValue": 437.15,
-            "sellerPlatformFee": 13.11,
-            "buyerPlatformFee": 8.74,
-            "totalPayable": 459.0
+          "considerationAttributes": {
+            "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "amount": {"currency": "INR", "value": 450.26},
+            "settlementStatus": "PENDING",
+            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"],
+            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0}
           }
         }
       ]

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
@@ -16,7 +16,8 @@
       "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld",
       "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
       "https://schema.beckn.io/BecknTimeSeries/v1.0/context.jsonld",
-      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld"
+      "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld",
+      "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld"
     ]
   },
   "message": {
@@ -277,6 +278,30 @@
             "@type": "DiscomLedgerProvider",
             "utilityId": "TEST_DISCOM_SELLER",
             "ledgerUri": "http://seller-discom-ledger.example.com:9000"
+          }
+        }
+      ],
+      "paymentTerms": [
+        {
+          "@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld",
+          "@type": "SettlementTerm",
+          "id": "payment-term-p2p-001",
+          "settlementFor": "sellerPlatform",
+          "amount": {"currency": "INR", "value": 450.26},
+          "settlementStatus": "PENDING",
+          "paymentTrigger": {"code": "ON_FULFILLMENT"},
+          "payTo": {
+            "accountHolderName": "Solar Farm Energy Provider Pvt Ltd",
+            "accountNumber": "9876543210",
+            "branchCode": "ICICI0005678",
+            "bankName": "ICICI Bank"
+          },
+          "acceptedPaymentMethods": ["BANK_TRANSFER"],
+          "settlementTermAttributes": {
+            "energyValue": 437.15,
+            "sellerPlatformFee": 13.11,
+            "buyerPlatformFee": 8.74,
+            "totalPayable": 459.0
           }
         }
       ]

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
@@ -289,7 +289,7 @@
             "@type": "SettlementTerm",
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "PENDING",
-            "paymentTrigger": {"code": "ON_FULFILLMENT"},
+            "paymentTrigger": "ON_FULFILLMENT",
             "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"],
             "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0}


### PR DESCRIPTION
## Summary

- Adds payment/settlement flows to the wave2 P2P trading devkit using `consideration[]` (beckn-native) as the container for both `SettlementTerm/2.0` and `RevenueFlow/v2.0` objects
- Attaches `https://schema.beckn.io/SettlementTerm/2.0/context.jsonld` to `schemaContext` in all 8 affected examples
- Settlement terms travel from `init` through `settled`, reflecting the agreed-upfront/pay-on-delivery pattern: `paymentTrigger: "ON_FULFILLMENT"`, `settlementStatus` transitions PENDING → COMPLETE

## Payment flow per message

| Message | `settlementStatus` | `amount` | Notes |
|---|---|---|---|
| `init-request` | PENDING | ₹481 (est.) | Buyer declares `BANK_TRANSFER` intent; no `payTo` yet |
| `on-init-response` | PENDING | ₹481 (est.) | Seller adds `payTo` (ICICI Bank) + `ON_FULFILLMENT` trigger |
| `confirm-request` | PENDING | ₹481 (est.) | Buyer echoes — accepts terms |
| `on-confirm-response` | PENDING | ₹481 (est.) | Contract `ACTIVE` |
| `on-status` (performance) | PENDING | ₹450.26 | Amount updated to `FINAL_ALLOC × price + 3% seller fee`; `settlementTermAttributes` shows breakdown (energyValue ₹437.15, sellerFee ₹13.11, buyerFee ₹8.74, totalPayable ₹459) |
| `on-status` (settled) ×3 | **COMPLETE** | ₹450.26 | `paidAt` + `txnRef` filled; consideration also carries net-zero RevenueFlow |

## Schema decisions

- **`consideration[]` not `paymentTerms[]`**: `paymentTerms` is not defined in the beckn v2.0.0-lts `Contract` schema (`additionalProperties: false`); `consideration[].considerationAttributes` is the beckn-native extension point for both SettlementTerm and RevenueFlow objects
- **`paymentTrigger: "ON_FULFILLMENT"`**: SettlementTerm/2.0 defines `paymentTrigger` as a string enum `[PRE_ORDER, PRE_FULFILLMENT, ON_FULFILLMENT, POST_FULFILLMENT]`, not a code-object
- **Contract status `COMPLETE`**: beckn core enum for `Contract.status.code` is `[DRAFT, ACTIVE, CANCELLED, COMPLETE]`; settled contracts use `COMPLETE`
- **Commitment status `CLOSED`**: beckn core enum for `Commitment.status.descriptor.code` is `[DRAFT, ACTIVE, CLOSED]`; fulfilled commitments use `CLOSED`

## Wave1 attributes not carried forward

| Wave1 field | Reason |
|---|---|
| `paymentStatus: INITIATED / AUTHORIZED` | Wave2 settles post-delivery; no pre-payment auth flow |
| `beckn:beneficiary: "BPP"` | Implicit in `payTo`; role name not needed |
| `acceptedPaymentMethod: UPI / WALLET` | UPI expressed via `payTo.vpa`; WALLET has no SettlementTerm enum |
| `settlementAccounts[]` (array) | Wave2 uses one SettlementTerm per payee; extensible via additional `consideration[]` items |
| `paidAt`, `txnRef` | No top-level field in SettlementTerm/2.0; placed in `settlementTermAttributes` |

## Test plan

- [x] All 8 modified JSON files parse without error
- [x] `revenueFlows` sum = 0 in settled examples (sellerPlatform +₹450.26, buyerPlatform −₹450.26)
- [x] Arazzo: 12/13 workflows pass (`discover` is a pre-existing Redocly runtime-expression bug, unrelated to this PR)
- [x] NACK check: PASSED — all steps returned ACK
- [x] `consideration[0].considerationAttributes.settlementStatus: COMPLETE` only in settled variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)