### PR TITLE
feat(wave2): settlements[], platform payTo, and payment method variants

### DIFF
--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
@@ -290,21 +290,28 @@
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "COMPLETE",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
-            "acceptedPaymentMethods": ["BANK_TRANSFER"],
-            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         },
         {
-          "id": "consideration-p2p-001",
+          "id": "auto-revenue-flows",
           "considerationAttributes": {
             "@context": "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
             "@type": "RevenueFlow",
             "revenueFlows": [
-              {"role": "sellerPlatform", "value": 450.26, "currency": "INR", "description": "Energy sale proceeds + seller platform fee (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5 + 3%)"},
-              {"role": "buyerPlatform", "value": -450.26, "currency": "INR", "description": "Energy purchase net of retained buyer platform fee (2%)"}
+              {"role": "sellerPlatform", "value": 437.15, "currency": "INR", "description": "Energy sale proceeds (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5)"},
+              {"role": "buyerPlatform", "value": -437.15, "currency": "INR", "description": "Energy purchase cost (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5)"}
             ]
           }
+        }
+      ],
+      "settlements": [
+        {
+          "id": "settlement-p2p-001",
+          "considerationId": "payment-term-p2p-001",
+          "status": "COMPLETE",
+          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST", "energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
@@ -290,21 +290,28 @@
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "COMPLETE",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
-            "acceptedPaymentMethods": ["BANK_TRANSFER"],
-            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         },
         {
-          "id": "consideration-p2p-001",
+          "id": "auto-revenue-flows",
           "considerationAttributes": {
             "@context": "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
             "@type": "RevenueFlow",
             "revenueFlows": [
-              {"role": "sellerPlatform", "value": 450.26, "currency": "INR", "description": "Energy sale proceeds + seller platform fee (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5 + 3%)"},
-              {"role": "buyerPlatform", "value": -450.26, "currency": "INR", "description": "Energy purchase net of retained buyer platform fee (2%)"}
+              {"role": "sellerPlatform", "value": 437.15, "currency": "INR", "description": "Energy sale proceeds (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5)"},
+              {"role": "buyerPlatform", "value": -437.15, "currency": "INR", "description": "Energy purchase cost (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5)"}
             ]
           }
+        }
+      ],
+      "settlements": [
+        {
+          "id": "settlement-p2p-001",
+          "considerationId": "payment-term-p2p-001",
+          "status": "COMPLETE",
+          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST", "energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-confirm-response.json
@@ -200,9 +200,17 @@
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
+        }
+      ],
+      "settlements": [
+        {
+          "id": "settlement-p2p-001",
+          "considerationId": "payment-term-p2p-001",
+          "status": "COMMITTED",
+          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 35 kWh on 2026-04-26 10:00-12:00 IST"}
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response-paymenturl.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response-paymenturl.json
@@ -2,14 +2,14 @@
   "context": {
     "networkId": "nfh.global/testnet-deg",
     "version": "2.0.0",
-    "action": "confirm",
+    "action": "on_init",
     "bapId": "buyerapp.example.com",
     "bapUri": "http://buyerapp.example.com:9000/bap/receiver",
     "bppId": "sellerapp.example.com",
     "bppUri": "http://sellerapp.example.com:9000/bpp/receiver",
     "transactionId": "1268c204-675b-4adb-9321-b08231b147b2",
-    "messageId": "54fb3f15-48aa-4408-bca4-52486b767679",
-    "timestamp": "2026-04-25T10:10:00Z",
+    "messageId": "a7c35d2f-9e14-4f61-b827-6d41e0f83c92",
+    "timestamp": "2026-04-25T10:05:05Z",
     "schemaContext": [
       "https://schema.beckn.io/EnergyTradeOffer/v2.0/context.jsonld",
       "https://schema.beckn.io/EnergyResource/v2.0/context.jsonld",
@@ -66,52 +66,22 @@
               "duration": "PT1H"
             },
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "PRICE_PER_KWH",
-                "currency": "INR",
-                "insertedBy": "sellerPlatform"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "REQUESTED_QTY",
-                "units": "KWH",
-                "insertedBy": "buyerPlatform"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE_PER_KWH", "currency": "INR", "insertedBy": "sellerPlatform"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "REQUESTED_QTY", "units": "KWH", "insertedBy": "buyerPlatform"}
             ],
             "intervals": [
               {
                 "id": 0,
                 "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      12.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      20.5
-                    ]
-                  }
+                  {"type": "PRICE_PER_KWH", "values": [12.5]},
+                  {"type": "REQUESTED_QTY", "values": [20.5]}
                 ]
               },
               {
                 "id": 1,
                 "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      14.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      15.5
-                    ]
-                  }
+                  {"type": "PRICE_PER_KWH", "values": [14.5]},
+                  {"type": "REQUESTED_QTY", "values": [15.5]}
                 ]
               }
             ]
@@ -122,22 +92,10 @@
         "@context": "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [
-          {
-            "role": "buyerPlatform",
-            "participantId": "buyerapp.example.com"
-          },
-          {
-            "role": "sellerPlatform",
-            "participantId": "sellerapp.example.com"
-          },
-          {
-            "role": "buyerDiscom",
-            "participantId": "buyer-discom-ledger.example.com"
-          },
-          {
-            "role": "sellerDiscom",
-            "participantId": "seller-discom-ledger.example.com"
-          }
+          {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
+          {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
+          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
+          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
         ],
         "policy": {
           "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/p2p_trading_ies_wave2_revenue.rego",
@@ -199,17 +157,9 @@
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
-            "acceptedPaymentMethods": ["BANK_TRANSFER"]
+            "payTo": {"paymentUrl": "https://pay.sellerplatform.example.com/invoice/offer-p2p-001"},
+            "acceptedPaymentMethods": ["PAYMENT_URL"]
           }
-        }
-      ],
-      "settlements": [
-        {
-          "id": "settlement-p2p-001",
-          "considerationId": "payment-term-p2p-001",
-          "status": "DRAFT",
-          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 35 kWh on 2026-04-26 10:00-12:00 IST"}
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response-vpa.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response-vpa.json
@@ -2,14 +2,14 @@
   "context": {
     "networkId": "nfh.global/testnet-deg",
     "version": "2.0.0",
-    "action": "confirm",
+    "action": "on_init",
     "bapId": "buyerapp.example.com",
     "bapUri": "http://buyerapp.example.com:9000/bap/receiver",
     "bppId": "sellerapp.example.com",
     "bppUri": "http://sellerapp.example.com:9000/bpp/receiver",
     "transactionId": "1268c204-675b-4adb-9321-b08231b147b2",
-    "messageId": "54fb3f15-48aa-4408-bca4-52486b767679",
-    "timestamp": "2026-04-25T10:10:00Z",
+    "messageId": "f3a91c4e-7d02-4b88-a315-9e52d0c84f17",
+    "timestamp": "2026-04-25T10:05:05Z",
     "schemaContext": [
       "https://schema.beckn.io/EnergyTradeOffer/v2.0/context.jsonld",
       "https://schema.beckn.io/EnergyResource/v2.0/context.jsonld",
@@ -66,52 +66,22 @@
               "duration": "PT1H"
             },
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "PRICE_PER_KWH",
-                "currency": "INR",
-                "insertedBy": "sellerPlatform"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "REQUESTED_QTY",
-                "units": "KWH",
-                "insertedBy": "buyerPlatform"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE_PER_KWH", "currency": "INR", "insertedBy": "sellerPlatform"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "REQUESTED_QTY", "units": "KWH", "insertedBy": "buyerPlatform"}
             ],
             "intervals": [
               {
                 "id": 0,
                 "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      12.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      20.5
-                    ]
-                  }
+                  {"type": "PRICE_PER_KWH", "values": [12.5]},
+                  {"type": "REQUESTED_QTY", "values": [20.5]}
                 ]
               },
               {
                 "id": 1,
                 "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      14.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      15.5
-                    ]
-                  }
+                  {"type": "PRICE_PER_KWH", "values": [14.5]},
+                  {"type": "REQUESTED_QTY", "values": [15.5]}
                 ]
               }
             ]
@@ -122,22 +92,10 @@
         "@context": "https://schema.beckn.io/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [
-          {
-            "role": "buyerPlatform",
-            "participantId": "buyerapp.example.com"
-          },
-          {
-            "role": "sellerPlatform",
-            "participantId": "sellerapp.example.com"
-          },
-          {
-            "role": "buyerDiscom",
-            "participantId": "buyer-discom-ledger.example.com"
-          },
-          {
-            "role": "sellerDiscom",
-            "participantId": "seller-discom-ledger.example.com"
-          }
+          {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
+          {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
+          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
+          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
         ],
         "policy": {
           "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/p2p_trading_ies_wave2_revenue.rego",
@@ -199,17 +157,9 @@
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
-            "acceptedPaymentMethods": ["BANK_TRANSFER"]
+            "payTo": {"vpa": "sellerplatform@hdfc"},
+            "acceptedPaymentMethods": ["UPI"]
           }
-        }
-      ],
-      "settlements": [
-        {
-          "id": "settlement-p2p-001",
-          "considerationId": "payment-term-p2p-001",
-          "status": "DRAFT",
-          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 35 kWh on 2026-04-26 10:00-12:00 IST"}
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-init-response.json
@@ -199,7 +199,7 @@
             "amount": {"currency": "INR", "value": 481.0},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
+            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-settled.json
@@ -290,21 +290,28 @@
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "COMPLETE",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
-            "acceptedPaymentMethods": ["BANK_TRANSFER"],
-            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         },
         {
-          "id": "consideration-p2p-001",
+          "id": "auto-revenue-flows",
           "considerationAttributes": {
             "@context": "https://schema.beckn.io/RevenueFlow/v2.0/context.jsonld",
             "@type": "RevenueFlow",
             "revenueFlows": [
-              {"role": "sellerPlatform", "value": 450.26, "currency": "INR", "description": "Energy sale proceeds + seller platform fee (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5 + 3%)"},
-              {"role": "buyerPlatform", "value": -450.26, "currency": "INR", "description": "Energy purchase net of retained buyer platform fee (2%)"}
+              {"role": "sellerPlatform", "value": 437.15, "currency": "INR", "description": "Energy sale proceeds (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5)"},
+              {"role": "buyerPlatform", "value": -437.15, "currency": "INR", "description": "Energy purchase cost (18.5 kWh × ₹12.5 + 14.2 kWh × ₹14.5)"}
             ]
           }
+        }
+      ],
+      "settlements": [
+        {
+          "id": "settlement-p2p-001",
+          "considerationId": "payment-term-p2p-001",
+          "status": "COMPLETE",
+          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST", "energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/on-status-response-with-performance.json
@@ -290,10 +290,17 @@
             "amount": {"currency": "INR", "value": 450.26},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {"accountHolderName": "Solar Farm Energy Provider Pvt Ltd", "accountNumber": "9876543210", "branchCode": "ICICI0005678", "bankName": "ICICI Bank"},
-            "acceptedPaymentMethods": ["BANK_TRANSFER"],
-            "settlementTermAttributes": {"energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0}
+            "payTo": {"accountHolderName": "Seller Platform Pvt Ltd", "accountNumber": "0012345678901", "branchCode": "HDFC0001234", "bankName": "HDFC Bank"},
+            "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
+        }
+      ],
+      "settlements": [
+        {
+          "id": "settlement-p2p-001",
+          "considerationId": "payment-term-p2p-001",
+          "status": "COMMITTED",
+          "settlementAttributes": {"@context": "https://schema.beckn.io/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST", "energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0}
         }
       ]
     }


### PR DESCRIPTION
## Summary

- **`settlements[]` discharge records**: Adds `contract.settlements[]` as the first-class beckn field for payment discharge evidence, separating it cleanly from `consideration[]` (which holds obligations). The single settlement record `settlement-p2p-001` progresses `DRAFT → COMMITTED → COMPLETE` across confirm / on-confirm / on-status-with-performance / on-status-settled.
- **Discharge data moved**: `energyValue`, `sellerPlatformFee`, `buyerPlatformFee`, `totalPayable`, `paidAt`, `txnRef` are now in `settlements[].settlementAttributes` (typed `SettlementTerm`). The `SettlementTerm` consideration stays clean with just the obligation fields.
- **Platform as payee**: All `payTo` entries updated from the end-seller's bank account to the seller platform's account (`Seller Platform Pvt Ltd / HDFC`). The platform handles seller-side distribution off-beckn.
- **RevenueFlow corrected**: `consideration[id=consideration-p2p-001]` renamed to `auto-revenue-flows` (matching what the revenueflows plugin actually inserts). Values corrected from ±450.26 → ±437.15 (energy only; plugin does not include platform fees in flow computation).
- **Payment method variants**: New example files showing alternative `payTo` options — `on-init-response-vpa.json` (UPI VPA `sellerplatform@hdfc`) and `on-init-response-paymenturl.json` (hosted payment URL).

## Architecture

```
consideration[]          → obligations (WHAT is owed and HOW to pay)
  [0] SettlementTerm     → amount, payTo, trigger, methods
  [1] auto-revenue-flows → plugin-computed net energy flows per role

settlements[]            → discharge evidence (PROOF of payment)
  [0] settlement-p2p-001 → DRAFT → COMMITTED → COMPLETE
                           settlementAttributes: energyValue, fees, paidAt, txnRef
```

## Test plan

- [x] Arazzo: 12/13 passing (`discover` pre-existing Redocly 2.13.0 runtime-expression failure, unchanged)
- [x] NACK check: PASSED — all steps return ACK
- [x] `settlements[].settlementAttributes` validated as `@type: SettlementTerm` (SettlementTerm schema has no `additionalProperties: false`, so extension fields pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)