### PR TITLE
Updated Wave 2 URL-key handling in degledgerrecorder to align with the latest p2p_wave_2 payload shape.

### DIFF
--- a/devkits/p2p-trading-ies-wave2/README.md
+++ b/devkits/p2p-trading-ies-wave2/README.md
@@ -34,7 +34,7 @@ The contract names four conceptual actors. Only buyer and seller speak Beckn dir
 | [EnergyTradeOffer](../../specification/schema/EnergyTradeOffer/v2.0/) | `offerAttributes` | Pricing model, validity / delivery window |
 | [EnergyTradeDelivery](../../specification/schema/EnergyTradeDelivery/v2.0/) | `performance.performanceAttributes` | Delivery status, meter readings, settled qty |
 | [DEGContract](../../specification/schema/DEGContract/v2.0/) | `contractAttributes` | Roles, policy reference, computed revenueFlows |
-| [DiscomLedgerProvider](../../specification/schema/DiscomLedgerProvider/v1.0/) | `participants[role=buyerDiscom\|sellerDiscom].participantAttributes` | Discom ledger TSP identity — `utilityId` + `ledgerUri` so the `degledgerrecorder` plugin can pick the right ledger URL per discom from the payload |
+| [DiscomLedgerProvider](../../specification/schema/DiscomLedgerProvider/v1.0/) | `participants[role=buyerDiscom\|sellerDiscom].participantAttributes` | Discom ledger TSP identity — `utilityId` + `ledgerUrl` so the `degledgerrecorder` plugin can pick the right ledger URL per discom from the payload |
 
 ## Postman
 
@@ -61,8 +61,8 @@ Signature/registry lookups currently target `nfh.global/testnet-deg` via the `al
 ## Ledger recording
 
 On `on_confirm` both platforms write a trade record to their own discom's ledger TSP via the [`degledgerrecorder`](../../plugins/degledgerrecorder/) plugin:
-- BAP-Receiver runs the plugin with `role: BUYER` and reads `participants[role=buyerDiscom].participantAttributes.ledgerUri` from the payload.
-- BPP-Caller runs the plugin with `role: SELLER` and reads `participants[role=sellerDiscom].participantAttributes.ledgerUri` from the payload.
+- BAP-Receiver runs the plugin with `role: BUYER` and reads `participants[role=buyerDiscom].participantAttributes.ledgerUrl` from the payload.
+- BPP-Caller runs the plugin with `role: SELLER` and reads `participants[role=sellerDiscom].participantAttributes.ledgerUrl` from the payload.
 
 Both URIs are wired in the example payloads to the IES ledger service (`https://ies-p2p-energy-ledger.beckn.io`); two discoms MAY share a TSP — each platform still writes only to its own side.
 

--- a/plugins/degledgerrecorder/README.md
+++ b/plugins/degledgerrecorder/README.md
@@ -14,7 +14,6 @@ This plugin intercepts Beckn protocol messages and records or cascades them to t
 - Asynchronous operation for legacy writes and status/on_status cascades
 - Blocking Wave 2 Beckn `on_confirm` ledger writes before onward forwarding
 - Configurable role (BUYER, SELLER, BUYER_DISCOM, SELLER_DISCOM)
-- Idempotent requests using client reference
 - **Beckn-style signature authentication** (same as beckn-onix outgoing messages)
 - Detailed request/response logging for debugging
 
@@ -61,7 +60,7 @@ steps:
 | Option | Values | Description |
 |--------|--------|-------------|
 | `payloadShape` | `wave1`, `wave2` | Which on_confirm body the mapper expects. `wave1` = `beckn:Order`/`orderItems` (p2p-trading-ies-wave1). `wave2` = `message.contract.commitments` (p2p-trading-ies-wave2, P2PTrade/v2.0). |
-| `ledgerUriSource` | `config`, `payload` | Where to find the target ledger base URL. `config` reads `ledgerHost`. `payload` reads `participants[role=buyerDiscom\|sellerDiscom].participantAttributes.ledgerUri` from the on_confirm body — required for wave2 since the URI varies per discom. |
+| `ledgerUriSource` | `config`, `payload` | Where to find the target ledger base URL. `config` reads `ledgerHost`. `payload` reads `participants[role=buyerDiscom\|sellerDiscom].participantAttributes.ledgerUrl` from the on_confirm body — required for wave2 since the URL varies per discom. |
 | `ledgerApi` | `legacy_ledger`, `beckn` | API style. `legacy_ledger` POSTs to `<uri>/ledger/put` with the custom JSON body. `beckn` POSTs the original on_confirm verbatim (with rewritten context) to `<uri>/on_confirm` and expects a beckn ACK envelope wrapping the legacy ledger response. |
 
 #### Core Settings
@@ -81,12 +80,12 @@ steps:
 #### Per-call ledger URI from payload
 
 When `ledgerUriSource=payload`, the plugin picks the URI based on `role`:
-- `BUYER` → `participants[role=buyerDiscom].participantAttributes.ledgerUri`
-- `SELLER` → `participants[role=sellerDiscom].participantAttributes.ledgerUri`
+- `BUYER` → `participants[role=buyerDiscom].participantAttributes.ledgerUrl`
+- `SELLER` → `participants[role=sellerDiscom].participantAttributes.ledgerUrl`
 
 A platform instance (BAP or BPP) only writes to its own side's discom ledger. The same trade is logged in two ledgers (one per discom) at the system level, with each platform contacting only its own; if the two discoms share a TSP, both calls land at the same URL.
 
-The discom `ledgerUri` is carried via the [`DiscomLedgerProvider/v1.0`](../../specification/schema/DiscomLedgerProvider/v1.0/) schema.
+The discom `ledgerUrl` is carried via the [`DiscomLedgerProvider/v1.0`](../../specification/schema/DiscomLedgerProvider/v1.0/) schema.
 
 #### `ledgerApi: beckn` mode
 
@@ -109,9 +108,6 @@ The plugin then POSTs the rewritten body to `<discomLedgerUri>/bap/receiver/on_c
     "status":    "ACK",
     "messageId": "8153a419-35b1-4ec8-bd23-16fcff1b7964",
     "ledger":    { "success": true, "recordId": "rec-...", "creationTime": "...", "rowDigest": "sha256:..." }
-  },
-  "details": {
-    "message": "Records already exist; skipped duplicate on_confirm"
   }
 }
 ```
@@ -121,10 +117,6 @@ object. The inner `message.ledger` block carries the same fields the legacy
 `/ledger/put` API used to return; the plugin surfaces it identically so
 call-site logging stays uniform across the two modes.
 
-If `message.ledger.message` is empty (e.g. when the ledger skips a duplicate
-write), the plugin copies `details.message` into the ledger response so the
-success log always includes a human-readable reason.
-
 For Wave 2 `ledgerApi: beckn`, every Beckn send must receive HTTP 2xx with `message.status = "ACK"` (flat — no nested `ack` object). Network errors, timeouts, non-2xx responses, malformed bodies, missing ACK, and NACK are retried using `retryCount` and `retryMaxTTL`.
 
 Each send attempt waits up to `asyncTimeout` for ACK. `asyncTimeout` defaults to `5000` ms and is configurable in the plugin YAML. `retryBackoff` is only the wait between failed attempts and defaults to `5s`.
@@ -133,7 +125,7 @@ Each send attempt waits up to `asyncTimeout` for ACK. `asyncTimeout` defaults to
 retryBackoff: "5s"
 ```
 
-Wave 2 `on_confirm` is synchronous. The ONIX step returns `nil` only after the DISCOM ledger returns ACK. If the ledger write is still not ACKed after retry exhaustion, or the target `ledgerUri` cannot be resolved from the contract participants, the step returns an error and ONIX does not forward the original `on_confirm` to the next trading platform. On success, the log line includes the `message` field from the ledger response (or `details.message` when the ledger skips a duplicate).
+Wave 2 `on_confirm` is synchronous. The ONIX step returns `nil` only after the DISCOM ledger returns ACK. If the ledger write is still not ACKed after retry exhaustion, or the target `ledgerUrl` cannot be resolved from the contract participants, the step returns an error and ONIX does not forward the original `on_confirm` to the next trading platform.
 
 Wave 2 `status` and `on_status` cascades remain asynchronous. The plugin keeps the pending payload in memory only while retrying and removes it after ACK or final failure. If an async `on_status` cascade exhausts retries, the plugin sends a best-effort error `on_status` callback back to the original sender with `error.code = "DEG_ASYNC_ACK_TIMEOUT"`.
 
@@ -246,7 +238,7 @@ plugins:
     - id: degledgerrecorder
       config:
         payloadShape: wave2
-        ledgerUriSource: payload         # read from participants[role=*Discom].participantAttributes.ledgerUri
+        ledgerUriSource: payload         # read from participants[role=*Discom].participantAttributes.ledgerUrl
         ledgerApi: legacy_ledger         # flip to "beckn" once the TSP is upgraded
         # ledgerHost intentionally omitted — the URI comes from the payload
         role: "BUYER"                    # BUYER on BAP side reads buyerDiscom; SELLER on BPP reads sellerDiscom
@@ -266,7 +258,7 @@ The on_confirm payload must carry, in `message.contract.participants`:
     "@context": ".../specification/schema/DiscomLedgerProvider/v1.0/context.jsonld",
     "@type": "DiscomLedgerProvider",
     "utilityId": "BRPL-DL",
-    "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+    "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io"
   }
 }
 ```

--- a/plugins/degledgerrecorder/config.go
+++ b/plugins/degledgerrecorder/config.go
@@ -34,7 +34,7 @@ const (
 // Sources for the target ledger URI.
 const (
 	LedgerUriSourceConfig  = "config"  // use plugin config ledgerHost
-	LedgerUriSourcePayload = "payload" // read participants[role=*Discom].participantAttributes.ledgerUri from payload
+	LedgerUriSourcePayload = "payload" // read participants[role=*Discom].participantAttributes.ledgerUrl from payload
 )
 
 // Ledger API styles the plugin can speak to.
@@ -51,7 +51,7 @@ type Config struct {
 
 	// LedgerUriSource determines where the target ledger URI comes from.
 	// Required. One of: "config" (uses LedgerHost), "payload" (reads
-	// participants[role=*Discom].participantAttributes.ledgerUri).
+	// participants[role=*Discom].participantAttributes.ledgerUrl).
 	LedgerUriSource string
 
 	// LedgerApi selects which API style the plugin speaks.

--- a/plugins/degledgerrecorder/mapper_wave2.go
+++ b/plugins/degledgerrecorder/mapper_wave2.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Side identifies which discom's ledgerUri to read from the payload.
+// Side identifies which discom's ledgerUrl to read from the payload.
 type Side string
 
 const (
@@ -235,12 +235,12 @@ func MapWave2ToLedgerRecords(payload *Wave2OnConfirmPayload, role string) ([]Led
 	return records, nil
 }
 
-// ExtractWave2DiscomLedgerUri returns the ledgerUri for the requested side from
-// `participants[role=buyerDiscom|sellerDiscom].participantAttributes.ledgerUri`.
-// Returns "" if the side is missing or has no ledgerUri.
-func ExtractWave2DiscomLedgerUri(payload *Wave2OnConfirmPayload, side Side) string {
+// ExtractWave2DiscomLedgerURL returns the ledgerUrl for the requested side from
+// `participants[role=buyerDiscom|sellerDiscom].participantAttributes.ledgerUrl`.
+// Returns "" if the side is missing or has no ledgerUrl.
+func ExtractWave2DiscomLedgerURL(payload *Wave2OnConfirmPayload, side Side) string {
 	part := findWave2Participant(payload.Message.Contract.Participants, string(side))
-	return wave2StringAttr(part, "ledgerUri")
+	return wave2StringAttr(part, "ledgerUrl")
 }
 
 // findWave2Participant returns the first participant entry matching the role.
@@ -478,7 +478,7 @@ func extractWave2IntervalIDs(offerAttrs map[string]interface{}) []int {
 // -------------------------
 
 // Wave2StatusPayload is the wave2 `status` request body. The contract carries
-// minimum id + participants (with ledgerUri) so the plugin can route to the
+// minimum id + participants (with ledgerUrl) so the plugin can route to the
 // right ledger without a cache lookup. Carries optional ack/error so
 // ShouldSkipCascade can stay symmetric across all three message shapes.
 type Wave2StatusPayload struct {
@@ -507,12 +507,12 @@ func ParseStatusWave2(body []byte) (*Wave2StatusPayload, error) {
 	return &payload, nil
 }
 
-// ExtractWave2StatusDiscomLedgerUri returns the ledgerUri for the given side
+// ExtractWave2StatusDiscomLedgerURL returns the ledgerUrl for the given side
 // from a wave2 status payload's participants array.
-func ExtractWave2StatusDiscomLedgerUri(payload *Wave2StatusPayload, side Side) string {
+func ExtractWave2StatusDiscomLedgerURL(payload *Wave2StatusPayload, side Side) string {
 	for i := range payload.Message.Contract.Participants {
 		if payload.Message.Contract.Participants[i].Role == string(side) {
-			return wave2StringAttr(&payload.Message.Contract.Participants[i], "ledgerUri")
+			return wave2StringAttr(&payload.Message.Contract.Participants[i], "ledgerUrl")
 		}
 	}
 	return ""
@@ -669,11 +669,11 @@ func timeseriesHasPerformanceData(ts map[string]interface{}) bool {
 	return false
 }
 
-// ExtractWave2OnStatusDiscomLedgerUri returns ledgerUri for the given side.
-func ExtractWave2OnStatusDiscomLedgerUri(payload *Wave2OnStatusPayload, side Side) string {
+// ExtractWave2OnStatusDiscomLedgerURL returns ledgerUrl for the given side.
+func ExtractWave2OnStatusDiscomLedgerURL(payload *Wave2OnStatusPayload, side Side) string {
 	for i := range payload.Message.Contract.Participants {
 		if payload.Message.Contract.Participants[i].Role == string(side) {
-			return wave2StringAttr(&payload.Message.Contract.Participants[i], "ledgerUri")
+			return wave2StringAttr(&payload.Message.Contract.Participants[i], "ledgerUrl")
 		}
 	}
 	return ""
@@ -692,7 +692,7 @@ func DeriveSenderHostFromWave2OnStatus(payload *Wave2OnStatusPayload, role strin
 }
 
 // ParticipantEndpointURI returns participants[role=<role>].participantAttributes.<key>,
-// or "" if missing. Used to look up bapUri/bppUri/ledgerUri for trading platforms
+// or "" if missing. Used to look up platformUrl/ledgerUrl for trading platforms
 // and discoms when rewriting context for a cascade sub-transaction.
 func ParticipantEndpointURI(participants []Wave2Participant, role, key string) string {
 	for i := range participants {

--- a/plugins/degledgerrecorder/mapper_wave2_test.go
+++ b/plugins/degledgerrecorder/mapper_wave2_test.go
@@ -7,7 +7,7 @@ import (
 // Trimmed wave2 on_confirm body covering all the fields the mapper reads:
 // context (transactionId, bapId, bppId, timestamp), participants
 // (buyerPlatform/sellerPlatform with utilityId+meterId, buyerDiscom/sellerDiscom with
-// ledgerUri), and a single commitment with a seller-side delivery window.
+// ledgerUrl), and a single commitment with a seller-side delivery window.
 const sampleWave2OnConfirm = `{
   "context": {
     "networkId": "nfh.global/testnet-deg",
@@ -95,7 +95,7 @@ const sampleWave2OnConfirm = `{
           "participantAttributes": {
             "@type": "DiscomLedgerProvider",
             "utilityId": "BRPL-DL",
-            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+            "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io"
           }
         },
         {
@@ -104,7 +104,7 @@ const sampleWave2OnConfirm = `{
           "participantAttributes": {
             "@type": "DiscomLedgerProvider",
             "utilityId": "TPDDL-DL",
-            "ledgerUri": "https://ies-p2p-energy-ledger.beckn.io"
+            "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io"
           }
         }
       ]
@@ -195,30 +195,41 @@ func TestMapWave2ToLedgerRecord_FallsBackToContextWhenParticipantIDEmpty(t *test
 	}
 }
 
-func TestExtractWave2DiscomLedgerUri(t *testing.T) {
+func TestExtractWave2DiscomLedgerURL(t *testing.T) {
 	p, err := ParseOnConfirmWave2([]byte(sampleWave2OnConfirm))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if got := ExtractWave2DiscomLedgerUri(p, SideBuyer); got != "https://ies-p2p-energy-ledger.beckn.io" {
-		t.Errorf("buyerDiscom ledgerUri: got %q", got)
+	if got := ExtractWave2DiscomLedgerURL(p, SideBuyer); got != "https://ies-p2p-energy-ledger.beckn.io" {
+		t.Errorf("buyerDiscom ledgerUrl: got %q", got)
 	}
-	if got := ExtractWave2DiscomLedgerUri(p, SideSeller); got != "https://ies-p2p-energy-ledger.beckn.io" {
-		t.Errorf("sellerDiscom ledgerUri: got %q", got)
+	if got := ExtractWave2DiscomLedgerURL(p, SideSeller); got != "https://ies-p2p-energy-ledger.beckn.io" {
+		t.Errorf("sellerDiscom ledgerUrl: got %q", got)
 	}
 }
 
-func TestExtractWave2DiscomLedgerUri_MissingReturnsEmpty(t *testing.T) {
-	const noLedgerUri = `{"context":{"transactionId":"x"},"message":{"contract":{"participants":[{"role":"buyerDiscom","participantId":"x"}]}}}`
-	p, err := ParseOnConfirmWave2([]byte(noLedgerUri))
+func TestExtractWave2DiscomLedgerURL_MissingReturnsEmpty(t *testing.T) {
+	const noLedgerURL = `{"context":{"transactionId":"x"},"message":{"contract":{"participants":[{"role":"buyerDiscom","participantId":"x"}]}}}`
+	p, err := ParseOnConfirmWave2([]byte(noLedgerURL))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if got := ExtractWave2DiscomLedgerUri(p, SideBuyer); got != "" {
+	if got := ExtractWave2DiscomLedgerURL(p, SideBuyer); got != "" {
 		t.Errorf("expected empty, got %q", got)
 	}
-	if got := ExtractWave2DiscomLedgerUri(p, SideSeller); got != "" {
+	if got := ExtractWave2DiscomLedgerURL(p, SideSeller); got != "" {
 		t.Errorf("expected empty for missing side, got %q", got)
+	}
+}
+
+func TestExtractWave2DiscomLedgerURL_DoesNotReadLegacyLedgerUri(t *testing.T) {
+	const legacyOnly = `{"context":{"transactionId":"x"},"message":{"contract":{"participants":[{"role":"buyerDiscom","participantId":"x","participantAttributes":{"ledgerUri":"https://legacy.example.com"}}]}}}`
+	p, err := ParseOnConfirmWave2([]byte(legacyOnly))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := ExtractWave2DiscomLedgerURL(p, SideBuyer); got != "" {
+		t.Errorf("expected legacy ledgerUri to be ignored, got %q", got)
 	}
 }
 

--- a/plugins/degledgerrecorder/recorder.go
+++ b/plugins/degledgerrecorder/recorder.go
@@ -393,7 +393,7 @@ func (r *DEGLedgerRecorder) sendBecknOnConfirmAsync(parentCtx *model.StepContext
 
 // resolveWave2BaseURL picks the target ledger URL according to LedgerUriSource.
 // For payload mode, the side is determined by the configured role:
-// BUYER → buyerDiscom.ledgerUri, SELLER → sellerDiscom.ledgerUri.
+// BUYER → buyerDiscom.ledgerUrl, SELLER → sellerDiscom.ledgerUrl.
 func (r *DEGLedgerRecorder) resolveWave2BaseURL(payload *Wave2OnConfirmPayload) (string, error) {
 	switch r.config.LedgerUriSource {
 	case LedgerUriSourceConfig:
@@ -411,9 +411,9 @@ func (r *DEGLedgerRecorder) resolveWave2BaseURL(payload *Wave2OnConfirmPayload) 
 		default:
 			return "", fmt.Errorf("payload-sourced ledger URI requires role BUYER or SELLER, got %s", r.config.Role)
 		}
-		uri := ExtractWave2DiscomLedgerUri(payload, side)
+		uri := ExtractWave2DiscomLedgerURL(payload, side)
 		if uri == "" {
-			return "", fmt.Errorf("no ledgerUri found in participants[role=%s].participantAttributes", side)
+			return "", fmt.Errorf("no ledgerUrl found in participants[role=%s].participantAttributes", side)
 		}
 		return uri, nil
 	default:
@@ -488,7 +488,7 @@ func (r *DEGLedgerRecorder) handleOnStatus(ctx *model.StepContext) error {
 // handleStatus forwards an incoming wave2 beckn `status` request to the
 // appropriate discom ledger as a beckn `status` call. The ledger will
 // asynchronously call back with `on_status`.
-// SELLER role → sellerDiscom.ledgerUri; BUYER role → buyerDiscom.ledgerUri.
+// SELLER role → sellerDiscom.ledgerUrl; BUYER role → buyerDiscom.ledgerUrl.
 func (r *DEGLedgerRecorder) handleStatus(ctx *model.StepContext) error {
 	log.Infof(ctx, "DEGLedgerRecorder: processing status (role=%s, ledgerApi=%s)", r.config.Role, r.config.LedgerApi)
 
@@ -522,10 +522,10 @@ func (r *DEGLedgerRecorder) handleStatus(ctx *model.StepContext) error {
 
 	ledgerHostBase := r.config.LedgerHost
 	if r.config.LedgerUriSource == LedgerUriSourcePayload {
-		ledgerHostBase = ExtractWave2StatusDiscomLedgerUri(payload, side)
+		ledgerHostBase = ExtractWave2StatusDiscomLedgerURL(payload, side)
 	}
 	if ledgerHostBase == "" {
-		log.Warnf(ctx, "DEGLedgerRecorder: no ledger URI resolved for status forwarding (role=%s, side=%s)", r.config.Role, side)
+		log.Warnf(ctx, "DEGLedgerRecorder: no ledgerUrl resolved for status forwarding (role=%s, side=%s)", r.config.Role, side)
 		return nil
 	}
 	// status is a REQUEST action; Beckn convention is requester=BAP, responder=BPP.
@@ -535,12 +535,12 @@ func (r *DEGLedgerRecorder) handleStatus(ctx *model.StepContext) error {
 	// will land), and in context.bppUri the ledger's BPP-receiver endpoint.
 	ledgerEndpoint := BppReceiverEndpoint(ledgerHostBase)
 
-	// platformUri comes from participants[<own-role>].participantAttributes.platformUri.
+	// platformUrl comes from participants[<own-role>].participantAttributes.platformUrl.
 	parts := payload.Message.Contract.Participants
 	ownPlatformRole := wave2PlatformRole(r.config.Role)
-	ownPlatformURI := ParticipantEndpointURI(parts, ownPlatformRole, "platformUri")
+	ownPlatformURI := ParticipantEndpointURI(parts, ownPlatformRole, "platformUrl")
 	if ownPlatformURI == "" {
-		log.Warnf(ctx, "DEGLedgerRecorder: own platformUri not found in participants[%s]; skipping status forward (transaction_id=%s)", ownPlatformRole, payload.Context.TransactionID)
+		log.Warnf(ctx, "DEGLedgerRecorder: own platformUrl not found in participants[%s]; skipping status forward (transaction_id=%s)", ownPlatformRole, payload.Context.TransactionID)
 		return nil
 	}
 	// Use participantId from the participants array for bapId/bppId so they are
@@ -569,7 +569,7 @@ func (r *DEGLedgerRecorder) handleStatus(ctx *model.StepContext) error {
 	// must kick off the sub-transaction to the PEER's discom as well. In a normal
 	// 2-platform setup peerPlatformURI != ownPlatformURI and none of this runs.
 	peerRole := wave2PeerPlatformRole(r.config.Role)
-	if ParticipantEndpointURI(parts, peerRole, "platformUri") != ownPlatformURI {
+	if ParticipantEndpointURI(parts, peerRole, "platformUrl") != ownPlatformURI {
 		return nil // 2-platform topology — peer will handle its own discom
 	}
 
@@ -584,9 +584,9 @@ func (r *DEGLedgerRecorder) handleStatus(ctx *model.StepContext) error {
 		return nil // both roles share one discom — already sent above
 	}
 
-	peerLedgerHost := ExtractWave2StatusDiscomLedgerUri(payload, peerDiscomSide)
+	peerLedgerHost := ExtractWave2StatusDiscomLedgerURL(payload, peerDiscomSide)
 	if peerLedgerHost == "" {
-		log.Warnf(ctx, "DEGLedgerRecorder: prosumer: peer discom ledger URI not found in payload participants (transaction_id=%s)", payload.Context.TransactionID)
+		log.Warnf(ctx, "DEGLedgerRecorder: prosumer: peer discom ledgerUrl not found in payload participants (transaction_id=%s)", payload.Context.TransactionID)
 		return nil
 	}
 
@@ -663,9 +663,9 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 	// (BPP-side of leg 5). The platform plays BPP-caller on both forwards.
 	parts := payload.Message.Contract.Participants
 	ownPlatformRole := wave2PlatformRole(r.config.Role)
-	ownPlatformURI := ParticipantEndpointURI(parts, ownPlatformRole, "platformUri")
+	ownPlatformURI := ParticipantEndpointURI(parts, ownPlatformRole, "platformUrl")
 	if ownPlatformURI == "" {
-		log.Warnf(ctx, "DEGLedgerRecorder: own platformUri not found in participants[%s] (transaction_id=%s)", ownPlatformRole, payload.Context.TransactionID)
+		log.Warnf(ctx, "DEGLedgerRecorder: own platformUrl not found in participants[%s] (transaction_id=%s)", ownPlatformRole, payload.Context.TransactionID)
 		return nil
 	}
 	ownBppEndpoint := BppCallerEndpoint(ownPlatformURI)
@@ -679,9 +679,9 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 		// Rule 2a: our discom just computed its allocation — pass the on_status to
 		// the peer so the peer can in turn cascade to its own discom (Rule 2b).
 		peerRole := wave2PeerPlatformRole(r.config.Role)
-		peerPlatformURI := ParticipantEndpointURI(parts, peerRole, "platformUri")
+		peerPlatformURI := ParticipantEndpointURI(parts, peerRole, "platformUrl")
 		if peerPlatformURI == "" {
-			log.Warnf(ctx, "DEGLedgerRecorder: peer platformUri not found in participants[%s] (transaction_id=%s)", peerRole, payload.Context.TransactionID)
+			log.Warnf(ctx, "DEGLedgerRecorder: peer platformUrl not found in participants[%s] (transaction_id=%s)", peerRole, payload.Context.TransactionID)
 			return nil
 		}
 
@@ -704,9 +704,9 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 				log.Debugf(ctx, "DEGLedgerRecorder: prosumer: no performance data; skipping peer discom cascade (transaction_id=%s)", payload.Context.TransactionID)
 				return nil
 			}
-			peerDiscomHost := ExtractWave2OnStatusDiscomLedgerUri(payload, peerDiscomSide)
+			peerDiscomHost := ExtractWave2OnStatusDiscomLedgerURL(payload, peerDiscomSide)
 			if peerDiscomHost == "" {
-				log.Warnf(ctx, "DEGLedgerRecorder: prosumer: peer discom ledger URI not found in payload participants (transaction_id=%s)", payload.Context.TransactionID)
+				log.Warnf(ctx, "DEGLedgerRecorder: prosumer: peer discom ledgerUrl not found in payload participants (transaction_id=%s)", payload.Context.TransactionID)
 				return nil
 			}
 			peerDiscomEndpoint := BapReceiverEndpoint(peerDiscomHost)
@@ -739,7 +739,7 @@ func (r *DEGLedgerRecorder) handleOnStatusWave2(ctx *model.StepContext) error {
 		}
 		discomLedgerHost := r.config.LedgerHost
 		if r.config.LedgerUriSource == LedgerUriSourcePayload {
-			discomLedgerHost = ExtractWave2OnStatusDiscomLedgerUri(payload, ownDiscomSide)
+			discomLedgerHost = ExtractWave2OnStatusDiscomLedgerURL(payload, ownDiscomSide)
 		}
 		discomLedgerEndpoint := BapReceiverEndpoint(discomLedgerHost)
 		branch = "discom"

--- a/plugins/degledgerrecorder/recorder_wave2_retry_test.go
+++ b/plugins/degledgerrecorder/recorder_wave2_retry_test.go
@@ -258,12 +258,12 @@ func sampleWave2Status(ledgerURI string) string {
 	        {
 	          "role": "sellerPlatform",
 	          "participantId": "sellerapp.example.com",
-	          "participantAttributes": {"platformUri": "http://sellerapp.example.com:9000"}
+	          "participantAttributes": {"platformUrl": "http://sellerapp.example.com:9000"}
 	        },
 	        {
 	          "role": "sellerDiscom",
 	          "participantId": "seller-discom-ledger.example.com",
-	          "participantAttributes": {"ledgerUri": "` + ledgerURI + `"}
+	          "participantAttributes": {"ledgerUrl": "` + ledgerURI + `"}
 	        }
 	      ]
 	    }
@@ -293,12 +293,12 @@ func sampleWave2OnStatus(targetLedgerURI, originalSenderURI string) string {
 	        {
 	          "role": "sellerPlatform",
 	          "participantId": "sellerapp.example.com",
-	          "participantAttributes": {"platformUri": "http://sellerapp.example.com:9000"}
+	          "participantAttributes": {"platformUrl": "http://sellerapp.example.com:9000"}
 	        },
 	        {
 	          "role": "sellerDiscom",
 	          "participantId": "seller-discom-ledger.example.com",
-	          "participantAttributes": {"ledgerUri": "` + targetLedgerURI + `"}
+	          "participantAttributes": {"ledgerUrl": "` + targetLedgerURI + `"}
 	        }
 	      ],
 	      "commitments": [


### PR DESCRIPTION
Changes:
- DISCOM ledger/service URLs now read only from participantAttributes.ledgerUrl.
- Platform callback URLs now read only from participantAttributes.platformUrl.
- Removed old ledgerUri/platformUri references from plugin docs and Wave 2 README.
- Added test coverage to confirm legacy ledgerUri is ignored instead of silently falling back.