### PR TITLE
refactor(schema): EnergyResource v2.0 flat allOf, maxImportKw/maxExportKw, INVERTER kind

### DIFF
--- a/specification/schema/ElectricityCredential/v1.2/README.md
+++ b/specification/schema/ElectricityCredential/v1.2/README.md
@@ -33,7 +33,9 @@ Each kind is also published as a **standalone reusable schema** in `specificatio
 |------|-------------------|------------------|-----------------------------|
 | `EnergyResourceMeter` | `EnergyResourceMeter/v1.0` | `METER` | `cim:Meter` / `cim:EndDevice` (IEC 61968-9) |
 | `EnergyResourceGenerator` | `EnergyResourceGenerator/v1.0` | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` | `cim:GeneratingUnit` subtypes (IEC 61970-302) |
-| `EnergyResourceStorage` | `EnergyResourceStorage/v1.0` | `BESS`, `EV_CHARGER`, `EV_V2G` | `cim:BatteryUnit`, `cim:ElectricVehicleChargingStation` (IEC 61970-302) |
+| `EnergyResourceStorage` | `EnergyResourceStorage/v1.0` | `BESS` | `cim:BatteryUnit` (IEC 61970-302) |
+| `EnergyResourceEVCharger` | `EnergyResourceEVCharger/v1.0` | `EV_CHARGER`, `EV_V2G` | `cim:ElectricVehicleChargingStation` (CIM17+) |
+| `EnergyResourceInverter` | `EnergyResourceInverter/v1.0` | `INVERTER` | `cim:PowerElectronicsConnection` (IEC 61970-302) |
 | `EnergyResourceLoad` | `EnergyResourceLoad/v1.0` | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` | `cim:EnergyConsumer` / `cim:ConformLoad` (IEC 61970-301) |
 | `EnergyResourceNetwork` | `EnergyResourceNetwork/v1.0` | `DT`, `BUS`, `FEEDER`, `MICROGRID` | `cim:PowerTransformer`, `cim:BusbarSection`, `cim:Feeder`, `cim:Substation` (IEC 61970-301) |
 
@@ -43,16 +45,18 @@ Each kind is also published as a **standalone reusable schema** in `specificatio
 
 ## EnergyResourceCommonAttributes
 
-Inherited by all five kinds. Does **not** include `storageCapacityKwh`.
+Inherited by all seven kinds via `allOf`. Does **not** include `storageCapacityKwh`.
 
 | Field | Type | CIM alignment | Description |
 |-------|------|---------------|-------------|
 | `make` | string | — | Manufacturer name |
 | `model` | string | — | Model number |
-| `ratedPowerKw` | number | `GeneratingUnit.maxOperatingP` | Nameplate peak power, kW |
+| `ratedPowerKw` | number ≥0 | `GeneratingUnit.maxOperatingP` | Nameplate peak power kW — kept for backward compatibility; prefer `maxExportKw` for new payloads |
+| `maxImportKw` | number | `PowerElectronicsConnection.minP` / `GeneratingUnit.minOperatingP` | Min operating power kW; **negative = max discharge/export** (e.g. -5 for 5 kW BESS or V2G); 0 for unidirectional |
+| `maxExportKw` | number ≥0 | `GeneratingUnit.maxOperatingP` / `PowerElectronicsConnection.maxP` | Max operating power kW (nameplate in principal direction); supersedes `ratedPowerKw` |
 | `telemetryProvider` | string | — | Vendor API / data-source for telemetry |
 | `commissioningDate` | string (date-time) | — | ISO 8601 commissioning date-time |
-| `location` | object | — | `geo` (GeoJSONGeometry) + optional `address` (PostalAddress) |
+| `location` | object | — | `geo` (GeoJSONGeometry, coordinates [lon, lat]) + optional `address` (PostalAddress) |
 
 ## Kind-specific attributes
 
@@ -79,15 +83,40 @@ Inherited by all five kinds. Does **not** include `storageCapacityKwh`.
 | `nominalPowerKw` | number | `GeneratingUnit.nominalP` | Nominal output power, kW (when distinct from peak) |
 | `efficiency` | number (0–100) | — | Conversion efficiency, % |
 
-### EnergyResourceStorage (type: `BESS` | `EV_CHARGER` | `EV_V2G`)
+### EnergyResourceStorage (type: `BESS`)
+
+Stationary battery. `storageCapacityKwh` is exclusive to this kind. Charge and discharge power limits are expressed via common attributes: `maxExportKw` (charge rate) and `maxImportKw` (discharge rate as a negative value, e.g. -5 for 5 kW discharge).
 
 | Field | Type | CIM alignment | Description |
 |-------|------|---------------|-------------|
 | `storageCapacityKwh` | number | `BatteryUnit.ratedE` | **Storage-only** — rated energy capacity, kWh |
 | `storageType` | enum | — | LithiumIon, LeadAcid, FlowBattery, NaS, NiCd, Flywheel, Other |
 | `stateOfHealthPct` | number (0–100) | — | Battery SoH as % of original capacity |
-| `maxChargeRateKw` | number | — | Maximum charge rate, kW |
-| `maxDischargeRateKw` | number | — | Maximum discharge rate, kW |
+
+### EnergyResourceEVCharger (type: `EV_CHARGER` | `EV_V2G`)
+
+EV charging station (EVSE) — a **flexible load**, not a storage resource. The EV battery is the storage; the EVSE is the charge/discharge interface. `EV_V2G` is a specialisation of `EV_CHARGER` with bidirectional ISO 15118-20 / OCPP 2.1 BPT capability; express power range via common attributes: `maxExportKw` (charge) and `maxImportKw` (negative, V2G discharge).
+
+| Field | Type | Standard | Description |
+|-------|------|----------|-------------|
+| `connectorType` | enum | IEC 62196 / CCS | Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other |
+| `controlProtocol` | enum | OCPP / ISO 15118 | OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other |
+| `v2xProtocol` | enum | ISO 15118-20 | CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other — present for EV_V2G only |
+
+### EnergyResourceInverter (type: `INVERTER`)
+
+Grid-connected power-electronics converter without a dedicated fuel source. Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702–714. Use cases: standalone battery inverters, VPP aggregation points, grid-forming inverters for microgrid islanding.
+
+| Field | Type | Standard | Description |
+|-------|------|----------|-------------|
+| `ratedApparentPowerKva` | number | SunSpec 702 `maxVA` | Rated apparent power, kVA |
+| `maxReactivePowerKvar` | number | IEEE 1547 / SunSpec `maxVar` | Max reactive power injection (leading), kVAr |
+| `minReactivePowerKvar` | number | SunSpec `maxVarNeg` | Max reactive power absorption (lagging); usually negative |
+| `rideThroughCategory` | enum | IEEE 1547-2018 | CategoryI / CategoryII / CategoryIII |
+| `operatingMode` | enum | CIM `inverterMode` | GridFollowing / GridForming / Standby |
+| `voltVarEnabled` | boolean | IEEE 2030.5 `opModVoltVar` | Volt-VAr curve active |
+| `freqDroopEnabled` | boolean | SunSpec Model 711 | Frequency-Watt droop active |
+| `enterServiceRampTimeSec` | number | SunSpec 703 `ESRmpTms` | Ramp-up time after reconnect, seconds |
 
 ### EnergyResourceLoad (type: `SMART_HVAC` | `SMART_WATER_HEATER` | `CONTROLLABLE_LOAD`)
 
@@ -183,12 +212,16 @@ A single `customerNumber` can span arbitrary asset topologies.
 
 | Change | v1.1 | v1.2 |
 |--------|------|------|
+| Power fields extended | `attributes.ratedPowerKw` | `ratedPowerKw` retained; add `attributes.maxExportKw` (preferred, ≥0) and `attributes.maxImportKw` (negative for discharge) |
 | Storage capacity field renamed | `attributes.energyCapacityKwh` | `attributes.storageCapacityKwh` |
+| EV kind separated from storage | `EnergyResourceStorage (EV_CHARGER, EV_V2G)` | new `EnergyResourceEVCharger` kind |
+| Storage charge/discharge rates | `maxChargeRateKw`, `maxDischargeRateKw` on storage | `maxExportKw` (charge) and `maxImportKw` (discharge, negative) in common attributes |
 | SOLAR deprecated | `type: "SOLAR"` | `type: "SOLAR_PV"` (preferred) |
 | BATTERY deprecated | `type: "BATTERY"` | `type: "BESS"` (preferred) |
-| EnergyResource now typed | single flat schema | `oneOf` 5 composable kinds |
+| EnergyResource now typed | single flat schema | `oneOf` 7 composable kinds |
 | storageCapacityKwh scope | on EnergyResourceCommonAttributes | exclusive to EnergyResourceStorage |
-| New storage fields | — | `stateOfHealthPct`, `maxChargeRateKw`, `maxDischargeRateKw` |
+| New EV kind | — | `EnergyResourceEVCharger` with `connectorType`, `controlProtocol`, `v2xProtocol` |
+| New inverter kind | — | `EnergyResourceInverter` with `ratedApparentPowerKva`, `rideThroughCategory`, `operatingMode`, `voltVarEnabled`, `freqDroopEnabled`, etc. |
 | New generator fields | — | `nominalPowerKw`, `efficiency` |
 | New meter fields | — | `communicationTechnology` |
 | New network fields | — | `nominalVoltageKv`, `zone`, `substationId`, `feederCode` |

--- a/specification/schema/ElectricityCredential/v1.2/README.md
+++ b/specification/schema/ElectricityCredential/v1.2/README.md
@@ -52,7 +52,7 @@ Inherited by all seven kinds via `allOf`. Does **not** include `storageCapacityK
 | `make` | string | — | Manufacturer name |
 | `model` | string | — | Model number |
 | `ratedPowerKw` | number ≥0 | `GeneratingUnit.maxOperatingP` | Nameplate peak power kW — kept for backward compatibility; prefer `maxExportKw` for new payloads |
-| `maxImportKw` | number | `PowerElectronicsConnection.minP` / `GeneratingUnit.minOperatingP` | Min operating power kW; **negative = max discharge/export** (e.g. -5 for 5 kW BESS or V2G); 0 for unidirectional |
+| `maxImportKw` | number ≥0 | `PowerElectronicsConnection.maxP` (absorption) | Max power drawn from grid (absorbed/charged), kW. Always ≥0. For BESS: max charge rate. For EV_V2G: max charge rate. Omit or 0 for pure generators. |
 | `maxExportKw` | number ≥0 | `GeneratingUnit.maxOperatingP` / `PowerElectronicsConnection.maxP` | Max operating power kW (nameplate in principal direction); supersedes `ratedPowerKw` |
 | `telemetryProvider` | string | — | Vendor API / data-source for telemetry |
 | `commissioningDate` | string (date-time) | — | ISO 8601 commissioning date-time |
@@ -85,7 +85,7 @@ Inherited by all seven kinds via `allOf`. Does **not** include `storageCapacityK
 
 ### EnergyResourceStorage (type: `BESS`)
 
-Stationary battery. `storageCapacityKwh` is exclusive to this kind. Charge and discharge power limits are expressed via common attributes: `maxExportKw` (charge rate) and `maxImportKw` (discharge rate as a negative value, e.g. -5 for 5 kW discharge).
+Stationary battery. `storageCapacityKwh` is exclusive to this kind. Discharge rate: `maxExportKw` (≥0). Charge rate: `maxImportKw` (≥0). Both in common attributes.
 
 | Field | Type | CIM alignment | Description |
 |-------|------|---------------|-------------|
@@ -95,7 +95,7 @@ Stationary battery. `storageCapacityKwh` is exclusive to this kind. Charge and d
 
 ### EnergyResourceEVCharger (type: `EV_CHARGER` | `EV_V2G`)
 
-EV charging station (EVSE) — a **flexible load**, not a storage resource. The EV battery is the storage; the EVSE is the charge/discharge interface. `EV_V2G` is a specialisation of `EV_CHARGER` with bidirectional ISO 15118-20 / OCPP 2.1 BPT capability; express power range via common attributes: `maxExportKw` (charge) and `maxImportKw` (negative, V2G discharge).
+EV charging station (EVSE) — a **flexible load**, not a storage resource. The EV battery is storage; the EVSE is the charge/discharge interface. `EV_V2G` is a specialisation of `EV_CHARGER` with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. V2G discharge: `maxExportKw` (≥0). Charge rate: `maxImportKw` (≥0).
 
 | Field | Type | Standard | Description |
 |-------|------|----------|-------------|
@@ -212,10 +212,10 @@ A single `customerNumber` can span arbitrary asset topologies.
 
 | Change | v1.1 | v1.2 |
 |--------|------|------|
-| Power fields extended | `attributes.ratedPowerKw` | `ratedPowerKw` retained; add `attributes.maxExportKw` (preferred, ≥0) and `attributes.maxImportKw` (negative for discharge) |
+| Power fields extended | `attributes.ratedPowerKw` | `ratedPowerKw` retained; add `attributes.maxExportKw` (≥0, grid injection) and `attributes.maxImportKw` (≥0, grid absorption) |
 | Storage capacity field renamed | `attributes.energyCapacityKwh` | `attributes.storageCapacityKwh` |
 | EV kind separated from storage | `EnergyResourceStorage (EV_CHARGER, EV_V2G)` | new `EnergyResourceEVCharger` kind |
-| Storage charge/discharge rates | `maxChargeRateKw`, `maxDischargeRateKw` on storage | `maxExportKw` (charge) and `maxImportKw` (discharge, negative) in common attributes |
+| Storage charge/discharge rates | `maxChargeRateKw`, `maxDischargeRateKw` on storage | `maxExportKw` (discharge, ≥0) and `maxImportKw` (charge, ≥0) in common attributes |
 | SOLAR deprecated | `type: "SOLAR"` | `type: "SOLAR_PV"` (preferred) |
 | BATTERY deprecated | `type: "BATTERY"` | `type: "BESS"` (preferred) |
 | EnergyResource now typed | single flat schema | `oneOf` 7 composable kinds |

--- a/specification/schema/ElectricityCredential/v1.2/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.2/attributes.yaml
@@ -7,22 +7,33 @@ info:
     electricity distribution utilities.
 
     v1.2 introduces composable EnergyResource kinds. energyResources[] entries
-    are now discriminated by 'type' into one of five kinds:
-      - EnergyResourceMeter    (type: METER)
+    are now discriminated by 'type' into one of seven kinds:
+      - EnergyResourceMeter     (type: METER)
       - EnergyResourceGenerator (type: SOLAR_PV | SOLAR | WIND | HYDRO | BIOGAS | CHP | FUEL_CELL)
-      - EnergyResourceStorage   (type: BESS | BATTERY | EV_CHARGER | EV_V2G)
+      - EnergyResourceStorage   (type: BESS | BATTERY)
+      - EnergyResourceEVCharger (type: EV_CHARGER | EV_V2G)
+      - EnergyResourceInverter  (type: INVERTER)
       - EnergyResourceLoad      (type: SMART_HVAC | SMART_WATER_HEATER | CONTROLLABLE_LOAD)
       - EnergyResourceNetwork   (type: DT | BUS | FEEDER | MICROGRID)
 
-    Each kind's attributes bag inherits EnergyResourceCommonAttributes.
-    storageCapacityKwh is ONLY on EnergyResourceStorage.
+    Each kind's attributes bag inherits EnergyResourceCommonAttributes via allOf.
+    storageCapacityKwh is ONLY on EnergyResourceStorage (BESS).
+    EV_CHARGER and EV_V2G are their own kind — NOT storage.
+    EV_V2G is a specialisation of EV_CHARGER; maxImportKw < 0 expresses discharge power.
+
+    Common attribute changes (all kinds):
+      ratedPowerKw replaced by maxImportKw + maxExportKw.
+      maxExportKw: nameplate rated power in the principal direction (≥0).
+      maxImportKw: minimum operating power; negative = max discharge/export capacity.
 
     CIM alignment: IEC 61970-301/302 (GeneratingUnit, BatteryUnit,
-    EnergyConsumer, Feeder) and IEC 61968-9 (Meter, EndDevice).
+    PowerElectronicsConnection, EnergyConsumer, Feeder) and IEC 61968-9 (Meter, EndDevice).
 
     v1.1 → v1.2 field changes
     ──────────────────────────
     energyResources[BATTERY/BESS].attributes.energyCapacityKwh → storageCapacityKwh
+    energyResources[*].attributes.ratedPowerKw → maxExportKw (set maxImportKw for discharge)
+    energyResources[EV_CHARGER/EV_V2G] → moved from Storage kind to EV kind
     energyResources[*].type enum "SOLAR"   → deprecated; use SOLAR_PV
     energyResources[*].type enum "BATTERY" → deprecated; use BESS
 
@@ -256,6 +267,12 @@ components:
     EnergyResourceStorage:
       $ref: "https://schema.beckn.io/EnergyResourceStorage/v1.0#/components/schemas/EnergyResourceStorage"
 
+    EnergyResourceEVCharger:
+      $ref: "https://schema.beckn.io/EnergyResourceEVCharger/v1.0#/components/schemas/EnergyResourceEVCharger"
+
+    EnergyResourceInverter:
+      $ref: "https://schema.beckn.io/EnergyResourceInverter/v1.0#/components/schemas/EnergyResourceInverter"
+
     EnergyResourceLoad:
       $ref: "https://schema.beckn.io/EnergyResourceLoad/v1.0#/components/schemas/EnergyResourceLoad"
 
@@ -265,10 +282,19 @@ components:
     EnergyResource:
       type: object
       description: >
-        Composable energy resource, discriminated by 'type' into one of five
+        Composable energy resource, discriminated by 'type' into one of seven
         kinds. id and type are required. Topology is expressed via
         subResources[] (children) and parentResources[] (parents, e.g. the
         meter a DER sits behind).
+
+        Common attribute change: ratedPowerKw is replaced by maxImportKw
+        and maxExportKw in EnergyResourceCommonAttributes. maxExportKw is
+        the nameplate power in the principal direction (≥0). maxImportKw can
+        be negative to express discharge/export capacity (V2G, BESS).
+
+        EV_CHARGER and EV_V2G are their own kind (EnergyResourceEVCharger),
+        not grouped with storage. INVERTER is a new kind for grid-connected
+        power-electronics converters.
       required:
         - id
         - type
@@ -297,5 +323,7 @@ components:
         - $ref: "#/components/schemas/EnergyResourceMeter"
         - $ref: "#/components/schemas/EnergyResourceGenerator"
         - $ref: "#/components/schemas/EnergyResourceStorage"
+        - $ref: "#/components/schemas/EnergyResourceEVCharger"
+        - $ref: "#/components/schemas/EnergyResourceInverter"
         - $ref: "#/components/schemas/EnergyResourceLoad"
         - $ref: "#/components/schemas/EnergyResourceNetwork"

--- a/specification/schema/ElectricityCredential/v1.2/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.2/attributes.yaml
@@ -287,10 +287,10 @@ components:
         subResources[] (children) and parentResources[] (parents, e.g. the
         meter a DER sits behind).
 
-        Common attribute change: ratedPowerKw is replaced by maxImportKw
-        and maxExportKw in EnergyResourceCommonAttributes. maxExportKw is
-        the nameplate power in the principal direction (≥0). maxImportKw can
-        be negative to express discharge/export capacity (V2G, BESS).
+        maxExportKw (≥0) and maxImportKw (≥0) replace ratedPowerKw in
+        EnergyResourceCommonAttributes. Both are non-negative directional
+        fields: maxExportKw = max power injected to grid; maxImportKw = max
+        power drawn from grid.
 
         EV_CHARGER and EV_V2G are their own kind (EnergyResourceEVCharger),
         not grouped with storage. INVERTER is a new kind for grid-connected

--- a/specification/schema/ElectricityCredential/v1.2/context.jsonld
+++ b/specification/schema/ElectricityCredential/v1.2/context.jsonld
@@ -42,6 +42,8 @@
                                 "make":                  { "@id": "erDeg:make",                  "@type": "xsd:string"  },
                                 "model":                 { "@id": "erDeg:model",                 "@type": "xsd:string"  },
                                 "ratedPowerKw":          { "@id": "erDeg:ratedPowerKw",          "@type": "xsd:decimal" },
+                                "maxImportKw":            { "@id": "erDeg:maxImportKw",            "@type": "xsd:decimal" },
+                                "maxExportKw":            { "@id": "erDeg:maxExportKw",            "@type": "xsd:decimal" },
                                 "telemetryProvider":     { "@id": "erDeg:telemetryProvider",     "@type": "xsd:string"  },
                                 "commissioningDate":     { "@id": "deg:commissioningDate",       "@type": "xsd:dateTime" },
                                 "location":              { "@id": "erDeg:location",              "@type": "@id"         },

--- a/specification/schema/ElectricityCredential/v1.2/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example-parallel-metering.json
@@ -32,7 +32,7 @@
         {
           "id": "did:web:tpddl.delhi.gov.in:assets:solar-plant:ROOFTOP-SOLAR-001",
           "type": "SOLAR_PV",
-          "attributes": {"ratedPowerKw": 5, "make": "Adani Solar", "model": "ASPM-400M", "commissioningDate": "2025-02-10T00:00:00+05:30"},
+          "attributes": {"maxExportKw": 5, "make": "Adani Solar", "model": "ASPM-400M", "commissioningDate": "2025-02-10T00:00:00+05:30"},
           "parentResources": ["did:web:tpddl.delhi.gov.in:assets:meter:MET-EXPORT-001"]
         }
       ],

--- a/specification/schema/ElectricityCredential/v1.2/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example-submetering.json
@@ -39,7 +39,7 @@
         {
           "id": "did:web:bescom.karnataka.gov.in:assets:solar-plant:ROOFTOP-UNIT-101",
           "type": "SOLAR_PV",
-          "attributes": {"ratedPowerKw": 2, "make": "Waaree", "model": "WS-200", "commissioningDate": "2024-06-15T00:00:00+05:30"},
+          "attributes": {"maxExportKw": 2, "make": "Waaree", "model": "WS-200", "commissioningDate": "2024-06-15T00:00:00+05:30"},
           "parentResources": ["did:web:bescom.karnataka.gov.in:assets:meter:MET-UNIT-101"]
         }
       ],

--- a/specification/schema/ElectricityCredential/v1.2/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example.json
@@ -33,25 +33,25 @@
         {
           "id": "did:web:example-utility.com:assets:solar-plant:DER-SOLAR-001",
           "type": "SOLAR_PV",
-          "attributes": {"ratedPowerKw": 3, "make": "SunPower Corporation", "model": "SPR-X22-360", "commissioningDate": "2025-01-12T00:00:00-05:00"},
+          "attributes": {"maxExportKw": 3, "make": "SunPower Corporation", "model": "SPR-X22-360", "commissioningDate": "2025-01-12T00:00:00-05:00"},
           "parentResources": ["did:web:example-utility.com:assets:meter:MET2025789456123"]
         },
         {
           "id": "did:web:example-utility.com:assets:wind-farm:DER-WIND-001",
           "type": "WIND",
-          "attributes": {"ratedPowerKw": 1.5, "make": "Windmill Co.", "model": "WM-MICRO-150", "commissioningDate": "2025-03-01T00:00:00-05:00"},
+          "attributes": {"maxExportKw": 1.5, "make": "Windmill Co.", "model": "WM-MICRO-150", "commissioningDate": "2025-03-01T00:00:00-05:00"},
           "parentResources": ["did:web:example-utility.com:assets:meter:MET2025789456123"]
         },
         {
           "id": "did:web:example-utility.com:assets:bess:BESS-001",
           "type": "BESS",
-          "attributes": {"ratedPowerKw": 5, "storageCapacityKwh": 10, "storageType": "LithiumIon", "commissioningDate": "2025-01-12T00:00:00-05:00"},
+          "attributes": {"maxExportKw": 5, "maxImportKw": 5, "storageCapacityKwh": 10, "storageType": "LithiumIon", "commissioningDate": "2025-01-12T00:00:00-05:00"},
           "parentResources": ["did:web:example-utility.com:assets:meter:MET2025789456123"]
         },
         {
           "id": "did:web:example-utility.com:assets:bess:BESS-002",
           "type": "BESS",
-          "attributes": {"ratedPowerKw": 2.5, "storageCapacityKwh": 5, "storageType": "LithiumIon", "commissioningDate": "2025-06-01T00:00:00-05:00"},
+          "attributes": {"maxExportKw": 2.5, "maxImportKw": 2.5, "storageCapacityKwh": 5, "storageType": "LithiumIon", "commissioningDate": "2025-06-01T00:00:00-05:00"},
           "parentResources": ["did:web:example-utility.com:assets:meter:MET2025789456123"]
         }
       ],

--- a/specification/schema/ElectricityCredential/v1.2/schema.json
+++ b/specification/schema/ElectricityCredential/v1.2/schema.json
@@ -121,7 +121,7 @@
         },
         "EnergyResourceCommonAttributes": {
             "type": "object",
-            "description": "Base attributes shared by all EnergyResource kinds. maxImportKw/maxExportKw replace the former ratedPowerKw: maxExportKw is the nameplate rated power in the principal direction; maxImportKw can be negative to express discharge/export capacity (e.g. -5 for 5 kW BESS or V2G discharge). storageCapacityKwh belongs exclusively to EnergyResourceStorage.",
+            "description": "Base attributes shared by all EnergyResource kinds. maxExportKw (≥0) is max power injected to grid; maxImportKw (≥0) is max power drawn from grid. Both are non-negative directional fields. storageCapacityKwh belongs exclusively to EnergyResourceStorage.",
             "additionalProperties": true,
             "properties": {
                 "make": { "type": "string", "description": "Manufacturer name." },
@@ -209,7 +209,7 @@
             ]
         },
         "EnergyResourceStorageAttributes": {
-            "description": "Attributes for stationary energy storage assets (BESS). CIM: BatteryUnit (IEC 61970-302). storageCapacityKwh is ONLY on this attributes type. Charge/discharge power limits are expressed via maxExportKw (charge) and maxImportKw (discharge, as a negative value) in EnergyResourceCommonAttributes.",
+            "description": "Attributes for stationary energy storage assets (BESS). CIM: BatteryUnit (IEC 61970-302). storageCapacityKwh is ONLY on this attributes type. Discharge power: maxExportKw (≥0). Charge power: maxImportKw (≥0). Both in EnergyResourceCommonAttributes.",
             "allOf": [
                 { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
                 {
@@ -236,7 +236,7 @@
             ]
         },
         "EnergyResourceEVChargerAttributes": {
-            "description": "Attributes for EV charging stations. EV_CHARGER is a flexible load — the EVSE hardware at the grid connection point, NOT a storage resource. EV_V2G is a specialisation of EV_CHARGER with bidirectional ISO 15118-20 / OCPP 2.1 BPT capability; express power limits via maxImportKw (negative, discharge) and maxExportKw (charge) in common attributes. CIM: ElectricVehicleChargingStation (CIM17+).",
+            "description": "Attributes for EV charging stations. EV_CHARGER is a flexible load — the EVSE hardware at the grid connection point, NOT a storage resource. EV_V2G is a specialisation of EV_CHARGER with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. V2G discharge: maxExportKw (≥0); charge: maxImportKw (≥0). CIM: ElectricVehicleChargingStation (CIM17+).",
             "allOf": [
                 { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
                 {
@@ -381,7 +381,7 @@
         },
         "EnergyResourceEVCharger": {
             "type": "object",
-            "description": "EV charging station (EVSE). A flexible load — NOT a storage resource. The EV battery is the storage; the EVSE is the charge/discharge interface. EV_V2G is a specialisation of EV_CHARGER with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability; express power range with maxImportKw (negative, discharge) and maxExportKw (charge) in common attributes. CIM: ElectricVehicleChargingStation (CIM17+).",
+            "description": "EV charging station (EVSE). A flexible load — NOT a storage resource. The EV battery is storage; the EVSE is the charge/discharge interface. EV_V2G has ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. V2G discharge: maxExportKw (≥0); charge: maxImportKw (≥0). CIM: ElectricVehicleChargingStation (CIM17+).",
             "properties": {
                 "type": {
                     "type": "string",
@@ -422,7 +422,7 @@
         },
         "EnergyResource": {
             "type": "object",
-            "description": "Composable energy resource, discriminated by 'type' into one of seven kinds. id and type are required. All other attributes live in the kind-specific 'attributes' bag which inherits EnergyResourceCommonAttributes via allOf. maxImportKw/maxExportKw in common attributes replace the former ratedPowerKw. Only EnergyResourceStorage carries storageCapacityKwh. EV_CHARGER/EV_V2G are their own kind (not storage). INVERTER captures IEEE 1547 grid-support capabilities.",
+            "description": "Composable energy resource, discriminated by 'type' into one of seven kinds. id and type are required. All other attributes live in the 'attributes' bag which inherits EnergyResourceCommonAttributes via allOf. maxExportKw (≥0) and maxImportKw (≥0) replace the former ratedPowerKw. Only EnergyResourceStorage carries storageCapacityKwh. EV_CHARGER/EV_V2G are their own kind (not storage). INVERTER captures IEEE 1547 grid-support capabilities.",
             "required": ["id", "type"],
             "properties": {
                 "id": { "type": "string", "minLength": 1, "description": "Stable identifier. For METER: meter serial number. For DERs: any stable scheme." },

--- a/specification/schema/ElectricityCredential/v1.2/schema.json
+++ b/specification/schema/ElectricityCredential/v1.2/schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/beckn/DEG/blob/main/specification/schema/ElectricityCredential/v1.2/schema.json",
     "title": "ElectricityCredential v1.2",
-    "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.2. EnergyResource is composable: oneOf [EnergyResourceMeter | EnergyResourceGenerator | EnergyResourceStorage | EnergyResourceLoad | EnergyResourceNetwork]. Each kind is also published as a standalone schema at schema.beckn.io/<Kind>/v1.0. $defs here mirror those external schemas. storageCapacityKwh is restricted to EnergyResourceStorage. type enums are restricted per kind. CIM alignment per IEC 61970-301/302 and IEC 61968-9.",
+    "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.2. EnergyResource is composable: oneOf [EnergyResourceMeter | EnergyResourceGenerator | EnergyResourceStorage | EnergyResourceEVCharger | EnergyResourceInverter | EnergyResourceLoad | EnergyResourceNetwork]. Each kind is also published as a standalone schema at schema.beckn.io/<Kind>/v1.0. $defs here mirror those external schemas. storageCapacityKwh is restricted to EnergyResourceStorage. EV_CHARGER and EV_V2G are their own kind (not storage). INVERTER captures reactive-power and frequency-support capabilities per IEEE 1547. CIM alignment per IEC 61970-301/302 and IEC 61968-9.",
     "type": "object",
     "required": ["@context", "id", "type", "issuer", "validFrom", "credentialSubject"],
     "properties": {
@@ -121,7 +121,7 @@
         },
         "EnergyResourceCommonAttributes": {
             "type": "object",
-            "description": "Base attributes shared by all EnergyResource kinds. Does NOT include storageCapacityKwh — that field belongs exclusively to EnergyResourceStorage.",
+            "description": "Base attributes shared by all EnergyResource kinds. maxImportKw/maxExportKw replace the former ratedPowerKw: maxExportKw is the nameplate rated power in the principal direction; maxImportKw can be negative to express discharge/export capacity (e.g. -5 for 5 kW BESS or V2G discharge). storageCapacityKwh belongs exclusively to EnergyResourceStorage.",
             "additionalProperties": true,
             "properties": {
                 "make": { "type": "string", "description": "Manufacturer name." },
@@ -129,7 +129,17 @@
                 "ratedPowerKw": {
                     "type": "number",
                     "minimum": 0,
-                    "description": "Nameplate peak power rating in kW. CIM: GeneratingUnit.maxOperatingP / EndDeviceInfo.ratedPower."
+                    "description": "Manufacturer-rated peak power in kW. Kept for backward compatibility. Prefer maxExportKw for new payloads. CIM: GeneratingUnit.maxOperatingP / EndDeviceInfo.ratedPower."
+                },
+                "maxImportKw": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Maximum power this resource draws from the grid (absorbs/charges), kW. Always ≥0. For bidirectional resources (BESS, V2G) this is the max charge rate. CIM: PowerElectronicsConnection.maxP (absorption direction)."
+                },
+                "maxExportKw": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Maximum power this resource injects to the grid (generates/discharges), kW. Always ≥0. Supersedes ratedPowerKw. CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP (injection direction)."
                 },
                 "telemetryProvider": { "type": "string", "description": "Vendor API or data-source identifier for telemetry." },
                 "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time the asset was commissioned." },
@@ -186,7 +196,7 @@
                         "nominalPowerKw": {
                             "type": "number",
                             "minimum": 0,
-                            "description": "Nominal rated output power in kW. CIM: GeneratingUnit.nominalP. Use when distinct from ratedPowerKw (peak)."
+                            "description": "Nominal rated output power in kW. CIM: GeneratingUnit.nominalP. Use when distinct from maxExportKw (peak)."
                         },
                         "efficiency": {
                             "type": "number",
@@ -199,7 +209,7 @@
             ]
         },
         "EnergyResourceStorageAttributes": {
-            "description": "Attributes for energy storage assets. CIM: BatteryUnit (IEC 61970-302), ElectricVehicleChargingStation (CIM17+). storageCapacityKwh is ONLY on this attributes type.",
+            "description": "Attributes for stationary energy storage assets (BESS). CIM: BatteryUnit (IEC 61970-302). storageCapacityKwh is ONLY on this attributes type. Charge/discharge power limits are expressed via maxExportKw (charge) and maxImportKw (discharge, as a negative value) in EnergyResourceCommonAttributes.",
             "allOf": [
                 { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
                 {
@@ -220,16 +230,80 @@
                             "minimum": 0,
                             "maximum": 100,
                             "description": "Battery state of health as percentage of original capacity."
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceEVChargerAttributes": {
+            "description": "Attributes for EV charging stations. EV_CHARGER is a flexible load — the EVSE hardware at the grid connection point, NOT a storage resource. EV_V2G is a specialisation of EV_CHARGER with bidirectional ISO 15118-20 / OCPP 2.1 BPT capability; express power limits via maxImportKw (negative, discharge) and maxExportKw (charge) in common attributes. CIM: ElectricVehicleChargingStation (CIM17+).",
+            "allOf": [
+                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "connectorType": {
+                            "type": "string",
+                            "enum": ["Type1", "Type2", "CCS1", "CCS2", "CHAdeMO", "GB_T", "NACS", "Other"],
+                            "description": "Physical connector standard. Type1/Type2: IEC 62196. CCS1/CCS2: Combined Charging System. CHAdeMO: CHAdeMO Association. GB_T: Chinese GB/T standard. NACS: North American Charging Standard."
                         },
-                        "maxChargeRateKw": {
+                        "controlProtocol": {
+                            "type": "string",
+                            "enum": ["OCPP_1.6", "OCPP_2.0.1", "OCPP_2.1", "ISO_15118_2", "ISO_15118_20", "Other"],
+                            "description": "EVSE control and smart-charging protocol."
+                        },
+                        "v2xProtocol": {
+                            "type": "string",
+                            "enum": ["CHAdeMO_V2G", "CCS_BPT", "ISO_15118_20_AC_BPT", "ISO_15118_20_DC_BPT", "Other"],
+                            "description": "Vehicle-to-Grid / Vehicle-to-Everything protocol. Present only for EV_V2G resources."
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceInverterAttributes": {
+            "description": "Attributes for grid-connected power-electronics inverters (type: INVERTER). Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702–714. CIM: PowerElectronicsConnection (IEC 61970-302).",
+            "allOf": [
+                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "ratedApparentPowerKva": {
                             "type": "number",
                             "minimum": 0,
-                            "description": "Maximum charge rate in kW."
+                            "description": "Rated apparent power in kVA. SunSpec Model 702 maxVA."
                         },
-                        "maxDischargeRateKw": {
+                        "maxReactivePowerKvar": {
                             "type": "number",
                             "minimum": 0,
-                            "description": "Maximum discharge rate in kW."
+                            "description": "Maximum reactive power injection (leading / over-excited), kVAr. SunSpec Model 702 maxVar."
+                        },
+                        "minReactivePowerKvar": {
+                            "type": "number",
+                            "description": "Maximum reactive power absorption (lagging / under-excited), kVAr. Usually a negative value. SunSpec Model 702 maxVarNeg."
+                        },
+                        "rideThroughCategory": {
+                            "type": "string",
+                            "enum": ["CategoryI", "CategoryII", "CategoryIII"],
+                            "description": "IEEE 1547-2018 abnormal operating performance category. CategoryI: basic ride-through. CategoryII: enhanced (distribution-level DER). CategoryIII: advanced (transmission-connected or large DER)."
+                        },
+                        "operatingMode": {
+                            "type": "string",
+                            "enum": ["GridFollowing", "GridForming", "Standby"],
+                            "description": "Inverter grid-interaction mode. GridFollowing: synchronises to existing grid voltage/frequency (typical DER). GridForming: establishes voltage and frequency reference (microgrid islanding). CIM: PowerElectronicsConnection.inverterMode."
+                        },
+                        "voltVarEnabled": {
+                            "type": "boolean",
+                            "description": "Volt-VAr curve active (autonomous reactive power vs. voltage). IEEE 2030.5 opModVoltVar / SunSpec Model 705."
+                        },
+                        "freqDroopEnabled": {
+                            "type": "boolean",
+                            "description": "Frequency-Watt droop active (active power response to frequency deviation). SunSpec Model 711 / IEEE 1547 Freq-Watt."
+                        },
+                        "enterServiceRampTimeSec": {
+                            "type": "number",
+                            "minimum": 0,
+                            "description": "Ramp-up time in seconds after reconnection to full output. SunSpec Model 703 ESRmpTms."
                         }
                     }
                 }
@@ -296,13 +370,32 @@
         },
         "EnergyResourceStorage": {
             "type": "object",
-            "description": "Energy storage asset. CIM PowerElectronicsUnit subtypes (IEC 61970-302): BESS=BatteryUnit, EV_CHARGER/EV_V2G=ElectricVehicleChargingStation. BATTERY is deprecated — use BESS.",
+            "description": "Stationary energy storage asset. CIM: BatteryUnit (IEC 61970-302). BATTERY is deprecated — use BESS. EV charging stations are NOT storage; see EnergyResourceEVCharger.",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["BESS", "BATTERY", "EV_CHARGER", "EV_V2G"]
+                    "enum": ["BESS", "BATTERY"]
                 },
                 "attributes": { "$ref": "#/$defs/EnergyResourceStorageAttributes" }
+            }
+        },
+        "EnergyResourceEVCharger": {
+            "type": "object",
+            "description": "EV charging station (EVSE). A flexible load — NOT a storage resource. The EV battery is the storage; the EVSE is the charge/discharge interface. EV_V2G is a specialisation of EV_CHARGER with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability; express power range with maxImportKw (negative, discharge) and maxExportKw (charge) in common attributes. CIM: ElectricVehicleChargingStation (CIM17+).",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["EV_CHARGER", "EV_V2G"]
+                },
+                "attributes": { "$ref": "#/$defs/EnergyResourceEVChargerAttributes" }
+            }
+        },
+        "EnergyResourceInverter": {
+            "type": "object",
+            "description": "Grid-connected power-electronics inverter without a dedicated fuel source. Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702–714. Use cases: standalone battery inverters, VPP aggregation points, grid-forming inverters for microgrid islanding. CIM: PowerElectronicsConnection (IEC 61970-302).",
+            "properties": {
+                "type": { "type": "string", "const": "INVERTER" },
+                "attributes": { "$ref": "#/$defs/EnergyResourceInverterAttributes" }
             }
         },
         "EnergyResourceLoad": {
@@ -329,7 +422,7 @@
         },
         "EnergyResource": {
             "type": "object",
-            "description": "Composable energy resource, discriminated by 'type' into one of five kinds. id and type are required. All other attributes live in the kind-specific 'attributes' bag which inherits EnergyResourceCommonAttributes. Only EnergyResourceStorage carries storageCapacityKwh.",
+            "description": "Composable energy resource, discriminated by 'type' into one of seven kinds. id and type are required. All other attributes live in the kind-specific 'attributes' bag which inherits EnergyResourceCommonAttributes via allOf. maxImportKw/maxExportKw in common attributes replace the former ratedPowerKw. Only EnergyResourceStorage carries storageCapacityKwh. EV_CHARGER/EV_V2G are their own kind (not storage). INVERTER captures IEEE 1547 grid-support capabilities.",
             "required": ["id", "type"],
             "properties": {
                 "id": { "type": "string", "minLength": 1, "description": "Stable identifier. For METER: meter serial number. For DERs: any stable scheme." },
@@ -351,6 +444,8 @@
                 { "$ref": "#/$defs/EnergyResourceMeter" },
                 { "$ref": "#/$defs/EnergyResourceGenerator" },
                 { "$ref": "#/$defs/EnergyResourceStorage" },
+                { "$ref": "#/$defs/EnergyResourceEVCharger" },
+                { "$ref": "#/$defs/EnergyResourceInverter" },
                 { "$ref": "#/$defs/EnergyResourceLoad" },
                 { "$ref": "#/$defs/EnergyResourceNetwork" }
             ]

--- a/specification/schema/ElectricityCredential/v1.2/vocab.jsonld
+++ b/specification/schema/ElectricityCredential/v1.2/vocab.jsonld
@@ -14,7 +14,7 @@
             "@id": "deg:ElectricityCredential",
             "@type": "rdfs:Class",
             "rdfs:label": "Electricity Credential",
-            "rdfs:comment": "W3C Verifiable Credential issued per meter by electricity distribution utilities. v1.2: EnergyResource is composable into five kinds (Meter, Generator, Storage, Load, Network); storageCapacityKwh is restricted to Storage kind; type enums restricted per kind; CIM IEC 61970/61968 alignment.",
+            "rdfs:comment": "W3C Verifiable Credential issued per meter by electricity distribution utilities. v1.2: EnergyResource is composable into seven kinds (Meter, Generator, Storage, EVCharger, Inverter, Load, Network); storageCapacityKwh is restricted to Storage; EV_CHARGER/EV_V2G have their own EVCharger kind; INVERTER captures IEEE 1547 grid-support capabilities; CIM IEC 61970/61968 alignment.",
             "rdfs:subClassOf": { "@id": "energyCred:EnergyCredential" }
         },
         {
@@ -33,13 +33,29 @@
             "@id": "deg:energyResources",
             "@type": "rdf:Property",
             "rdfs:label": "Energy Resources",
-            "rdfs:comment": "Array of composable EnergyResource entries. Each entry is discriminated by 'type' into one of: EnergyResourceMeter, EnergyResourceGenerator, EnergyResourceStorage, EnergyResourceLoad, EnergyResourceNetwork."
+            "rdfs:comment": "Array of composable EnergyResource entries. Each entry is discriminated by 'type' into one of: EnergyResourceMeter, EnergyResourceGenerator, EnergyResourceStorage, EnergyResourceEVCharger, EnergyResourceInverter, EnergyResourceLoad, EnergyResourceNetwork."
         },
         {
             "@id": "erDeg:EnergyResourceCommonAttributes",
             "@type": "rdfs:Class",
             "rdfs:label": "Energy Resource Common Attributes",
-            "rdfs:comment": "Base attributes shared by all EnergyResource kinds. Does not include storageCapacityKwh."
+            "rdfs:comment": "Base attributes shared by all EnergyResource kinds via allOf. Does not include storageCapacityKwh. maxImportKw/maxExportKw replace the former ratedPowerKw."
+        },
+        {
+            "@id": "erDeg:maxImportKw",
+            "@type": "rdf:Property",
+            "rdfs:label": "Minimum Power (kW)",
+            "rdfs:comment": "Minimum operating power in kW. Negative values indicate maximum discharge or export capacity. CIM: PowerElectronicsConnection.minP / GeneratingUnit.minOperatingP.",
+            "rdfs:domain": { "@id": "erDeg:EnergyResourceCommonAttributes" },
+            "rdfs:range": "xsd:decimal"
+        },
+        {
+            "@id": "erDeg:maxExportKw",
+            "@type": "rdf:Property",
+            "rdfs:label": "Maximum Power (kW)",
+            "rdfs:comment": "Maximum operating power in kW (generation, charging, or absorption). CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP.",
+            "rdfs:domain": { "@id": "erDeg:EnergyResourceCommonAttributes" },
+            "rdfs:range": "xsd:decimal"
         },
         {
             "@id": "erDeg:EnergyResourceMeter",
@@ -61,9 +77,25 @@
             "@id": "erDeg:EnergyResourceStorage",
             "@type": "rdfs:Class",
             "rdfs:label": "Energy Resource — Storage",
-            "rdfs:comment": "Energy storage asset. type: BESS | BATTERY | EV_CHARGER | EV_V2G. CIM: BatteryUnit / ElectricVehicleChargingStation (IEC 61970-302).",
+            "rdfs:comment": "Stationary energy storage asset. type: BESS. storageCapacityKwh is exclusive to this kind. CIM: BatteryUnit (IEC 61970-302).",
             "rdfs:subClassOf": { "@id": "erDeg:EnergyResourceCommonAttributes" },
             "rdfs:seeAlso": { "@id": "cim:BatteryUnit" }
+        },
+        {
+            "@id": "erDeg:EnergyResourceEVCharger",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Energy Resource — EV Charger",
+            "rdfs:comment": "EV charging station (EVSE). type: EV_CHARGER | EV_V2G. A flexible load, NOT storage. EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+).",
+            "rdfs:subClassOf": { "@id": "erDeg:EnergyResourceCommonAttributes" },
+            "rdfs:seeAlso": { "@id": "cim:ElectricVehicleChargingStation" }
+        },
+        {
+            "@id": "erDeg:EnergyResourceInverter",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Energy Resource — Inverter",
+            "rdfs:comment": "Grid-connected power-electronics inverter. type: INVERTER. Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302).",
+            "rdfs:subClassOf": { "@id": "erDeg:EnergyResourceCommonAttributes" },
+            "rdfs:seeAlso": { "@id": "cim:PowerElectronicsConnection" }
         },
         {
             "@id": "erDeg:EnergyResourceLoad",
@@ -85,7 +117,7 @@
             "@id": "erDeg:storageCapacityKwh",
             "@type": "rdf:Property",
             "rdfs:label": "Storage Capacity (kWh)",
-            "rdfs:comment": "Rated energy capacity in kWh. Exclusive to EnergyResourceStorage. CIM: BatteryUnit.ratedE. v1.1 equivalent: energyCapacityKwh.",
+            "rdfs:comment": "Rated energy capacity in kWh. Exclusive to EnergyResourceStorage (BESS). CIM: BatteryUnit.ratedE. v1.1 equivalent: energyCapacityKwh.",
             "rdfs:domain": { "@id": "erDeg:EnergyResourceStorage" },
             "rdfs:range": "xsd:decimal"
         },
@@ -112,6 +144,22 @@
             "rdfs:comment": "Nominal voltage level in kV. CIM: BaseVoltage.nominalVoltage.",
             "rdfs:domain": { "@id": "erDeg:EnergyResourceNetwork" },
             "rdfs:range": "xsd:decimal"
+        },
+        {
+            "@id": "erDeg:rideThroughCategory",
+            "@type": "rdf:Property",
+            "rdfs:label": "Ride-Through Category",
+            "rdfs:comment": "IEEE 1547-2018 abnormal operating performance category: CategoryI, CategoryII, CategoryIII.",
+            "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+            "rdfs:range": "xsd:string"
+        },
+        {
+            "@id": "erDeg:operatingMode",
+            "@type": "rdf:Property",
+            "rdfs:label": "Operating Mode",
+            "rdfs:comment": "Inverter grid-interaction mode: GridFollowing, GridForming, Standby. CIM: PowerElectronicsConnection.inverterMode.",
+            "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+            "rdfs:range": "xsd:string"
         },
         {
             "@id": "deg:ConsumptionProfile",

--- a/specification/schema/EnergyResource/README.md
+++ b/specification/schema/EnergyResource/README.md
@@ -2,7 +2,7 @@
 
 Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy — solar PV, wind, batteries / BESS, EVs and EVSE/V2G, controllable loads, the metering and connection points that anchor them, and aggregate sites that contain other resources.
 
-Per the [DEG Hourglass architecture](https://github.com/beckn/DEG/issues/119), `EnergyResource` is one of the five core primitives at the neck of the hourglass — every higher-layer schema (P2P-trading, demand-flex, EV-charging, …) converges on this class to describe the assets a contract is about.
+`EnergyResource` is the shared asset-description class used by every DEG domain schema — P2P-trading, demand-flex, EV-charging, and ElectricityCredential all reference it to describe the physical asset a transaction or credential is about.
 
 **Canonical IRI:** `https://schema.beckn.io/EnergyResource/v2.0`
 

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -1,6 +1,6 @@
 # EnergyResource — v2.0
 
-Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by **P2P-trading** (`{id, type}` for the asset being sold), **demand-flex** (identity + dimensioning + topology), and **ElectricityCredential/v1.2** (`customerProfile.energyResources[]`).
+Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by **P2P-trading** (`{id, type}` for the asset being traded), **demand-flex** (identity + dimensioning + topology), and **ElectricityCredential/v1.2** (`customerProfile.energyResources[]`).
 
 Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 
@@ -8,154 +8,222 @@ Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 
 | File | Description |
 |------|-------------|
-| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 — `EnergyResource` and `EnergyResourceCommon` |
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 — `EnergyResource` discriminated union and all typed kinds |
 | [context.jsonld](./context.jsonld) | JSON-LD context |
 | [vocab.jsonld](./vocab.jsonld) | RDF vocabulary |
 
-## Structure
+## Architecture
 
-`EnergyResource` inherits all fields from `EnergyResourceCommon` via `allOf`. Type-specific fields are set directly at the top level — no nested `attributes` bag.
+`EnergyResource` is a discriminated union (`oneOf`) of seven typed kinds. Each kind does `allOf [EnergyResourceCommon]` and refines the `attributes` bag with kind-specific fields. `make`, `model`, and all dimensioning fields live **inside the `attributes` bag**.
 
 ```
-EnergyResourceCommon
-├── id                  — stable identifier
-├── type                — asset class enum (see table below)
-├── make / model        — manufacturer info
-├── maxImportKw          — min power kW (negative = max discharge/export capacity)
-├── maxExportKw          — max power kW (generation / charge / absorption)
-├── energyCapacityKwh   — storage capacity kWh (storage resources only; omit for pure-flow)
-├── telemetryProvider   — vendor API / data source
-├── commissioningDate   — ISO 8601 commissioning date-time
-├── location            — physical location (geo: GeoJSON Point + optional address)
-├── subResources[]      — child resource ids or inline EnergyResource objects
-└── parentResources[]   — parent resource ids (string FK refs — no cycle)
-
+EnergyResourceCommonAttributes   ← attributes bag base (make, model, power, location…)
+        ↑ allOf
+EnergyResourceCommon             ← envelope (id, type, subResources, parentResources, attributes)
+        ↑ allOf  (each kind)
+EnergyResourceMeter        (METER)
+EnergyResourceGenerator    (SOLAR_PV | WIND | HYDRO | BIOGAS | CHP | FUEL_CELL)
+EnergyResourceBESS         (BESS)
+EnergyResourceEVCharger    (EV_CHARGER | EV_V2G)
+EnergyResourceInverter     (INVERTER)
+EnergyResourceLoad         (SMART_HVAC | SMART_WATER_HEATER | CONTROLLABLE_LOAD)
+EnergyResourceNetwork      (DT | BUS | FEEDER | MICROGRID)
+        ↑ oneOf
 EnergyResource
-└── allOf: [EnergyResourceCommon]   — plus additionalProperties: true
 ```
 
-All fields are optional at the schema level.
+## Typed kinds
 
-## EnergyResourceCommon fields
+| Kind | `type` values | CIM alignment |
+|------|--------------|---------------|
+| `EnergyResourceMeter` | `METER` | `Meter` / `EndDevice` (IEC 61968-9) |
+| `EnergyResourceGenerator` | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` | `GeneratingUnit` subtypes (IEC 61970-302) |
+| `EnergyResourceBESS` | `BESS` | `BatteryUnit` (IEC 61970-302) |
+| `EnergyResourceEVCharger` | `EV_CHARGER`, `EV_V2G` | `ElectricVehicleChargingStation` (CIM17+) |
+| `EnergyResourceInverter` | `INVERTER` | `PowerElectronicsConnection` (IEC 61970-302) |
+| `EnergyResourceLoad` | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` | `EnergyConsumer` / `ConformLoad` (IEC 61970-301) |
+| `EnergyResourceNetwork` | `DT`, `BUS`, `FEEDER`, `MICROGRID` | `PowerTransformer`, `BusbarSection`, `Feeder` (IEC 61970-301) |
+
+Deprecated values still accepted: `SOLAR` → use `SOLAR_PV`; `BATTERY` → use `BESS`.
+
+## Envelope fields (EnergyResourceCommon)
 
 | Field | Type | Notes |
 |-------|------|-------|
 | `id` | string | Stable identifier; meter serial for METER |
-| `type` | string enum | See table below |
+| `type` | string enum | Discriminator — see table above |
+| `subResources` | array | Child ids (string) or inline `EnergyResource` objects |
+| `parentResources` | array of strings | FK refs to parent resources |
+| `attributes` | object | `EnergyResourceCommonAttributes` + kind-specific fields |
+
+`subResources` uses a recursive `$ref: EnergyResource`, which is explicitly valid in JSON Schema 2020-12 and OpenAPI 3.1.
+
+## Common attributes (EnergyResourceCommonAttributes)
+
+All live inside the `attributes` bag. No field is required at the schema level.
+
+| Field | Type | Notes |
+|-------|------|-------|
 | `make` | string | Manufacturer |
 | `model` | string | Model |
-| `ratedPowerKw` | number ≥0 | Manufacturer-rated peak power kW — kept for backward compat; prefer `maxExportKw` for new payloads |
-| `maxImportKw` | number | Min power kW; **negative = max discharge/export** (e.g. -5 for 5 kW V2G or BESS discharge); 0 for unidirectional |
-| `maxExportKw` | number ≥0 | Max power kW (nameplate in principal direction); supersedes `ratedPowerKw` |
-| `energyCapacityKwh` | number ≥0 | Storage capacity kWh; omit for pure-flow resources |
+| `ratedPowerKw` | number ≥0 | Backward compat; prefer `maxExportKw` |
+| `maxExportKw` | number ≥0 | Max power injected to grid (generation / discharge). Always ≥0. Supersedes `ratedPowerKw`. CIM: `GeneratingUnit.maxOperatingP` |
+| `maxImportKw` | number ≥0 | Max power drawn from grid (load / charge). Always ≥0. CIM: `PowerElectronicsConnection.maxP` (absorption) |
 | `telemetryProvider` | string | Vendor API / data source |
 | `commissioningDate` | string (date-time) | ISO 8601 |
 | `location` | object | `geo` (GeoJSON, coordinates [lon, lat]) + optional `address` |
-| `subResources` | array | Child ids or inline EnergyResource objects |
-| `parentResources` | array of strings | FK refs to parent resources |
 
-## `type` enum
+Power fields summary:
 
-| Category | Values | Notes |
-|----------|--------|-------|
-| Grid infrastructure | `METER`, `DT`, `BUS`, `FEEDER` | |
-| Generation DERs | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` | |
-| Storage | `BESS` | Stationary battery; use `energyCapacityKwh` for capacity |
-| EV charging | `EV_CHARGER`, `EV_V2G` | `EV_CHARGER` is a **flexible load** (NOT storage); `EV_V2G` is a subtype with bidirectional ISO 15118-20 / OCPP 2.1 BPT capability — set `maxImportKw < 0` for discharge power |
-| Power electronics | `INVERTER` | Grid-connected converter for VAr / frequency support (IEEE 1547) |
-| Flexible loads | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` | |
-| System | `MICROGRID` | |
-| Deprecated | `SOLAR` → `SOLAR_PV` · `BATTERY` → `BESS` | Still accepted for backward compat |
+| Resource | `maxExportKw` | `maxImportKw` |
+|----------|--------------|--------------|
+| SOLAR_PV, WIND, HYDRO | peak generation | 0 or omit |
+| BESS | max discharge rate | max charge rate |
+| EV_CHARGER | 0 or omit | max charge rate |
+| EV_V2G | max V2G discharge | max charge rate |
+| INVERTER | max active power export | max active power import |
+| SMART_HVAC, loads | 0 or omit | rated load draw |
 
-### INVERTER type
+## Kind-specific attributes
 
-`INVERTER` represents a grid-connected power-electronics converter without a dedicated fuel source: standalone battery inverters, virtual power plant aggregation points, grid-forming inverters in microgrids. Common type-specific fields (set at top level):
+### EnergyResourceMeter
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `meterCapability` | enum | `Electromechanical` · `CMRI` · `AMR` · `AMI`. CIM: `AmiBillingReadyKind` |
+| `energyDirection` | enum | `Forward` (default) · `Reverse` · `Bidirectional` · `Net`. CIM: `FlowDirectionKind` |
+| `functions` | string[] | `ToU`, `NetMetering`, `MaxDemand`, `LoadControl`, `TamperDetection`, `PowerQuality`, `EventLogging` |
+| `feeder` | string | Feeder ID |
+| `bus` | string | Busbar ID |
+| `communicationTechnology` | enum | `PLC`, `RF_Mesh`, `GPRS`, `NB-IoT`, `LoRa`, `ZigBee`, `Other` |
+| `applicationProtocol` | enum | `DLMS_COSEM`, `ANSI_C12_18`, `IEC_61850`, `Modbus`, `Other` |
+
+### EnergyResourceGenerator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `nominalPowerKw` | number ≥0 | Nominal rated output (CIM: `GeneratingUnit.nominalP`) |
+| `efficiency` | number 0–100 | Conversion efficiency %; relevant for FUEL_CELL, CHP |
+
+### EnergyResourceBESS
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `storageCapacityKwh` | number ≥0 | Rated energy capacity kWh (exclusive to BESS). CIM: `BatteryUnit.ratedE` |
+| `storageType` | enum | `LithiumIon` · `LeadAcid` · `FlowBattery` · `NaS` · `NiCd` · `Flywheel` · `Other` |
+| `stateOfHealthPct` | number 0–100 | State of health as % of original capacity |
+
+### EnergyResourceEVCharger
+
+`EV_CHARGER` is the EVSE hardware at the grid connection point — a **flexible load**, not a storage resource. The EV battery is storage; use `BESS` for stationary batteries.
+
+`EV_V2G` is a specialisation of `EV_CHARGER` with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. Set both `maxImportKw` (charge) and `maxExportKw` (V2G discharge) in the attributes bag.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `connectorType` | enum | `Type1`, `Type2`, `CCS1`, `CCS2`, `CHAdeMO`, `GB_T`, `NACS`, `Other` (IEC 62196 / J3400) |
+| `controlProtocol` | enum | `OCPP_1.6`, `OCPP_2.0.1`, `OCPP_2.1`, `ISO_15118_2`, `ISO_15118_20`, `Other` |
+| `v2xProtocol` | enum | `CHAdeMO_V2G`, `CCS_BPT`, `ISO_15118_20_AC_BPT`, `ISO_15118_20_DC_BPT`, `Other` — present for EV_V2G |
+
+### EnergyResourceInverter
+
+Grid-connected power-electronics converter without a dedicated fuel source. Captures reactive-power and frequency-support capabilities per **IEEE 1547-2018** and **SunSpec DER Models 702–714**. Use cases: standalone battery inverters, VPP aggregation points, grid-forming inverters for microgrid islanding.
 
 | Field | Type | Standard | Description |
 |-------|------|----------|-------------|
-| `ratedApparentPowerKva` | number | SunSpec Model 702 `maxVA` | Rated apparent power, kVA |
-| `maxReactivePowerKvar` | number | IEEE 1547 / SunSpec `maxVar` | Max reactive power injection (leading), kVAr |
-| `minReactivePowerKvar` | number | SunSpec `maxVarNeg` | Max reactive power absorption (lagging); usually negative |
+| `ratedApparentPowerKva` | number ≥0 | SunSpec 702 `maxVA` | Rated apparent power, kVA |
+| `maxReactivePowerKvar` | number ≥0 | SunSpec 702 `maxVar` | Max reactive injection (leading), kVAr |
+| `minReactivePowerKvar` | number | SunSpec 702 `maxVarNeg` | Max reactive absorption (lagging); usually negative |
 | `rideThroughCategory` | enum | IEEE 1547-2018 | `CategoryI` / `CategoryII` / `CategoryIII` |
 | `operatingMode` | enum | CIM `inverterMode` | `GridFollowing` / `GridForming` / `Standby` |
-| `voltVarEnabled` | boolean | IEEE 2030.5 `opModVoltVar` | Volt-VAr curve active |
-| `freqDroopEnabled` | boolean | SunSpec Model 711 | Frequency-Watt droop active |
-| `enterServiceRampTimeSec` | number | SunSpec Model 703 `ESRmpTms` | Ramp-up time after reconnect, seconds |
+| `voltVarEnabled` | boolean | IEEE 2030.5 `opModVoltVar` / SunSpec 705 | Volt-VAr curve active |
+| `freqDroopEnabled` | boolean | SunSpec 711 / IEEE 1547 Freq-Watt | Frequency-Watt droop active |
+| `enterServiceRampTimeSec` | number ≥0 | SunSpec 703 `ESRmpTms` | Ramp-up time after reconnect, seconds |
 
-### EV_CHARGER / EV_V2G clarification
+### EnergyResourceLoad
 
-`EV_CHARGER` is the EVSE (charge station) hardware at the grid connection point — it is a **flexible load**, not a storage resource. The EV battery is storage; use `BESS` for stationary batteries.
+| Field | Type | Notes |
+|-------|------|-------|
+| `controlProtocol` | enum | `OpenADR_2.0b`, `OCPP_2.0.1`, `SunSpec_Modbus`, `EEBus`, `Modbus`, `Other` |
+| `loadCategory` | enum | `Heating`, `Cooling`, `WaterHeating`, `Lighting`, `EV`, `Industrial`, `Other` |
 
-`EV_V2G` is a specialisation of `EV_CHARGER` with Vehicle-to-Grid capability. Express power range via:
-- `maxExportKw`: max charge power (e.g. 7.4 for 7.4 kW AC)
-- `maxImportKw`: discharge power as a negative value (e.g. -3.7 for 3.7 kW V2G export)
+### EnergyResourceNetwork
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `nominalVoltageKv` | number ≥0 | Nominal voltage, kV. CIM: `BaseVoltage.nominalVoltage` |
+| `zone` | string | Operating zone or region identifier |
+| `substationId` | string | Parent substation identifier |
+| `feederCode` | string | Feeder code per utility network records |
 
 ## Topology
 
-`subResources` and `parentResources` reference other EnergyResources by `id`. `subResources` items may also be inline-nested EnergyResource objects — this is a recursive (`$ref: EnergyResource`) reference, which is explicitly valid in JSON Schema 2020-12 and OpenAPI 3.1. `parentResources` items are always string FKs to avoid cycles.
+`parentResources` and `subResources` link resources by `id`. `subResources` items may be inline `EnergyResource` objects — the recursive `$ref` is valid in JSON Schema 2020-12. `parentResources` are always string references to avoid definitional cycles.
+
+Typical patterns:
+- DER behind a meter: DER `parentResources: [meterId]`
+- Sub-meter: `parentResources: [buildingMeterId]`
+- Parallel meters: both meters are siblings with no parent/child relationship
+- Feeder topology: METER `parentResources: [feederId]`
 
 ## Examples
 
 **METER:**
 ```json
 {
-  "id": "MET2025789456123",
+  "id": "did:web:utility.com:assets:meter:MET001",
   "type": "METER",
-  "meterCapability": "AMI",
-  "location": {"geo": {"type": "Point", "coordinates": [77.5946, 12.9716]}},
-  "parentResources": ["BAN-NR-F22"]
+  "attributes": {
+    "meterCapability": "AMI",
+    "energyDirection": "Forward",
+    "location": {"geo": {"type": "Point", "coordinates": [77.5946, 12.9716]}}
+  },
+  "parentResources": ["did:web:utility.com:assets:feeder:BAN-NR-F22"]
 }
 ```
 
 **SOLAR DER behind a meter:**
 ```json
 {
-  "id": "DER-SOLAR-001",
+  "id": "did:web:utility.com:assets:solar:DER-SOLAR-001",
   "type": "SOLAR_PV",
-  "maxExportKw": 3,
-  "make": "Waaree", "model": "WS-300",
-  "commissioningDate": "2025-01-12T00:00:00+05:30",
-  "parentResources": ["MET2025789456123"]
+  "attributes": {"maxExportKw": 5, "make": "Waaree", "model": "WS-400M", "commissioningDate": "2025-02-10T00:00:00+05:30"},
+  "parentResources": ["did:web:utility.com:assets:meter:MET001"]
 }
 ```
 
-**BESS (5 kW charge / 5 kW discharge):**
+**BESS (5 kW charge / 5 kW discharge, 10 kWh):**
 ```json
 {
-  "id": "BESS-001",
+  "id": "did:web:utility.com:assets:bess:BESS-001",
   "type": "BESS",
-  "maxExportKw": 5, "maxImportKw": -5,
-  "energyCapacityKwh": 10,
-  "storageType": "LithiumIon",
-  "parentResources": ["MET2025789456123"]
+  "attributes": {"maxExportKw": 5, "maxImportKw": 5, "storageCapacityKwh": 10, "storageType": "LithiumIon"},
+  "parentResources": ["did:web:utility.com:assets:meter:MET001"]
 }
 ```
 
-**V2G EV charger (7.4 kW charge / 3.7 kW V2G discharge):**
+**EV_V2G charger (7.4 kW charge / 3.7 kW V2G discharge):**
 ```json
 {
-  "id": "EVSE-001",
+  "id": "did:web:utility.com:assets:evse:EVSE-001",
   "type": "EV_V2G",
-  "maxExportKw": 7.4, "maxImportKw": -3.7,
-  "connectorType": "Type2",
-  "v2xProtocol": "ISO_15118_20_AC_BPT",
-  "parentResources": ["MET2025789456123"]
+  "attributes": {"maxImportKw": 7.4, "maxExportKw": 3.7, "connectorType": "Type2", "v2xProtocol": "ISO_15118_20_AC_BPT"},
+  "parentResources": ["did:web:utility.com:assets:meter:MET001"]
 }
 ```
 
-**INVERTER (grid-forming, VAr support, freq droop):**
+**INVERTER (grid-forming, VAr + freq support):**
 ```json
 {
-  "id": "INV-001",
+  "id": "did:web:utility.com:assets:inv:INV-001",
   "type": "INVERTER",
-  "maxExportKw": 10, "maxImportKw": -10,
-  "ratedApparentPowerKva": 12,
-  "maxReactivePowerKvar": 6,
-  "operatingMode": "GridForming",
-  "voltVarEnabled": true,
-  "freqDroopEnabled": true,
-  "rideThroughCategory": "CategoryIII",
-  "parentResources": ["MET2025789456123"]
+  "attributes": {
+    "maxExportKw": 10, "maxImportKw": 10,
+    "ratedApparentPowerKva": 12, "maxReactivePowerKvar": 6,
+    "operatingMode": "GridForming", "voltVarEnabled": true, "freqDroopEnabled": true,
+    "rideThroughCategory": "CategoryIII"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET001"]
 }
 ```
 
@@ -163,24 +231,3 @@ All fields are optional at the schema level.
 ```json
 {"id": "MET001", "type": "SOLAR_PV"}
 ```
-
-**Microgrid topology:**
-```json
-{
-  "id": "MICROGRID01", "type": "MICROGRID",
-  "subResources": [
-    "PV001", "BAT001",
-    {"id": "EVSE-001", "type": "EV_V2G", "maxExportKw": 7.4, "maxImportKw": -3.7, "parentResources": ["MICROGRID01"]}
-  ]
-}
-```
-
-## Changes from earlier v2.0 (breaking)
-
-- **`ratedPowerKw` retained; `maxImportKw` and `maxExportKw` added** — `ratedPowerKw` still accepted for backward compatibility. `maxExportKw` is the preferred field for new payloads (nameplate power in the principal direction); `maxImportKw` can be negative to express discharge/export capacity.
-- **`attributes` bag removed** — common and type-specific fields are now at the top level via `allOf` inheritance. Migration: `attributes.make` → `make`, `attributes.ratedPowerKw` → `maxExportKw`, etc.
-- **`location` elevated to `EnergyResourceCommon`** — was meter-specific; now applies to all resource types.
-- **`gps` field removed** — use `location.geo` (GeoJSON Point, coordinates `[longitude, latitude]`).
-- **`INVERTER` type added** — grid-connected power-electronics converters.
-- **`EV_CHARGER` reclassified** — flexible load, not storage.
-- **`SOLAR` and `BATTERY` deprecated** — use `SOLAR_PV` and `BESS` respectively.

--- a/specification/schema/EnergyResource/v2.0/README.md
+++ b/specification/schema/EnergyResource/v2.0/README.md
@@ -1,6 +1,6 @@
 # EnergyResource — v2.0
 
-Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by **P2P-trading** (`{id, type}` for the asset being sold), **demand-flex** (richer identity + dimensioning + topology), and **ElectricityCredential/v1.1** (`customerProfile.energyResources[]`).
+Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by **P2P-trading** (`{id, type}` for the asset being sold), **demand-flex** (identity + dimensioning + topology), and **ElectricityCredential/v1.2** (`customerProfile.energyResources[]`).
 
 Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 
@@ -8,56 +8,91 @@ Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
 
 | File | Description |
 |------|-------------|
-| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 — `EnergyResource` and `CommonResourceAttributes` |
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 — `EnergyResource` and `EnergyResourceCommon` |
 | [context.jsonld](./context.jsonld) | JSON-LD context |
 | [vocab.jsonld](./vocab.jsonld) | RDF vocabulary |
 
 ## Structure
 
+`EnergyResource` inherits all fields from `EnergyResourceCommon` via `allOf`. Type-specific fields are set directly at the top level — no nested `attributes` bag.
+
 ```
+EnergyResourceCommon
+├── id                  — stable identifier
+├── type                — asset class enum (see table below)
+├── make / model        — manufacturer info
+├── maxImportKw          — min power kW (negative = max discharge/export capacity)
+├── maxExportKw          — max power kW (generation / charge / absorption)
+├── energyCapacityKwh   — storage capacity kWh (storage resources only; omit for pure-flow)
+├── telemetryProvider   — vendor API / data source
+├── commissioningDate   — ISO 8601 commissioning date-time
+├── location            — physical location (geo: GeoJSON Point + optional address)
+├── subResources[]      — child resource ids or inline EnergyResource objects
+└── parentResources[]   — parent resource ids (string FK refs — no cycle)
+
 EnergyResource
-├── id                  — stable identifier (meter serial number for METER resources)
-├── type                — asset class enum (METER, DT, BUS, FEEDER, SOLAR, BATTERY, …)
-├── attributes          — all other properties (open bag)
-│   ├── CommonResourceAttributes: make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider
-│   └── type-specific:  meterType, gps, location, feeder, bus, commissioningDate, storageType, VIN, …
-├── subResources[]      — child resource ids or inline objects (topology)
-└── parentResources[]   — parent resource ids (topology)
+└── allOf: [EnergyResourceCommon]   — plus additionalProperties: true
 ```
 
 All fields are optional at the schema level.
 
-## CommonResourceAttributes
+## EnergyResourceCommon fields
 
-Dimensioning fields shared across all resource types. Live inside `attributes`.
-
-| Field | Type | Description |
-|-------|------|-------------|
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Stable identifier; meter serial for METER |
+| `type` | string enum | See table below |
 | `make` | string | Manufacturer |
 | `model` | string | Model |
-| `ratedPowerKw` | number ≥0 | Rated peak power, kW |
-| `energyCapacityKwh` | number ≥0 | Stored-energy capacity, kWh (storage-class only) |
-| `telemetryProvider` | string | Vendor API / data source for telemetry |
+| `ratedPowerKw` | number ≥0 | Manufacturer-rated peak power kW — kept for backward compat; prefer `maxExportKw` for new payloads |
+| `maxImportKw` | number | Min power kW; **negative = max discharge/export** (e.g. -5 for 5 kW V2G or BESS discharge); 0 for unidirectional |
+| `maxExportKw` | number ≥0 | Max power kW (nameplate in principal direction); supersedes `ratedPowerKw` |
+| `energyCapacityKwh` | number ≥0 | Storage capacity kWh; omit for pure-flow resources |
+| `telemetryProvider` | string | Vendor API / data source |
+| `commissioningDate` | string (date-time) | ISO 8601 |
+| `location` | object | `geo` (GeoJSON, coordinates [lon, lat]) + optional `address` |
+| `subResources` | array | Child ids or inline EnergyResource objects |
+| `parentResources` | array of strings | FK refs to parent resources |
 
 ## `type` enum
 
-| Category | Values |
-|----------|--------|
-| Grid infrastructure | `METER`, `DT`, `BUS`, `FEEDER` |
-| Generation DERs | `SOLAR`, `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` |
-| Storage | `BATTERY`, `BESS` |
-| Flexible loads | `EV_CHARGER`, `EV_V2G`, `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` |
-| System | `MICROGRID` |
+| Category | Values | Notes |
+|----------|--------|-------|
+| Grid infrastructure | `METER`, `DT`, `BUS`, `FEEDER` | |
+| Generation DERs | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` | |
+| Storage | `BESS` | Stationary battery; use `energyCapacityKwh` for capacity |
+| EV charging | `EV_CHARGER`, `EV_V2G` | `EV_CHARGER` is a **flexible load** (NOT storage); `EV_V2G` is a subtype with bidirectional ISO 15118-20 / OCPP 2.1 BPT capability — set `maxImportKw < 0` for discharge power |
+| Power electronics | `INVERTER` | Grid-connected converter for VAr / frequency support (IEEE 1547) |
+| Flexible loads | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` | |
+| System | `MICROGRID` | |
+| Deprecated | `SOLAR` → `SOLAR_PV` · `BATTERY` → `BESS` | Still accepted for backward compat |
 
-## Meter attributes (`type: METER`, inside `attributes`)
+### INVERTER type
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `meterType` | enum | AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other |
-| `gps` | string | `"lat,lng"` coordinates |
-| `location` | object | Postal location (beckn Location shape) |
+`INVERTER` represents a grid-connected power-electronics converter without a dedicated fuel source: standalone battery inverters, virtual power plant aggregation points, grid-forming inverters in microgrids. Common type-specific fields (set at top level):
 
-Grid topology (feeder, bus, DT) is expressed via `parentResources[]` — reference the id of a `FEEDER`, `BUS`, or `DT` resource.
+| Field | Type | Standard | Description |
+|-------|------|----------|-------------|
+| `ratedApparentPowerKva` | number | SunSpec Model 702 `maxVA` | Rated apparent power, kVA |
+| `maxReactivePowerKvar` | number | IEEE 1547 / SunSpec `maxVar` | Max reactive power injection (leading), kVAr |
+| `minReactivePowerKvar` | number | SunSpec `maxVarNeg` | Max reactive power absorption (lagging); usually negative |
+| `rideThroughCategory` | enum | IEEE 1547-2018 | `CategoryI` / `CategoryII` / `CategoryIII` |
+| `operatingMode` | enum | CIM `inverterMode` | `GridFollowing` / `GridForming` / `Standby` |
+| `voltVarEnabled` | boolean | IEEE 2030.5 `opModVoltVar` | Volt-VAr curve active |
+| `freqDroopEnabled` | boolean | SunSpec Model 711 | Frequency-Watt droop active |
+| `enterServiceRampTimeSec` | number | SunSpec Model 703 `ESRmpTms` | Ramp-up time after reconnect, seconds |
+
+### EV_CHARGER / EV_V2G clarification
+
+`EV_CHARGER` is the EVSE (charge station) hardware at the grid connection point — it is a **flexible load**, not a storage resource. The EV battery is storage; use `BESS` for stationary batteries.
+
+`EV_V2G` is a specialisation of `EV_CHARGER` with Vehicle-to-Grid capability. Express power range via:
+- `maxExportKw`: max charge power (e.g. 7.4 for 7.4 kW AC)
+- `maxImportKw`: discharge power as a negative value (e.g. -3.7 for 3.7 kW V2G export)
+
+## Topology
+
+`subResources` and `parentResources` reference other EnergyResources by `id`. `subResources` items may also be inline-nested EnergyResource objects — this is a recursive (`$ref: EnergyResource`) reference, which is explicitly valid in JSON Schema 2020-12 and OpenAPI 3.1. `parentResources` items are always string FKs to avoid cycles.
 
 ## Examples
 
@@ -66,7 +101,8 @@ Grid topology (feeder, bus, DT) is expressed via `parentResources[]` — referen
 {
   "id": "MET2025789456123",
   "type": "METER",
-  "attributes": {"meterType": "AMI", "gps": "12.9716,77.5946"},
+  "meterCapability": "AMI",
+  "location": {"geo": {"type": "Point", "coordinates": [77.5946, 12.9716]}},
   "parentResources": ["BAN-NR-F22"]
 }
 ```
@@ -75,60 +111,76 @@ Grid topology (feeder, bus, DT) is expressed via `parentResources[]` — referen
 ```json
 {
   "id": "DER-SOLAR-001",
-  "type": "SOLAR",
-  "attributes": {"ratedPowerKw": 3, "make": "Waaree", "model": "WS-300", "commissioningDate": "2025-01-12"},
+  "type": "SOLAR_PV",
+  "maxExportKw": 3,
+  "make": "Waaree", "model": "WS-300",
+  "commissioningDate": "2025-01-12T00:00:00+05:30",
+  "parentResources": ["MET2025789456123"]
+}
+```
+
+**BESS (5 kW charge / 5 kW discharge):**
+```json
+{
+  "id": "BESS-001",
+  "type": "BESS",
+  "maxExportKw": 5, "maxImportKw": -5,
+  "energyCapacityKwh": 10,
+  "storageType": "LithiumIon",
+  "parentResources": ["MET2025789456123"]
+}
+```
+
+**V2G EV charger (7.4 kW charge / 3.7 kW V2G discharge):**
+```json
+{
+  "id": "EVSE-001",
+  "type": "EV_V2G",
+  "maxExportKw": 7.4, "maxImportKw": -3.7,
+  "connectorType": "Type2",
+  "v2xProtocol": "ISO_15118_20_AC_BPT",
+  "parentResources": ["MET2025789456123"]
+}
+```
+
+**INVERTER (grid-forming, VAr support, freq droop):**
+```json
+{
+  "id": "INV-001",
+  "type": "INVERTER",
+  "maxExportKw": 10, "maxImportKw": -10,
+  "ratedApparentPowerKva": 12,
+  "maxReactivePowerKvar": 6,
+  "operatingMode": "GridForming",
+  "voltVarEnabled": true,
+  "freqDroopEnabled": true,
+  "rideThroughCategory": "CategoryIII",
   "parentResources": ["MET2025789456123"]
 }
 ```
 
 **P2P-trading (minimal):**
 ```json
-{"id": "MET001", "type": "SOLAR"}
+{"id": "MET001", "type": "SOLAR_PV"}
 ```
 
-**Demand-flex (EV with parent meter):**
+**Microgrid topology:**
 ```json
 {
-  "id": "VIN001",
-  "type": "EV_CHARGER",
-  "attributes": {
-    "make": "Tata", "model": "Nexon EV",
-    "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0,
-    "telemetryProvider": "tata-evp-telematics",
-    "vin": "MAT123456789012345",
-    "chargingProtocol": "OCPP_2_0_1"
-  },
-  "parentResources": ["MET001"]
-}
-```
-
-**Topology — microgrid:**
-```json
-{
-  "id": "MICROGRID01",
-  "type": "MICROGRID",
+  "id": "MICROGRID01", "type": "MICROGRID",
   "subResources": [
-    "PV001",
-    "BAT001",
-    {
-      "id": "VIN001",
-      "type": "EV_CHARGER",
-      "attributes": {"ratedPowerKw": 7.0},
-      "parentResources": ["MICROGRID01"]
-    }
+    "PV001", "BAT001",
+    {"id": "EVSE-001", "type": "EV_V2G", "maxExportKw": 7.4, "maxImportKw": -3.7, "parentResources": ["MICROGRID01"]}
   ]
 }
 ```
 
-## Topology
-
-`subResources` and `parentResources` reference other EnergyResources by `id`. `subResources` items may also be inline-nested EnergyResource objects. `parentResources` items are always strings (FK references — inlining parents would create a cycle).
-
 ## Changes from earlier v2.0 (breaking)
 
-- **`resourceId` → `id`**, **`resourceType` → `type`** — simpler names.
-- **`resourceAttributes` → `attributes`** — renamed; still the open attribute bag.
-- **`CommonResourceAttributes` added** — named sub-schema for make/model/ratedPowerKw/energyCapacityKwh/telemetryProvider; all live inside `attributes`.
-- **Meter fields absorbed into `attributes`** — meterType, gps, location, feeder, bus are documented properties within the `attributes` bag for METER resources.
-- **`@type` discriminator field removed** — no longer needed.
-- **`sourceType` / `meterId`** — removed in the previous revision; still absent.
+- **`ratedPowerKw` retained; `maxImportKw` and `maxExportKw` added** — `ratedPowerKw` still accepted for backward compatibility. `maxExportKw` is the preferred field for new payloads (nameplate power in the principal direction); `maxImportKw` can be negative to express discharge/export capacity.
+- **`attributes` bag removed** — common and type-specific fields are now at the top level via `allOf` inheritance. Migration: `attributes.make` → `make`, `attributes.ratedPowerKw` → `maxExportKw`, etc.
+- **`location` elevated to `EnergyResourceCommon`** — was meter-specific; now applies to all resource types.
+- **`gps` field removed** — use `location.geo` (GeoJSON Point, coordinates `[longitude, latitude]`).
+- **`INVERTER` type added** — grid-connected power-electronics converters.
+- **`EV_CHARGER` reclassified** — flexible load, not storage.
+- **`SOLAR` and `BATTERY` deprecated** — use `SOLAR_PV` and `BESS` respectively.

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -4,96 +4,49 @@ info:
   version: 2.0.0
   description: >
     Canonical, technology-neutral class for any asset that produces,
-    consumes, stores, or modulates energy — solar PV, wind, hydro,
-    biogas, CHP, fuel cells, batteries / BESS, EVs and EVSE/V2G,
-    inverters, controllable loads (HVAC, water heaters, …), and the
-    metering points / connection points / feeders that anchor them.
+    consumes, stores, or modulates energy.
 
-    Structure
-    ─────────
-    EnergyResource inherits all fields from EnergyResourceCommon via
-    allOf. Type-specific fields are set directly at the top level —
-    no nested attributes bag.
+    Architecture
+    ────────────
+    EnergyResourceCommonAttributes defines common dimensioning fields
+    (make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
+    commissioningDate, location) shared by all resource kinds.
 
-    EnergyResourceCommon defines:
-      id              — stable identifier
-      type            — asset class enum
-      make / model    — manufacturer info
-      maxImportKw      — min operating power (negative = max discharge/export)
-      maxExportKw      — max operating power (generation / charge)
-      energyCapacityKwh — storage capacity (omit for pure-flow resources)
-      telemetryProvider — vendor API / data source for telemetry
-      commissioningDate — ISO 8601 commissioning date-time
-      location        — physical location (GeoJSON + postal address)
-      subResources    — child resource ids or inline objects (topology)
+    EnergyResourceCommon is the base envelope inherited by every kind via allOf:
+      id            — stable identifier
+      type          — asset class discriminator
+      subResources  — child resource ids or inline objects (topology)
       parentResources — parent resource ids (topology)
+      attributes    — allOf [EnergyResourceCommonAttributes] + open bag
+
+    Seven typed kinds each do allOf [EnergyResourceCommon] and refine the
+    attributes bag with kind-specific fields:
+      EnergyResourceMeter     (METER)
+      EnergyResourceGenerator (SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL)
+      EnergyResourceBESS      (BESS)
+      EnergyResourceEVCharger (EV_CHARGER, EV_V2G)
+      EnergyResourceInverter  (INVERTER)
+      EnergyResourceLoad      (SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD)
+      EnergyResourceNetwork   (DT, BUS, FEEDER, MICROGRID)
+
+    EnergyResource is the discriminated union: oneOf [all seven kinds].
+    Domain profiles reference individual kinds for targeted validation.
 
 components:
   schemas:
 
-    EnergyResourceCommon:
+    # ── Common attribute base (goes inside attributes bag) ────────────────
+
+    EnergyResourceCommonAttributes:
       type: object
       additionalProperties: true
       description: >
-        Base schema for all EnergyResource types. All fields are optional
-        at the schema level — domain profiles enforce their own constraints.
-        Inherited via allOf by EnergyResource and any profile-defined subtypes.
+        Dimensioning and provenance fields shared by all resource kinds.
+        Live inside each kind's attributes bag. No field is required at
+        the schema level.
       x-tags:
         - energy-resource
       properties:
-
-        id:
-          type: string
-          description: >
-            Stable identifier for this resource. For METER resources the
-            meter serial number is conventional. Any stable scheme that
-            is locally unique within the payload works.
-          example: "MET2025789456123"
-          x-jsonld:
-            "@id": "@id"
-
-        type:
-          type: string
-          description: >
-            Asset class. Grid infrastructure: METER, DT (distribution
-            transformer), BUS, FEEDER. Generation DERs: SOLAR_PV, WIND,
-            HYDRO, BIOGAS, CHP, FUEL_CELL. Storage: BESS.
-            EV charging: EV_CHARGER, EV_V2G (EV_V2G is a specialisation of
-            EV_CHARGER with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability;
-            set both maxImportKw (charging) and maxExportKw (V2G discharge);
-            EV_CHARGER is a flexible load — NOT a storage resource).
-            Power electronics: INVERTER (grid-connected converter for
-            reactive-power and frequency-support services per IEEE 1547 /
-            SunSpec DER Models 702–714; typical fields: ratedApparentPowerKva,
-            maxReactivePowerKvar, rideThroughCategory, operatingMode,
-            voltVarEnabled, freqDroopEnabled).
-            Flexible loads: SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD.
-            System: MICROGRID. Deprecated aliases: SOLAR (use SOLAR_PV),
-            BATTERY (use BESS).
-          enum:
-            - METER
-            - DT
-            - BUS
-            - FEEDER
-            - SOLAR_PV
-            - WIND
-            - HYDRO
-            - BIOGAS
-            - CHP
-            - FUEL_CELL
-            - BESS
-            - EV_CHARGER
-            - EV_V2G
-            - INVERTER
-            - SMART_HVAC
-            - SMART_WATER_HEATER
-            - CONTROLLABLE_LOAD
-            - MICROGRID
-            - SOLAR
-            - BATTERY
-          example: "SOLAR_PV"
-          x-jsonld:
-            "@id": deg:resourceType
 
         make:
           type: string
@@ -117,41 +70,30 @@ components:
           x-jsonld:
             "@id": deg:ratedPowerKw
 
-        maxImportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum power this resource draws from the grid (absorbs / charges), kW.
-            Always ≥0. Set for loads, storage charging, and EV charging.
-            Omit or set to 0 for pure generators (solar, wind).
-            For bidirectional resources (BESS, V2G) this is the max charge rate.
-            CIM: PowerElectronicsConnection.maxP (absorption direction).
-          x-jsonld:
-            "@id": deg:maxImportKw
-
         maxExportKw:
           type: number
           minimum: 0
           description: >
-            Maximum power this resource injects to the grid (generates / discharges), kW.
-            Always ≥0. Set for generators (solar, wind, CHP) and discharging storage.
-            Omit or set to 0 for pure loads.
-            For bidirectional resources (BESS, V2G) this is the max discharge rate.
-            Supersedes ratedPowerKw. CIM: GeneratingUnit.maxOperatingP /
-            PowerElectronicsConnection.maxP (injection direction).
+            Maximum power this resource injects to the grid (generates /
+            discharges), kW. Always ≥0. Set for generators (SOLAR_PV, WIND,
+            CHP) and discharging storage. For bidirectional resources (BESS,
+            V2G) this is the max discharge rate. Supersedes ratedPowerKw.
+            CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP
+            (injection direction).
           x-jsonld:
             "@id": deg:maxExportKw
 
-        energyCapacityKwh:
+        maxImportKw:
           type: number
           minimum: 0
           description: >
-            Rated stored-energy capacity, kWh. Populate for resources
-            with on-site storage (BESS). For EV resources this is the
-            usable battery capacity. Omit for pure-flow resources (solar,
-            wind, loads, network elements, inverters).
+            Maximum power this resource draws from the grid (absorbs /
+            charges), kW. Always ≥0. Set for loads, charging storage, and
+            EV chargers. For bidirectional resources (BESS, V2G) this is
+            the max charge rate. Omit or 0 for pure generators.
+            CIM: PowerElectronicsConnection.maxP (absorption direction).
           x-jsonld:
-            "@id": deg:energyCapacityKwh
+            "@id": deg:maxImportKw
 
         telemetryProvider:
           type: string
@@ -169,34 +111,26 @@ components:
         location:
           type: object
           description: >
-            Physical location of the asset (beckn Location shape).
-            geo (required) is a GeoJSON geometry with coordinates
-            [longitude, latitude] per RFC 7946. address (optional) is a
-            schema.org PostalAddress-aligned object. Applies to all
-            resource types, not only meters.
+            Physical location of the asset (beckn Location shape). geo
+            (required) is a GeoJSON geometry with coordinates [longitude,
+            latitude] per RFC 7946. address (optional) is a schema.org
+            PostalAddress-aligned object.
           additionalProperties: true
+          required:
+            - geo
           properties:
             geo:
               type: object
-              description: GeoJSON geometry. Coordinates are [longitude, latitude].
-              required:
-                - type
+              required: [type]
               additionalProperties: true
               properties:
                 type:
                   type: string
                   enum: [Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString]
-                coordinates:
-                  type: array
-                  description: For a Point — [longitude, latitude].
-                bbox:
-                  type: array
-                  minItems: 4
-                  maxItems: 4
-                  items: { type: number }
+                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
+                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
             address:
               type: object
-              description: Postal address (schema.org PostalAddress-aligned).
               additionalProperties: false
               properties:
                 streetAddress:   { type: string }
@@ -208,14 +142,40 @@ components:
           x-jsonld:
             "@id": deg:location
 
+    # ── Common envelope (inherited by every kind) ─────────────────────────
+
+    EnergyResourceCommon:
+      type: object
+      additionalProperties: true
+      description: >
+        Envelope schema inherited by every typed EnergyResource kind via allOf.
+        Defines the top-level fields common to all kinds: id, type, topology,
+        and the attributes bag (allOf EnergyResourceCommonAttributes).
+      x-tags:
+        - energy-resource
+      properties:
+
+        id:
+          type: string
+          description: >
+            Stable identifier for this resource. For METER resources the
+            meter serial number is conventional.
+          example: "MET2025789456123"
+          x-jsonld:
+            "@id": "@id"
+
+        type:
+          type: string
+          description: Asset class discriminator. See individual kind schemas for constrained enums.
+          x-jsonld:
+            "@id": deg:resourceType
+
         subResources:
           type: array
           description: >
-            Topology — child resources. Each item is EITHER a bare id
-            string (reference to a sibling EnergyResource in the same
-            payload) OR an inline-nested EnergyResource object.
-            Note: inline items use a recursive $ref, which is valid in
-            JSON Schema 2020-12 and OpenAPI 3.1.
+            Topology — child resources. Each item is EITHER a bare id string
+            (reference to a sibling EnergyResource) OR an inline EnergyResource
+            object. Uses a recursive $ref which is valid in JSON Schema 2020-12.
           items:
             oneOf:
               - type: string
@@ -228,34 +188,332 @@ components:
         parentResources:
           type: array
           description: >
-            Upward topology — ids of parent resources (e.g. the meter
-            this DER sits behind). String references only — inlining
-            parents would create a definitional cycle.
+            Upward topology — ids of parent resources (e.g. the meter this
+            DER sits behind). String references only; inlining parents would
+            create a definitional cycle.
           items:
             type: string
-            description: id of a parent EnergyResource.
           x-jsonld:
             "@id": deg:parentResources
 
-    EnergyResource:
-      description: >
-        Canonical energy-asset class. Inherits all common fields from
-        EnergyResourceCommon via allOf. Additional type-specific fields
-        are set directly at the top level (additionalProperties: true).
+        attributes:
+          type: object
+          additionalProperties: true
+          description: >
+            Attribute bag. Contains EnergyResourceCommonAttributes (make,
+            model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
+            commissioningDate, location) plus kind-specific fields defined
+            by each typed subschema.
+          allOf:
+            - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+          x-jsonld:
+            "@id": deg:attributes
 
-        Domain profiles add type-specific fields at the top level, for example:
-          METER:        meterCapability, energyDirection, functions, feeder, bus,
-                        communicationTechnology, applicationProtocol
-          BESS:         storageCapacityKwh, storageType, stateOfHealthPct
-          EV_CHARGER:   connectorType, controlProtocol
-          EV_V2G:       connectorType, controlProtocol, v2xProtocol
-          INVERTER:     ratedApparentPowerKva, maxReactivePowerKvar,
-                        minReactivePowerKvar, rideThroughCategory, operatingMode,
-                        voltVarEnabled, freqDroopEnabled, enterServiceRampTimeSec
-          SOLAR_PV/WIND: efficiency, nominalPowerKw
+    # ── Typed kinds ───────────────────────────────────────────────────────
+
+    EnergyResourceMeter:
+      description: >
+        Metering device. CIM: cim:Meter extends cim:EndDevice (IEC 61968-9).
       allOf:
         - $ref: "#/components/schemas/EnergyResourceCommon"
-      additionalProperties: true
+        - type: object
+          properties:
+            type:
+              type: string
+              const: METER
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                meterCapability:
+                  type: string
+                  enum: [Electromechanical, CMRI, AMR, AMI]
+                  description: >
+                    Communication/automation generation. Electromechanical=induction disc.
+                    CMRI=static optical-port read. AMR=one-way automated read.
+                    AMI=two-way smart meter. CIM: AmiBillingReadyKind (IEC 61968-9).
+                energyDirection:
+                  type: string
+                  enum: [Forward, Reverse, Bidirectional, Net]
+                  default: Forward
+                  description: >
+                    Energy flow direction. Forward=import (default). Reverse=export.
+                    Bidirectional=separate registers. Net=algebraically netted.
+                    CIM: FlowDirectionKind (ESPI NAESB REQ.21).
+                functions:
+                  type: array
+                  uniqueItems: true
+                  description: Bag of active capabilities (IEC 61968-9 EndDeviceFunction[0..*]).
+                  items:
+                    type: string
+                    enum: [ToU, NetMetering, MaxDemand, LoadControl, TamperDetection, PowerQuality, EventLogging]
+                feeder:
+                  type: string
+                  description: Feeder identifier this meter is supplied from.
+                bus:
+                  type: string
+                  description: Busbar identifier.
+                communicationTechnology:
+                  type: string
+                  enum: [PLC, RF_Mesh, GPRS, NB-IoT, LoRa, ZigBee, Other]
+                  description: Last-mile (physical layer) communication technology.
+                applicationProtocol:
+                  type: string
+                  enum: [DLMS_COSEM, ANSI_C12_18, IEC_61850, Modbus, Other]
+                  description: Application-layer protocol for meter data.
+
+    EnergyResourceGenerator:
+      description: >
+        Electrical generation asset. CIM GeneratingUnit subtypes (IEC 61970-302):
+        SOLAR_PV=PhotovoltaicUnit, WIND=WindGeneratingUnit,
+        HYDRO=HydroGeneratingUnit, BIOGAS/CHP=ThermalGeneratingUnit,
+        FUEL_CELL=IEC 62933-2. SOLAR is deprecated — use SOLAR_PV.
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, SOLAR]
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                nominalPowerKw:
+                  type: number
+                  minimum: 0
+                  description: >
+                    Nominal rated output power in kW when distinct from peak.
+                    CIM: GeneratingUnit.nominalP.
+                efficiency:
+                  type: number
+                  minimum: 0
+                  maximum: 100
+                  description: Conversion efficiency, %. Relevant for FUEL_CELL and CHP.
+
+    EnergyResourceBESS:
+      description: >
+        Stationary battery energy storage system. storageCapacityKwh is
+        exclusive to this kind. CIM: BatteryUnit (IEC 61970-302).
+        BATTERY is deprecated — use BESS.
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [BESS, BATTERY]
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                storageCapacityKwh:
+                  type: number
+                  minimum: 0
+                  description: >
+                    Rated energy capacity in kWh. Exclusive to this kind.
+                    CIM: BatteryUnit.ratedE.
+                storageType:
+                  type: string
+                  enum: [LithiumIon, LeadAcid, FlowBattery, NaS, NiCd, Flywheel, Other]
+                  description: Storage chemistry or technology type.
+                stateOfHealthPct:
+                  type: number
+                  minimum: 0
+                  maximum: 100
+                  description: Battery state of health as % of original capacity.
+
+    EnergyResourceEVCharger:
+      description: >
+        EV charging station (EVSE). A flexible load — NOT a storage resource.
+        The EV battery is storage; the EVSE is the charge/discharge interface.
+        EV_V2G is a specialisation of EV_CHARGER with ISO 15118-20 / OCPP 2.1
+        BPT bidirectional capability. Express power via maxImportKw (charge)
+        and maxExportKw (V2G discharge) in common attributes.
+        CIM: ElectricVehicleChargingStation (CIM17+).
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [EV_CHARGER, EV_V2G]
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                connectorType:
+                  type: string
+                  enum: [Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other]
+                  description: >
+                    Physical connector standard. Type1/Type2: IEC 62196.
+                    CCS1/CCS2: Combined Charging System. NACS: North American
+                    Charging Standard (J3400).
+                controlProtocol:
+                  type: string
+                  enum: [OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other]
+                  description: EVSE control and smart-charging protocol.
+                v2xProtocol:
+                  type: string
+                  enum: [CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other]
+                  description: >
+                    Vehicle-to-Grid / V2X protocol. Present only for EV_V2G
+                    resources.
+
+    EnergyResourceInverter:
+      description: >
+        Grid-connected power-electronics converter without a dedicated fuel
+        source. Captures reactive-power and frequency-support capabilities
+        per IEEE 1547-2018 and SunSpec DER Models 702–714. Use cases:
+        standalone battery inverters, VPP aggregation points, grid-forming
+        inverters for microgrid islanding.
+        CIM: PowerElectronicsConnection (IEC 61970-302).
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+        - type: object
+          properties:
+            type:
+              type: string
+              const: INVERTER
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                ratedApparentPowerKva:
+                  type: number
+                  minimum: 0
+                  description: Rated apparent power, kVA. SunSpec Model 702 maxVA.
+                maxReactivePowerKvar:
+                  type: number
+                  minimum: 0
+                  description: >
+                    Max reactive power injection (leading / over-excited), kVAr.
+                    SunSpec Model 702 maxVar.
+                minReactivePowerKvar:
+                  type: number
+                  description: >
+                    Max reactive power absorption (lagging / under-excited), kVAr.
+                    Usually negative. SunSpec Model 702 maxVarNeg.
+                rideThroughCategory:
+                  type: string
+                  enum: [CategoryI, CategoryII, CategoryIII]
+                  description: >
+                    IEEE 1547-2018 abnormal operating performance category.
+                    CategoryI: basic. CategoryII: enhanced (distribution DER).
+                    CategoryIII: advanced (large / transmission-connected DER).
+                operatingMode:
+                  type: string
+                  enum: [GridFollowing, GridForming, Standby]
+                  description: >
+                    Inverter grid-interaction mode. GridFollowing: synchronises
+                    to existing voltage/frequency (typical DER). GridForming:
+                    establishes V/f reference (microgrid islanding).
+                    CIM: PowerElectronicsConnection.inverterMode.
+                voltVarEnabled:
+                  type: boolean
+                  description: >
+                    Volt-VAr curve active (autonomous reactive power vs. voltage).
+                    IEEE 2030.5 opModVoltVar / SunSpec Model 705.
+                freqDroopEnabled:
+                  type: boolean
+                  description: >
+                    Frequency-Watt droop active (active power vs. frequency
+                    deviation). SunSpec Model 711 / IEEE 1547 Freq-Watt.
+                enterServiceRampTimeSec:
+                  type: number
+                  minimum: 0
+                  description: >
+                    Ramp-up time in seconds after reconnection.
+                    SunSpec Model 703 ESRmpTms.
+
+    EnergyResourceLoad:
+      description: >
+        Controllable electrical load.
+        CIM: EnergyConsumer / ConformLoad (IEC 61970-301).
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD]
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                controlProtocol:
+                  type: string
+                  enum: [OpenADR_2.0b, OCPP_2.0.1, SunSpec_Modbus, EEBus, Modbus, Other]
+                  description: Demand-response or load-control protocol.
+                loadCategory:
+                  type: string
+                  enum: [Heating, Cooling, WaterHeating, Lighting, EV, Industrial, Other]
+                  description: Load category for aggregation and dispatch optimisation.
+
+    EnergyResourceNetwork:
+      description: >
+        Distribution network topology element. CIM: DT=PowerTransformer,
+        BUS=BusbarSection, FEEDER=Feeder, MICROGRID=Substation/custom
+        (IEC 61970-301).
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum: [DT, BUS, FEEDER, MICROGRID]
+            attributes:
+              allOf:
+                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+              type: object
+              additionalProperties: true
+              properties:
+                nominalVoltageKv:
+                  type: number
+                  minimum: 0
+                  description: Nominal voltage level, kV. CIM: BaseVoltage.nominalVoltage.
+                zone:
+                  type: string
+                  description: Operating zone or region identifier.
+                substationId:
+                  type: string
+                  description: Parent substation identifier.
+                feederCode:
+                  type: string
+                  description: Feeder code per utility network records.
+
+    # ── Union entry point ─────────────────────────────────────────────────
+
+    EnergyResource:
+      description: >
+        Discriminated union of all typed EnergyResource kinds. Dispatched by
+        the 'type' field. Each kind inherits EnergyResourceCommon (id, type,
+        subResources, parentResources, attributes) via allOf and refines the
+        attributes bag with kind-specific fields.
+
+        For P2P-trading: minimal usage is {id, type}.
+        For demand-flex and credentials: add attributes fields as needed.
+        For targeted validation: $ref the specific kind directly.
+      oneOf:
+        - $ref: "#/components/schemas/EnergyResourceMeter"
+        - $ref: "#/components/schemas/EnergyResourceGenerator"
+        - $ref: "#/components/schemas/EnergyResourceBESS"
+        - $ref: "#/components/schemas/EnergyResourceEVCharger"
+        - $ref: "#/components/schemas/EnergyResourceInverter"
+        - $ref: "#/components/schemas/EnergyResourceLoad"
+        - $ref: "#/components/schemas/EnergyResourceNetwork"
       x-tags:
         - energy-trade
         - p2p-trading

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -6,90 +6,40 @@ info:
     Canonical, technology-neutral class for any asset that produces,
     consumes, stores, or modulates energy — solar PV, wind, hydro,
     biogas, CHP, fuel cells, batteries / BESS, EVs and EVSE/V2G,
-    controllable loads (HVAC, water heaters, …), and the metering
-    points / connection points / feeders that anchor them.
+    inverters, controllable loads (HVAC, water heaters, …), and the
+    metering points / connection points / feeders that anchor them.
 
     Structure
     ─────────
-    EnergyResource has exactly four top-level fields:
-      id            — stable identifier (meter serial number for METER resources)
-      type          — open-string asset class (METER, SOLAR, BATTERY, …)
-      subResources  — child resource ids or inline objects (topology)
-      parentResources — parent resource ids (topology)
+    EnergyResource inherits all fields from EnergyResourceCommon via
+    allOf. Type-specific fields are set directly at the top level —
+    no nested attributes bag.
 
-    Everything else — dimensioning, physical location, type-specific data —
-    lives in the `attributes` bag. CommonResourceAttributes defines the
-    sub-schema for the fields shared across all resource types
-    (make, model, ratedPowerKw, energyCapacityKwh, telemetryProvider).
-    The bag is open-ended; any domain may add further fields.
+    EnergyResourceCommon defines:
+      id              — stable identifier
+      type            — asset class enum
+      make / model    — manufacturer info
+      maxImportKw      — min operating power (negative = max discharge/export)
+      maxExportKw      — max operating power (generation / charge)
+      energyCapacityKwh — storage capacity (omit for pure-flow resources)
+      telemetryProvider — vendor API / data source for telemetry
+      commissioningDate — ISO 8601 commissioning date-time
+      location        — physical location (GeoJSON + postal address)
+      subResources    — child resource ids or inline objects (topology)
+      parentResources — parent resource ids (topology)
 
 components:
   schemas:
 
-    CommonResourceAttributes:
+    EnergyResourceCommon:
       type: object
-      description: >
-        Dimensioning fields common to all EnergyResource types.
-        These live inside EnergyResource.attributes alongside any
-        type-specific fields. No field is required.
       additionalProperties: true
-      x-tags:
-        - energy-resource
-      properties:
-
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": deg:make
-
-        model:
-          type: string
-          description: Model (free text).
-          x-jsonld:
-            "@id": deg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: Manufacturer-rated peak dispatchable power, kW.
-          x-jsonld:
-            "@id": deg:ratedPowerKw
-
-        energyCapacityKwh:
-          type: number
-          minimum: 0
-          description: >
-            Rated stored-energy capacity, kWh. Populated for storage-class
-            resources (BATTERY, BESS, EV). Omit for pure-flow resources.
-          x-jsonld:
-            "@id": deg:energyCapacityKwh
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": deg:telemetryProvider
-
-    EnergyResource:
-      type: object
-      additionalProperties: false
       description: >
-        Canonical energy-asset class. Exactly four top-level fields:
-        id, type, subResources, parentResources. All other attributes
-        — dimensioning, location, type-specific data — live in `attributes`.
-
-        No field is required at the schema level. Domain profiles enforce
-        their own cross-field rules.
+        Base schema for all EnergyResource types. All fields are optional
+        at the schema level — domain profiles enforce their own constraints.
+        Inherited via allOf by EnergyResource and any profile-defined subtypes.
       x-tags:
-        - energy-trade
-        - p2p-trading
-        - demand-flex
-        - item
         - energy-resource
-      x-jsonld:
-        "@context": ./context.jsonld
-        "@type": EnergyResource
       properties:
 
         id:
@@ -106,141 +56,166 @@ components:
           type: string
           description: >
             Asset class. Grid infrastructure: METER, DT (distribution
-            transformer), BUS, FEEDER. Generation DERs: SOLAR, SOLAR_PV,
-            WIND, HYDRO, BIOGAS, CHP, FUEL_CELL. Storage: BATTERY, BESS.
-            Flexible loads: EV_CHARGER, EV_V2G, SMART_HVAC,
-            SMART_WATER_HEATER, CONTROLLABLE_LOAD. System: MICROGRID.
+            transformer), BUS, FEEDER. Generation DERs: SOLAR_PV, WIND,
+            HYDRO, BIOGAS, CHP, FUEL_CELL. Storage: BESS.
+            EV charging: EV_CHARGER, EV_V2G (EV_V2G is a specialisation of
+            EV_CHARGER with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability;
+            set both maxImportKw (charging) and maxExportKw (V2G discharge);
+            EV_CHARGER is a flexible load — NOT a storage resource).
+            Power electronics: INVERTER (grid-connected converter for
+            reactive-power and frequency-support services per IEEE 1547 /
+            SunSpec DER Models 702–714; typical fields: ratedApparentPowerKva,
+            maxReactivePowerKvar, rideThroughCategory, operatingMode,
+            voltVarEnabled, freqDroopEnabled).
+            Flexible loads: SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD.
+            System: MICROGRID. Deprecated aliases: SOLAR (use SOLAR_PV),
+            BATTERY (use BESS).
           enum:
             - METER
             - DT
             - BUS
             - FEEDER
-            - SOLAR
             - SOLAR_PV
             - WIND
             - HYDRO
             - BIOGAS
             - CHP
             - FUEL_CELL
-            - BATTERY
             - BESS
             - EV_CHARGER
             - EV_V2G
+            - INVERTER
             - SMART_HVAC
             - SMART_WATER_HEATER
             - CONTROLLABLE_LOAD
             - MICROGRID
-          example: "METER"
+            - SOLAR
+            - BATTERY
+          example: "SOLAR_PV"
           x-jsonld:
             "@id": deg:resourceType
 
-        attributes:
+        make:
+          type: string
+          description: Manufacturer (free text).
+          x-jsonld:
+            "@id": deg:make
+
+        model:
+          type: string
+          description: Model (free text).
+          x-jsonld:
+            "@id": deg:model
+
+        ratedPowerKw:
+          type: number
+          minimum: 0
           description: >
-            Attribute bag containing all non-topological properties of this
-            resource. CommonResourceAttributes (make, model, ratedPowerKw,
-            energyCapacityKwh, telemetryProvider) are the common fields
-            present across all resource types. Additional type-specific
-            fields (meterType, feeder, commissioningDate, storageType, VIN,
-            …) are placed here alongside them.
+            Manufacturer-rated peak power in kW (nameplate value in the
+            principal direction). Kept for backward compatibility.
+            Prefer maxExportKw for new payloads.
+          x-jsonld:
+            "@id": deg:ratedPowerKw
 
-            For METER resources: meterType, gps, location, feeder, bus.
-            For generation DERs: commissioningDate, and generation-type info.
-            For storage DERs: storageType, commissioningDate.
-            For EV resources: vin, chargingProtocol.
+        maxImportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum power this resource draws from the grid (absorbs / charges), kW.
+            Always ≥0. Set for loads, storage charging, and EV charging.
+            Omit or set to 0 for pure generators (solar, wind).
+            For bidirectional resources (BESS, V2G) this is the max charge rate.
+            CIM: PowerElectronicsConnection.maxP (absorption direction).
+          x-jsonld:
+            "@id": deg:maxImportKw
+
+        maxExportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum power this resource injects to the grid (generates / discharges), kW.
+            Always ≥0. Set for generators (solar, wind, CHP) and discharging storage.
+            Omit or set to 0 for pure loads.
+            For bidirectional resources (BESS, V2G) this is the max discharge rate.
+            Supersedes ratedPowerKw. CIM: GeneratingUnit.maxOperatingP /
+            PowerElectronicsConnection.maxP (injection direction).
+          x-jsonld:
+            "@id": deg:maxExportKw
+
+        energyCapacityKwh:
+          type: number
+          minimum: 0
+          description: >
+            Rated stored-energy capacity, kWh. Populate for resources
+            with on-site storage (BESS). For EV resources this is the
+            usable battery capacity. Omit for pure-flow resources (solar,
+            wind, loads, network elements, inverters).
+          x-jsonld:
+            "@id": deg:energyCapacityKwh
+
+        telemetryProvider:
+          type: string
+          description: Vendor API / data source identifier for telemetry.
+          x-jsonld:
+            "@id": deg:telemetryProvider
+
+        commissioningDate:
+          type: string
+          format: date-time
+          description: ISO 8601 date-time the asset was commissioned.
+          x-jsonld:
+            "@id": deg:commissioningDate
+
+        location:
           type: object
+          description: >
+            Physical location of the asset (beckn Location shape).
+            geo (required) is a GeoJSON geometry with coordinates
+            [longitude, latitude] per RFC 7946. address (optional) is a
+            schema.org PostalAddress-aligned object. Applies to all
+            resource types, not only meters.
           additionalProperties: true
-          allOf:
-            - $ref: "#/components/schemas/CommonResourceAttributes"
           properties:
-
-            # ── Common (from CommonResourceAttributes) ────────────────
-            make:
-              type: string
-              x-jsonld:
-                "@id": deg:make
-            model:
-              type: string
-              x-jsonld:
-                "@id": deg:model
-            ratedPowerKw:
-              type: number
-              minimum: 0
-              x-jsonld:
-                "@id": deg:ratedPowerKw
-            energyCapacityKwh:
-              type: number
-              minimum: 0
-              x-jsonld:
-                "@id": deg:energyCapacityKwh
-            telemetryProvider:
-              type: string
-              x-jsonld:
-                "@id": deg:telemetryProvider
-
-            # ── Meter-specific (type = METER) ─────────────────────────
-            meterType:
-              type: string
-              enum:
-                - AMR
-                - AMI
-                - Electromechanical
-                - Forward
-                - Reverse
-                - Bidirectional
-                - Prepaid
-                - NetMeter
-                - Other
-              description: Meter kind classification (Green Button / ESPI).
-              x-jsonld:
-                "@id": deg:meterType
-
-            gps:
-              type: string
-              pattern: "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-              description: GPS coordinates of the asset as 'lat,lng'.
-              x-jsonld:
-                "@id": deg:gps
-
-            location:
+            geo:
               type: object
-              description: >
-                Postal location of the meter (beckn Location shape).
-                Use when the physical location differs from the customer's
-                registered installation address.
+              description: GeoJSON geometry. Coordinates are [longitude, latitude].
+              required:
+                - type
               additionalProperties: true
               properties:
-                address: { type: string }
-                city:
-                  type: object
-                  properties:
-                    name: { type: string }
-                    code: { type: string }
-                district: { type: string }
-                state:
-                  type: object
-                  properties:
-                    name: { type: string }
-                    code: { type: string }
-                country:
-                  type: object
-                  properties:
-                    name: { type: string }
-                    code: { type: string, pattern: "^[A-Z]{2}$" }
-                area_code: { type: string }
-                gps: { type: string }
-                openLocationCode: { type: string }
-              x-jsonld:
-                "@id": deg:meterLocation
-
+                type:
+                  type: string
+                  enum: [Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString]
+                coordinates:
+                  type: array
+                  description: For a Point — [longitude, latitude].
+                bbox:
+                  type: array
+                  minItems: 4
+                  maxItems: 4
+                  items: { type: number }
+            address:
+              type: object
+              description: Postal address (schema.org PostalAddress-aligned).
+              additionalProperties: false
+              properties:
+                streetAddress:   { type: string }
+                extendedAddress: { type: string }
+                addressLocality: { type: string }
+                addressRegion:   { type: string }
+                postalCode:      { type: string }
+                addressCountry:  { type: string, description: "ISO 3166-1 alpha-2 or country name." }
           x-jsonld:
-            "@id": deg:attributes
+            "@id": deg:location
 
         subResources:
           type: array
           description: >
-            Topology — child resources. Each item is EITHER a bare `id`
+            Topology — child resources. Each item is EITHER a bare id
             string (reference to a sibling EnergyResource in the same
             payload) OR an inline-nested EnergyResource object.
+            Note: inline items use a recursive $ref, which is valid in
+            JSON Schema 2020-12 and OpenAPI 3.1.
           items:
             oneOf:
               - type: string
@@ -253,12 +228,40 @@ components:
         parentResources:
           type: array
           description: >
-            Upward topology — `id`s of parent resources (e.g. the meter
-            this DER sits behind). String references only — parents are
-            always enumerated elsewhere in the same payload; inlining
-            them here would create a definitional cycle.
+            Upward topology — ids of parent resources (e.g. the meter
+            this DER sits behind). String references only — inlining
+            parents would create a definitional cycle.
           items:
             type: string
             description: id of a parent EnergyResource.
           x-jsonld:
             "@id": deg:parentResources
+
+    EnergyResource:
+      description: >
+        Canonical energy-asset class. Inherits all common fields from
+        EnergyResourceCommon via allOf. Additional type-specific fields
+        are set directly at the top level (additionalProperties: true).
+
+        Domain profiles add type-specific fields at the top level, for example:
+          METER:        meterCapability, energyDirection, functions, feeder, bus,
+                        communicationTechnology, applicationProtocol
+          BESS:         storageCapacityKwh, storageType, stateOfHealthPct
+          EV_CHARGER:   connectorType, controlProtocol
+          EV_V2G:       connectorType, controlProtocol, v2xProtocol
+          INVERTER:     ratedApparentPowerKva, maxReactivePowerKvar,
+                        minReactivePowerKvar, rideThroughCategory, operatingMode,
+                        voltVarEnabled, freqDroopEnabled, enterServiceRampTimeSec
+          SOLAR_PV/WIND: efficiency, nominalPowerKw
+      allOf:
+        - $ref: "#/components/schemas/EnergyResourceCommon"
+      additionalProperties: true
+      x-tags:
+        - energy-trade
+        - p2p-trading
+        - demand-flex
+        - item
+        - energy-resource
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": EnergyResource

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -209,299 +209,46 @@ components:
           x-jsonld:
             "@id": deg:attributes
 
-    # ── Typed kinds ───────────────────────────────────────────────────────
+    # ── Canonical kind aliases ────────────────────────────────────────────
+    # Each kind lives in its own specification/schema/<Kind>/v1.0/ folder
+    # and is published to schema.beckn.io/<Kind>/v1.0.
+    # EnergyResource/v2.0 owns EnergyResourceCommon and EnergyResourceCommonAttributes;
+    # the kind schemas are the authoritative source for type-specific attributes.
 
     EnergyResourceMeter:
-      description: >
-        Metering device. CIM: cim:Meter extends cim:EndDevice (IEC 61968-9).
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              const: METER
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                meterCapability:
-                  type: string
-                  enum: [Electromechanical, CMRI, AMR, AMI]
-                  description: >
-                    Communication/automation generation. Electromechanical=induction disc.
-                    CMRI=static optical-port read. AMR=one-way automated read.
-                    AMI=two-way smart meter. CIM: AmiBillingReadyKind (IEC 61968-9).
-                energyDirection:
-                  type: string
-                  enum: [Forward, Reverse, Bidirectional, Net]
-                  default: Forward
-                  description: >
-                    Energy flow direction. Forward=import (default). Reverse=export.
-                    Bidirectional=separate registers. Net=algebraically netted.
-                    CIM: FlowDirectionKind (ESPI NAESB REQ.21).
-                functions:
-                  type: array
-                  uniqueItems: true
-                  description: Bag of active capabilities (IEC 61968-9 EndDeviceFunction[0..*]).
-                  items:
-                    type: string
-                    enum: [ToU, NetMetering, MaxDemand, LoadControl, TamperDetection, PowerQuality, EventLogging]
-                feeder:
-                  type: string
-                  description: Feeder identifier this meter is supplied from.
-                bus:
-                  type: string
-                  description: Busbar identifier.
-                communicationTechnology:
-                  type: string
-                  enum: [PLC, RF_Mesh, GPRS, NB-IoT, LoRa, ZigBee, Other]
-                  description: Last-mile (physical layer) communication technology.
-                applicationProtocol:
-                  type: string
-                  enum: [DLMS_COSEM, ANSI_C12_18, IEC_61850, Modbus, Other]
-                  description: Application-layer protocol for meter data.
+      $ref: "https://schema.beckn.io/EnergyResourceMeter/v1.0#/components/schemas/EnergyResourceMeter"
 
     EnergyResourceGenerator:
-      description: >
-        Electrical generation asset. CIM GeneratingUnit subtypes (IEC 61970-302):
-        SOLAR_PV=PhotovoltaicUnit, WIND=WindGeneratingUnit,
-        HYDRO=HydroGeneratingUnit, BIOGAS/CHP=ThermalGeneratingUnit,
-        FUEL_CELL=IEC 62933-2. SOLAR is deprecated — use SOLAR_PV.
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              enum: [SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, SOLAR]
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                nominalPowerKw:
-                  type: number
-                  minimum: 0
-                  description: >
-                    Nominal rated output power in kW when distinct from peak.
-                    CIM: GeneratingUnit.nominalP.
-                efficiency:
-                  type: number
-                  minimum: 0
-                  maximum: 100
-                  description: Conversion efficiency, %. Relevant for FUEL_CELL and CHP.
+      $ref: "https://schema.beckn.io/EnergyResourceGenerator/v1.0#/components/schemas/EnergyResourceGenerator"
 
-    EnergyResourceBESS:
-      description: >
-        Stationary battery energy storage system. storageCapacityKwh is
-        exclusive to this kind. CIM: BatteryUnit (IEC 61970-302).
-        BATTERY is deprecated — use BESS.
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              enum: [BESS, BATTERY]
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                storageCapacityKwh:
-                  type: number
-                  minimum: 0
-                  description: >
-                    Rated energy capacity in kWh. Exclusive to this kind.
-                    CIM: BatteryUnit.ratedE.
-                storageType:
-                  type: string
-                  enum: [LithiumIon, LeadAcid, FlowBattery, NaS, NiCd, Flywheel, Other]
-                  description: Storage chemistry or technology type.
-                stateOfHealthPct:
-                  type: number
-                  minimum: 0
-                  maximum: 100
-                  description: Battery state of health as % of original capacity.
+    EnergyResourceStorage:
+      $ref: "https://schema.beckn.io/EnergyResourceStorage/v1.0#/components/schemas/EnergyResourceStorage"
 
     EnergyResourceEVCharger:
-      description: >
-        EV charging station (EVSE). A flexible load — NOT a storage resource.
-        The EV battery is storage; the EVSE is the charge/discharge interface.
-        EV_V2G is a specialisation of EV_CHARGER with ISO 15118-20 / OCPP 2.1
-        BPT bidirectional capability. Express power via maxImportKw (charge)
-        and maxExportKw (V2G discharge) in common attributes.
-        CIM: ElectricVehicleChargingStation (CIM17+).
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              enum: [EV_CHARGER, EV_V2G]
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                connectorType:
-                  type: string
-                  enum: [Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other]
-                  description: >
-                    Physical connector standard. Type1/Type2: IEC 62196.
-                    CCS1/CCS2: Combined Charging System. NACS: North American
-                    Charging Standard (J3400).
-                controlProtocol:
-                  type: string
-                  enum: [OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other]
-                  description: EVSE control and smart-charging protocol.
-                v2xProtocol:
-                  type: string
-                  enum: [CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other]
-                  description: >
-                    Vehicle-to-Grid / V2X protocol. Present only for EV_V2G
-                    resources.
+      $ref: "https://schema.beckn.io/EnergyResourceEVCharger/v1.0#/components/schemas/EnergyResourceEVCharger"
 
     EnergyResourceInverter:
-      description: >
-        Grid-connected power-electronics converter without a dedicated fuel
-        source. Captures reactive-power and frequency-support capabilities
-        per IEEE 1547-2018 and SunSpec DER Models 702–714. Use cases:
-        standalone battery inverters, VPP aggregation points, grid-forming
-        inverters for microgrid islanding.
-        CIM: PowerElectronicsConnection (IEC 61970-302).
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              const: INVERTER
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                ratedApparentPowerKva:
-                  type: number
-                  minimum: 0
-                  description: Rated apparent power, kVA. SunSpec Model 702 maxVA.
-                maxReactivePowerKvar:
-                  type: number
-                  minimum: 0
-                  description: >
-                    Max reactive power injection (leading / over-excited), kVAr.
-                    SunSpec Model 702 maxVar.
-                minReactivePowerKvar:
-                  type: number
-                  description: >
-                    Max reactive power absorption (lagging / under-excited), kVAr.
-                    Usually negative. SunSpec Model 702 maxVarNeg.
-                rideThroughCategory:
-                  type: string
-                  enum: [CategoryI, CategoryII, CategoryIII]
-                  description: >
-                    IEEE 1547-2018 abnormal operating performance category.
-                    CategoryI: basic. CategoryII: enhanced (distribution DER).
-                    CategoryIII: advanced (large / transmission-connected DER).
-                operatingMode:
-                  type: string
-                  enum: [GridFollowing, GridForming, Standby]
-                  description: >
-                    Inverter grid-interaction mode. GridFollowing: synchronises
-                    to existing voltage/frequency (typical DER). GridForming:
-                    establishes V/f reference (microgrid islanding).
-                    CIM: PowerElectronicsConnection.inverterMode.
-                voltVarEnabled:
-                  type: boolean
-                  description: >
-                    Volt-VAr curve active (autonomous reactive power vs. voltage).
-                    IEEE 2030.5 opModVoltVar / SunSpec Model 705.
-                freqDroopEnabled:
-                  type: boolean
-                  description: >
-                    Frequency-Watt droop active (active power vs. frequency
-                    deviation). SunSpec Model 711 / IEEE 1547 Freq-Watt.
-                enterServiceRampTimeSec:
-                  type: number
-                  minimum: 0
-                  description: >
-                    Ramp-up time in seconds after reconnection.
-                    SunSpec Model 703 ESRmpTms.
+      $ref: "https://schema.beckn.io/EnergyResourceInverter/v1.0#/components/schemas/EnergyResourceInverter"
 
     EnergyResourceLoad:
-      description: >
-        Controllable electrical load.
-        CIM: EnergyConsumer / ConformLoad (IEC 61970-301).
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              enum: [SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD]
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                controlProtocol:
-                  type: string
-                  enum: [OpenADR_2.0b, OCPP_2.0.1, SunSpec_Modbus, EEBus, Modbus, Other]
-                  description: Demand-response or load-control protocol.
-                loadCategory:
-                  type: string
-                  enum: [Heating, Cooling, WaterHeating, Lighting, EV, Industrial, Other]
-                  description: Load category for aggregation and dispatch optimisation.
+      $ref: "https://schema.beckn.io/EnergyResourceLoad/v1.0#/components/schemas/EnergyResourceLoad"
 
     EnergyResourceNetwork:
-      description: >
-        Distribution network topology element. CIM: DT=PowerTransformer,
-        BUS=BusbarSection, FEEDER=Feeder, MICROGRID=Substation/custom
-        (IEC 61970-301).
-      allOf:
-        - $ref: "#/components/schemas/EnergyResourceCommon"
-        - type: object
-          properties:
-            type:
-              type: string
-              enum: [DT, BUS, FEEDER, MICROGRID]
-            attributes:
-              allOf:
-                - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-              type: object
-              additionalProperties: true
-              properties:
-                nominalVoltageKv:
-                  type: number
-                  minimum: 0
-                  description: Nominal voltage level, kV. CIM: BaseVoltage.nominalVoltage.
-                zone:
-                  type: string
-                  description: Operating zone or region identifier.
-                substationId:
-                  type: string
-                  description: Parent substation identifier.
-                feederCode:
-                  type: string
-                  description: Feeder code per utility network records.
+      $ref: "https://schema.beckn.io/EnergyResourceNetwork/v1.0#/components/schemas/EnergyResourceNetwork"
 
     # ── Union entry point ─────────────────────────────────────────────────
 
     EnergyResource:
       description: >
         Discriminated union of all typed EnergyResource kinds. Dispatched by
-        the 'type' field. Each kind inherits EnergyResourceCommon (id, type,
-        subResources, parentResources, attributes) via allOf and refines the
-        attributes bag with kind-specific fields.
+        the 'type' field. Each kind lives in its own schema at
+        schema.beckn.io/<Kind>/v1.0 and is referenced above.
+
+        EnergyResourceCommon (id, type, subResources, parentResources,
+        attributes) and EnergyResourceCommonAttributes (make, model,
+        maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
+        commissioningDate, location) are defined in this schema and inherited
+        by all kinds.
 
         For P2P-trading: minimal usage is {id, type}.
         For demand-flex and credentials: add attributes fields as needed.
@@ -509,7 +256,7 @@ components:
       oneOf:
         - $ref: "#/components/schemas/EnergyResourceMeter"
         - $ref: "#/components/schemas/EnergyResourceGenerator"
-        - $ref: "#/components/schemas/EnergyResourceBESS"
+        - $ref: "#/components/schemas/EnergyResourceStorage"
         - $ref: "#/components/schemas/EnergyResourceEVCharger"
         - $ref: "#/components/schemas/EnergyResourceInverter"
         - $ref: "#/components/schemas/EnergyResourceLoad"

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -8,17 +8,11 @@ info:
 
     Architecture
     ────────────
-    EnergyResourceCommon (envelope) and EnergyResourceCommonAttributes
-    (attributes bag base) are defined in EnergyResourceCommon/v1.0 and
-    aliased here for tooling convenience.
-
-    EnergyResourceCommonAttributes holds shared dimensioning fields:
-      make, model, maxExportKw, maxImportKw, ratedPowerKw,
-      telemetryProvider, commissioningDate, location.
-
-    EnergyResourceCommon is the structural envelope:
-      id, type, subResources, parentResources,
-      attributes (allOf EnergyResourceCommonAttributes).
+    EnergyResourceCommon (envelope: id, type, subResources, parentResources,
+    attributes) and EnergyResourceCommonAttributes (attribute bag base: make,
+    model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
+    commissioningDate, location) are defined in EnergyResourceCommon/v1.0.
+    All seven kinds inherit them via allOf external $ref.
 
     Seven typed kinds each inherit EnergyResourceCommon via allOf and
     refine the attributes bag with kind-specific fields:
@@ -36,20 +30,12 @@ info:
 components:
   schemas:
 
-    # ── Common base schemas — defined in EnergyResourceCommon/v1.0 ────────
-    # Aliased here so tooling resolving EnergyResource/v2.0 can reach them.
-
-    EnergyResourceCommonAttributes:
-      $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
-
-    EnergyResourceCommon:
-      $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
-
     # ── Canonical kind aliases ────────────────────────────────────────────
     # Each kind lives in its own specification/schema/<Kind>/v1.0/ folder
     # and is published to schema.beckn.io/<Kind>/v1.0.
-    # EnergyResource/v2.0 owns EnergyResourceCommon and EnergyResourceCommonAttributes;
-    # the kind schemas are the authoritative source for type-specific attributes.
+    # Common base schemas (EnergyResourceCommon, EnergyResourceCommonAttributes)
+    # live at schema.beckn.io/EnergyResourceCommon/v1.0 and are referenced
+    # directly by the kind schemas — not re-aliased here.
 
     EnergyResourceMeter:
       $ref: "https://schema.beckn.io/EnergyResourceMeter/v1.0#/components/schemas/EnergyResourceMeter"
@@ -83,8 +69,8 @@ components:
         EnergyResourceCommon (id, type, subResources, parentResources,
         attributes) and EnergyResourceCommonAttributes (make, model,
         maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
-        commissioningDate, location) are defined in this schema and inherited
-        by all kinds.
+        commissioningDate, location) are defined in EnergyResourceCommon/v1.0
+        and inherited by all kinds via allOf external $ref.
 
         For P2P-trading: minimal usage is {id, type}.
         For demand-flex and credentials: add attributes fields as needed.

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -8,22 +8,23 @@ info:
 
     Architecture
     ────────────
-    EnergyResourceCommonAttributes defines common dimensioning fields
-    (make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
-    commissioningDate, location) shared by all resource kinds.
+    EnergyResourceCommon (envelope) and EnergyResourceCommonAttributes
+    (attributes bag base) are defined in EnergyResourceCommon/v1.0 and
+    aliased here for tooling convenience.
 
-    EnergyResourceCommon is the base envelope inherited by every kind via allOf:
-      id            — stable identifier
-      type          — asset class discriminator
-      subResources  — child resource ids or inline objects (topology)
-      parentResources — parent resource ids (topology)
-      attributes    — allOf [EnergyResourceCommonAttributes] + open bag
+    EnergyResourceCommonAttributes holds shared dimensioning fields:
+      make, model, maxExportKw, maxImportKw, ratedPowerKw,
+      telemetryProvider, commissioningDate, location.
 
-    Seven typed kinds each do allOf [EnergyResourceCommon] and refine the
-    attributes bag with kind-specific fields:
+    EnergyResourceCommon is the structural envelope:
+      id, type, subResources, parentResources,
+      attributes (allOf EnergyResourceCommonAttributes).
+
+    Seven typed kinds each inherit EnergyResourceCommon via allOf and
+    refine the attributes bag with kind-specific fields:
       EnergyResourceMeter     (METER)
       EnergyResourceGenerator (SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL)
-      EnergyResourceBESS      (BESS)
+      EnergyResourceStorage   (BESS)
       EnergyResourceEVCharger (EV_CHARGER, EV_V2G)
       EnergyResourceInverter  (INVERTER)
       EnergyResourceLoad      (SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD)
@@ -35,179 +36,14 @@ info:
 components:
   schemas:
 
-    # ── Common attribute base (goes inside attributes bag) ────────────────
+    # ── Common base schemas — defined in EnergyResourceCommon/v1.0 ────────
+    # Aliased here so tooling resolving EnergyResource/v2.0 can reach them.
 
     EnergyResourceCommonAttributes:
-      type: object
-      additionalProperties: true
-      description: >
-        Dimensioning and provenance fields shared by all resource kinds.
-        Live inside each kind's attributes bag. No field is required at
-        the schema level.
-      x-tags:
-        - energy-resource
-      properties:
-
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": deg:make
-
-        model:
-          type: string
-          description: Model (free text).
-          x-jsonld:
-            "@id": deg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power in kW (nameplate value in the
-            principal direction). Kept for backward compatibility.
-            Prefer maxExportKw for new payloads.
-          x-jsonld:
-            "@id": deg:ratedPowerKw
-
-        maxExportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum power this resource injects to the grid (generates /
-            discharges), kW. Always ≥0. Set for generators (SOLAR_PV, WIND,
-            CHP) and discharging storage. For bidirectional resources (BESS,
-            V2G) this is the max discharge rate. Supersedes ratedPowerKw.
-            CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP
-            (injection direction).
-          x-jsonld:
-            "@id": deg:maxExportKw
-
-        maxImportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum power this resource draws from the grid (absorbs /
-            charges), kW. Always ≥0. Set for loads, charging storage, and
-            EV chargers. For bidirectional resources (BESS, V2G) this is
-            the max charge rate. Omit or 0 for pure generators.
-            CIM: PowerElectronicsConnection.maxP (absorption direction).
-          x-jsonld:
-            "@id": deg:maxImportKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": deg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time the asset was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of the asset (beckn Location shape). geo
-            (required) is a GeoJSON geometry with coordinates [longitude,
-            latitude] per RFC 7946. address (optional) is a schema.org
-            PostalAddress-aligned object.
-          additionalProperties: true
-          required:
-            - geo
-          properties:
-            geo:
-              type: object
-              required: [type]
-              additionalProperties: true
-              properties:
-                type:
-                  type: string
-                  enum: [Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString]
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-            address:
-              type: object
-              additionalProperties: false
-              properties:
-                streetAddress:   { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion:   { type: string }
-                postalCode:      { type: string }
-                addressCountry:  { type: string, description: "ISO 3166-1 alpha-2 or country name." }
-          x-jsonld:
-            "@id": deg:location
-
-    # ── Common envelope (inherited by every kind) ─────────────────────────
+      $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
 
     EnergyResourceCommon:
-      type: object
-      additionalProperties: true
-      description: >
-        Envelope schema inherited by every typed EnergyResource kind via allOf.
-        Defines the top-level fields common to all kinds: id, type, topology,
-        and the attributes bag (allOf EnergyResourceCommonAttributes).
-      x-tags:
-        - energy-resource
-      properties:
-
-        id:
-          type: string
-          description: >
-            Stable identifier for this resource. For METER resources the
-            meter serial number is conventional.
-          example: "MET2025789456123"
-          x-jsonld:
-            "@id": "@id"
-
-        type:
-          type: string
-          description: Asset class discriminator. See individual kind schemas for constrained enums.
-          x-jsonld:
-            "@id": deg:resourceType
-
-        subResources:
-          type: array
-          description: >
-            Topology — child resources. Each item is EITHER a bare id string
-            (reference to a sibling EnergyResource) OR an inline EnergyResource
-            object. Uses a recursive $ref which is valid in JSON Schema 2020-12.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource.
-              - $ref: "#/components/schemas/EnergyResource"
-                description: Inline-nested EnergyResource.
-          x-jsonld:
-            "@id": deg:subResources
-
-        parentResources:
-          type: array
-          description: >
-            Upward topology — ids of parent resources (e.g. the meter this
-            DER sits behind). String references only; inlining parents would
-            create a definitional cycle.
-          items:
-            type: string
-          x-jsonld:
-            "@id": deg:parentResources
-
-        attributes:
-          type: object
-          additionalProperties: true
-          description: >
-            Attribute bag. Contains EnergyResourceCommonAttributes (make,
-            model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
-            commissioningDate, location) plus kind-specific fields defined
-            by each typed subschema.
-          allOf:
-            - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
-          x-jsonld:
-            "@id": deg:attributes
+      $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
 
     # ── Canonical kind aliases ────────────────────────────────────────────
     # Each kind lives in its own specification/schema/<Kind>/v1.0/ folder

--- a/specification/schema/EnergyResource/v2.0/context.jsonld
+++ b/specification/schema/EnergyResource/v2.0/context.jsonld
@@ -13,24 +13,15 @@
     "id":   "@id",
     "type": { "@id": "deg:resourceType", "@type": "xsd:string" },
 
-    "attributes": {
-      "@id": "deg:attributes",
-      "@type": "@id",
-      "@context": {
-        "make":              { "@id": "deg:make",              "@type": "xsd:string"  },
-        "model":             { "@id": "deg:model",             "@type": "xsd:string"  },
-        "ratedPowerKw":      { "@id": "deg:ratedPowerKw",      "@type": "xsd:decimal" },
-        "energyCapacityKwh": { "@id": "deg:energyCapacityKwh", "@type": "xsd:decimal" },
-        "telemetryProvider": { "@id": "deg:telemetryProvider", "@type": "xsd:string"  },
-        "meterType":         { "@id": "deg:meterType",         "@type": "xsd:string"  },
-        "gps":               { "@id": "deg:gps",               "@type": "xsd:string"  },
-        "meterLocation":     { "@id": "deg:meterLocation",     "@type": "@id"         },
-        "feeder":            { "@id": "deg:feeder",            "@type": "xsd:string"  },
-        "bus":               { "@id": "deg:bus",               "@type": "xsd:string"  },
-        "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:string"  },
-        "storageType":       { "@id": "deg:storageType",       "@type": "xsd:string"  }
-      }
-    },
+    "make":              { "@id": "deg:make",              "@type": "xsd:string"   },
+    "model":             { "@id": "deg:model",             "@type": "xsd:string"   },
+    "ratedPowerKw":      { "@id": "deg:ratedPowerKw",      "@type": "xsd:decimal"  },
+    "maxImportKw":        { "@id": "deg:maxImportKw",        "@type": "xsd:decimal"  },
+    "maxExportKw":        { "@id": "deg:maxExportKw",        "@type": "xsd:decimal"  },
+    "energyCapacityKwh": { "@id": "deg:energyCapacityKwh", "@type": "xsd:decimal"  },
+    "telemetryProvider": { "@id": "deg:telemetryProvider", "@type": "xsd:string"   },
+    "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
+    "location":          { "@id": "deg:location",          "@type": "@id"          },
 
     "subResources":    { "@id": "deg:subResources",    "@container": "@list" },
     "parentResources": { "@id": "deg:parentResources", "@container": "@list" }

--- a/specification/schema/EnergyResource/v2.0/context.jsonld
+++ b/specification/schema/EnergyResource/v2.0/context.jsonld
@@ -13,18 +13,54 @@
     "id":   "@id",
     "type": { "@id": "deg:resourceType", "@type": "xsd:string" },
 
+    "subResources":    { "@id": "deg:subResources",    "@container": "@list" },
+    "parentResources": { "@id": "deg:parentResources", "@container": "@list" },
+
+    "attributes": { "@id": "deg:attributes" },
+
     "make":              { "@id": "deg:make",              "@type": "xsd:string"   },
     "model":             { "@id": "deg:model",             "@type": "xsd:string"   },
     "ratedPowerKw":      { "@id": "deg:ratedPowerKw",      "@type": "xsd:decimal"  },
-    "maxImportKw":        { "@id": "deg:maxImportKw",        "@type": "xsd:decimal"  },
-    "maxExportKw":        { "@id": "deg:maxExportKw",        "@type": "xsd:decimal"  },
-    "energyCapacityKwh": { "@id": "deg:energyCapacityKwh", "@type": "xsd:decimal"  },
+    "maxImportKw":       { "@id": "deg:maxImportKw",       "@type": "xsd:decimal"  },
+    "maxExportKw":       { "@id": "deg:maxExportKw",       "@type": "xsd:decimal"  },
     "telemetryProvider": { "@id": "deg:telemetryProvider", "@type": "xsd:string"   },
     "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
     "location":          { "@id": "deg:location",          "@type": "@id"          },
 
-    "subResources":    { "@id": "deg:subResources",    "@container": "@list" },
-    "parentResources": { "@id": "deg:parentResources", "@container": "@list" }
+    "meterCapability":         { "@id": "deg:meterCapability",         "@type": "xsd:string"  },
+    "energyDirection":         { "@id": "deg:energyDirection",         "@type": "xsd:string"  },
+    "functions":               { "@id": "deg:functions",               "@container": "@list"  },
+    "feeder":                  { "@id": "deg:feeder",                  "@type": "xsd:string"  },
+    "bus":                     { "@id": "deg:bus",                     "@type": "xsd:string"  },
+    "communicationTechnology": { "@id": "deg:communicationTechnology", "@type": "xsd:string"  },
+    "applicationProtocol":     { "@id": "deg:applicationProtocol",     "@type": "xsd:string"  },
+
+    "nominalPowerKw": { "@id": "deg:nominalPowerKw", "@type": "xsd:decimal" },
+    "efficiency":     { "@id": "deg:efficiency",     "@type": "xsd:decimal" },
+
+    "storageCapacityKwh": { "@id": "deg:storageCapacityKwh", "@type": "xsd:decimal" },
+    "storageType":        { "@id": "deg:storageType",        "@type": "xsd:string"  },
+    "stateOfHealthPct":   { "@id": "deg:stateOfHealthPct",   "@type": "xsd:decimal" },
+
+    "connectorType":   { "@id": "deg:connectorType",   "@type": "xsd:string" },
+    "controlProtocol": { "@id": "deg:controlProtocol", "@type": "xsd:string" },
+    "v2xProtocol":     { "@id": "deg:v2xProtocol",     "@type": "xsd:string" },
+
+    "ratedApparentPowerKva":  { "@id": "deg:ratedApparentPowerKva",  "@type": "xsd:decimal" },
+    "maxReactivePowerKvar":   { "@id": "deg:maxReactivePowerKvar",   "@type": "xsd:decimal" },
+    "minReactivePowerKvar":   { "@id": "deg:minReactivePowerKvar",   "@type": "xsd:decimal" },
+    "rideThroughCategory":    { "@id": "deg:rideThroughCategory",    "@type": "xsd:string"  },
+    "operatingMode":          { "@id": "deg:operatingMode",          "@type": "xsd:string"  },
+    "voltVarEnabled":         { "@id": "deg:voltVarEnabled",         "@type": "xsd:boolean" },
+    "freqDroopEnabled":       { "@id": "deg:freqDroopEnabled",       "@type": "xsd:boolean" },
+    "enterServiceRampTimeSec":{ "@id": "deg:enterServiceRampTimeSec","@type": "xsd:decimal" },
+
+    "loadCategory": { "@id": "deg:loadCategory", "@type": "xsd:string" },
+
+    "nominalVoltageKv": { "@id": "deg:nominalVoltageKv", "@type": "xsd:decimal" },
+    "zone":             { "@id": "deg:zone",             "@type": "xsd:string"  },
+    "substationId":     { "@id": "deg:substationId",     "@type": "xsd:string"  },
+    "feederCode":       { "@id": "deg:feederCode",       "@type": "xsd:string"  }
   },
   "@graph": []
 }

--- a/specification/schema/EnergyResource/v2.0/vocab.jsonld
+++ b/specification/schema/EnergyResource/v2.0/vocab.jsonld
@@ -13,35 +13,28 @@
       "@id": "deg:EnergyResource",
       "@type": "rdfs:Class",
       "rdfs:label": "Energy Resource",
-      "rdfs:comment": "Canonical energy-asset class. Top-level: id, type, attributes, subResources, parentResources."
+      "rdfs:comment": "Canonical energy-asset class. Inherits EnergyResourceCommon via allOf: id, type, make, model, maxImportKw, maxExportKw, energyCapacityKwh, telemetryProvider, commissioningDate, location, subResources, parentResources."
     },
     {
-      "@id": "deg:CommonResourceAttributes",
+      "@id": "deg:EnergyResourceCommon",
       "@type": "rdfs:Class",
-      "rdfs:label": "Common Resource Attributes",
-      "rdfs:comment": "Dimensioning fields shared across all resource types. Live inside EnergyResource.attributes."
+      "rdfs:label": "Energy Resource Common",
+      "rdfs:comment": "Base schema defining all common fields for EnergyResource types. Inherited via allOf."
     },
     {
       "@id": "deg:resourceType",
       "@type": "rdf:Property",
       "rdfs:label": "Resource Type",
-      "rdfs:comment": "Open-string asset class: METER, SOLAR, SOLAR_PV, WIND, HYDRO, BATTERY, BESS, EV_CHARGER, EV_V2G, CONTROLLABLE_LOAD, …",
-      "rdfs:domain": { "@id": "deg:EnergyResource" },
+      "rdfs:comment": "Asset class: METER, DT, BUS, FEEDER, SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, BESS, EV_CHARGER, EV_V2G, INVERTER, SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD, MICROGRID. Deprecated: SOLAR (use SOLAR_PV), BATTERY (use BESS).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:attributes",
-      "@type": "rdf:Property",
-      "rdfs:label": "Attributes",
-      "rdfs:comment": "Open attribute bag. Contains CommonResourceAttributes fields plus any type-specific fields.",
-      "rdfs:domain": { "@id": "deg:EnergyResource" }
     },
     {
       "@id": "deg:make",
       "@type": "rdf:Property",
       "rdfs:label": "Make",
       "rdfs:comment": "Manufacturer (free text).",
-      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:range": "xsd:string"
     },
     {
@@ -49,23 +42,39 @@
       "@type": "rdf:Property",
       "rdfs:label": "Model",
       "rdfs:comment": "Model (free text).",
-      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:range": "xsd:string"
     },
     {
       "@id": "deg:ratedPowerKw",
       "@type": "rdf:Property",
       "rdfs:label": "Rated Power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak dispatchable power, kW.",
-      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:comment": "Manufacturer-rated peak power in kW. Kept for backward compatibility. Prefer maxExportKw for new payloads.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
+      "rdfs:range": "xsd:decimal"
+    },
+    {
+      "@id": "deg:maxImportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max Import Power (kW)",
+      "rdfs:comment": "Maximum power drawn from the grid (absorbed/charged), kW. Always ≥0. For bidirectional resources (BESS, V2G) this is the max charge rate. CIM: PowerElectronicsConnection.maxP (absorption direction).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
+      "rdfs:range": "xsd:decimal"
+    },
+    {
+      "@id": "deg:maxExportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max Export Power (kW)",
+      "rdfs:comment": "Maximum power injected to the grid (generated/discharged), kW. Always ≥0. Supersedes ratedPowerKw. CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP (injection direction).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:range": "xsd:decimal"
     },
     {
       "@id": "deg:energyCapacityKwh",
       "@type": "rdf:Property",
       "rdfs:label": "Energy Capacity (kWh)",
-      "rdfs:comment": "Rated stored-energy capacity, kWh. For storage-class resources.",
-      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:comment": "Rated stored-energy capacity, kWh. For storage resources (BESS). CIM: BatteryUnit.ratedE.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:range": "xsd:decimal"
     },
     {
@@ -73,48 +82,43 @@
       "@type": "rdf:Property",
       "rdfs:label": "Telemetry Provider",
       "rdfs:comment": "Vendor API / data source identifier for telemetry.",
-      "rdfs:domain": { "@id": "deg:CommonResourceAttributes" },
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "deg:commissioningDate",
+      "@type": "rdf:Property",
+      "rdfs:label": "Commissioning Date",
+      "rdfs:comment": "ISO 8601 date-time the asset was commissioned.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
+      "rdfs:range": "xsd:dateTime"
+    },
+    {
+      "@id": "deg:location",
+      "@type": "rdf:Property",
+      "rdfs:label": "Location",
+      "rdfs:comment": "Physical location of the asset: geo (GeoJSON geometry, coordinates [lon, lat]) + optional postal address. Applies to all resource types.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
     },
     {
       "@id": "deg:subResources",
       "@type": "rdf:Property",
       "rdfs:label": "Sub Resources",
-      "rdfs:comment": "Child resources (topology: downward). Each item is an id string or inline EnergyResource.",
-      "rdfs:domain": { "@id": "deg:EnergyResource" }
+      "rdfs:comment": "Child resources (topology: downward). Each item is an id string or inline EnergyResource. Recursive reference is valid in JSON Schema 2020-12.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
     },
     {
       "@id": "deg:parentResources",
       "@type": "rdf:Property",
       "rdfs:label": "Parent Resources",
-      "rdfs:comment": "Parent resource ids (topology: upward). String references only.",
-      "rdfs:domain": { "@id": "deg:EnergyResource" }
-    },
-    {
-      "@id": "deg:meterType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Meter Type",
-      "rdfs:comment": "Meter kind (Green Button / ESPI): AMR, AMI, Electromechanical, Forward, Reverse, Bidirectional, Prepaid, NetMeter, Other.",
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:gps",
-      "@type": "rdf:Property",
-      "rdfs:label": "GPS",
-      "rdfs:comment": "GPS coordinates of the asset as 'lat,lng'.",
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:meterLocation",
-      "@type": "rdf:Property",
-      "rdfs:label": "Meter Location",
-      "rdfs:comment": "Postal location of the meter (beckn Location shape)."
+      "rdfs:comment": "Parent resource ids (topology: upward). String references only to avoid cycles.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
     },
     {
       "@id": "deg:feeder",
       "@type": "rdf:Property",
       "rdfs:label": "Feeder",
-      "rdfs:comment": "Distribution feeder ID or name serving this meter.",
+      "rdfs:comment": "Distribution feeder ID or name serving this resource.",
       "rdfs:range": "xsd:string"
     },
     {

--- a/specification/schema/EnergyResource/v2.0/vocab.jsonld
+++ b/specification/schema/EnergyResource/v2.0/vocab.jsonld
@@ -9,124 +9,66 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
   "@graph": [
-    {
-      "@id": "deg:EnergyResource",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Energy Resource",
-      "rdfs:comment": "Canonical energy-asset class. Inherits EnergyResourceCommon via allOf: id, type, make, model, maxImportKw, maxExportKw, energyCapacityKwh, telemetryProvider, commissioningDate, location, subResources, parentResources."
-    },
-    {
-      "@id": "deg:EnergyResourceCommon",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Energy Resource Common",
-      "rdfs:comment": "Base schema defining all common fields for EnergyResource types. Inherited via allOf."
-    },
-    {
-      "@id": "deg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource Type",
-      "rdfs:comment": "Asset class: METER, DT, BUS, FEEDER, SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, BESS, EV_CHARGER, EV_V2G, INVERTER, SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD, MICROGRID. Deprecated: SOLAR (use SOLAR_PV), BATTERY (use BESS).",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Make",
-      "rdfs:comment": "Manufacturer (free text).",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model (free text).",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated Power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kW. Kept for backward compatibility. Prefer maxExportKw for new payloads.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:decimal"
-    },
-    {
-      "@id": "deg:maxImportKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max Import Power (kW)",
-      "rdfs:comment": "Maximum power drawn from the grid (absorbed/charged), kW. Always ≥0. For bidirectional resources (BESS, V2G) this is the max charge rate. CIM: PowerElectronicsConnection.maxP (absorption direction).",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:decimal"
-    },
-    {
-      "@id": "deg:maxExportKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max Export Power (kW)",
-      "rdfs:comment": "Maximum power injected to the grid (generated/discharged), kW. Always ≥0. Supersedes ratedPowerKw. CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP (injection direction).",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:decimal"
-    },
-    {
-      "@id": "deg:energyCapacityKwh",
-      "@type": "rdf:Property",
-      "rdfs:label": "Energy Capacity (kWh)",
-      "rdfs:comment": "Rated stored-energy capacity, kWh. For storage resources (BESS). CIM: BatteryUnit.ratedE.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:decimal"
-    },
-    {
-      "@id": "deg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry Provider",
-      "rdfs:comment": "Vendor API / data source identifier for telemetry.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning Date",
-      "rdfs:comment": "ISO 8601 date-time the asset was commissioned.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
-      "rdfs:range": "xsd:dateTime"
-    },
-    {
-      "@id": "deg:location",
-      "@type": "rdf:Property",
-      "rdfs:label": "Location",
-      "rdfs:comment": "Physical location of the asset: geo (GeoJSON geometry, coordinates [lon, lat]) + optional postal address. Applies to all resource types.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
-    },
-    {
-      "@id": "deg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub Resources",
-      "rdfs:comment": "Child resources (topology: downward). Each item is an id string or inline EnergyResource. Recursive reference is valid in JSON Schema 2020-12.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
-    },
-    {
-      "@id": "deg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent Resources",
-      "rdfs:comment": "Parent resource ids (topology: upward). String references only to avoid cycles.",
-      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
-    },
-    {
-      "@id": "deg:feeder",
-      "@type": "rdf:Property",
-      "rdfs:label": "Feeder",
-      "rdfs:comment": "Distribution feeder ID or name serving this resource.",
-      "rdfs:range": "xsd:string"
-    },
-    {
-      "@id": "deg:bus",
-      "@type": "rdf:Property",
-      "rdfs:label": "Bus",
-      "rdfs:comment": "Substation bus reference (HV/LV bus node).",
-      "rdfs:range": "xsd:string"
-    }
+
+    { "@id": "deg:EnergyResource",        "@type": "rdfs:Class", "rdfs:label": "Energy Resource",        "rdfs:comment": "Discriminated union of all typed EnergyResource kinds. Dispatched by the type field." },
+    { "@id": "deg:EnergyResourceCommon",  "@type": "rdfs:Class", "rdfs:label": "Energy Resource Common", "rdfs:comment": "Envelope schema inherited by every typed kind via allOf. Defines id, type, subResources, parentResources, and the attributes bag." },
+
+    { "@id": "deg:EnergyResourceMeter",     "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — Meter",      "rdfs:comment": "Metering device (type: METER). CIM: Meter extends EndDevice (IEC 61968-9)." },
+    { "@id": "deg:EnergyResourceGenerator", "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — Generator",  "rdfs:comment": "Electrical generation asset (SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL). CIM: GeneratingUnit subtypes (IEC 61970-302)." },
+    { "@id": "deg:EnergyResourceBESS",      "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — BESS",        "rdfs:comment": "Stationary battery energy storage system (type: BESS). CIM: BatteryUnit (IEC 61970-302). BATTERY deprecated." },
+    { "@id": "deg:EnergyResourceEVCharger", "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — EV Charger",  "rdfs:comment": "EV charging station (EV_CHARGER, EV_V2G). Flexible load — not storage. EV_V2G has ISO 15118-20 / OCPP 2.1 BPT bidirectional capability." },
+    { "@id": "deg:EnergyResourceInverter",  "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — Inverter",    "rdfs:comment": "Grid-connected power-electronics converter (type: INVERTER). IEEE 1547-2018 / SunSpec DER Models 702-714. CIM: PowerElectronicsConnection." },
+    { "@id": "deg:EnergyResourceLoad",      "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — Load",        "rdfs:comment": "Controllable electrical load (SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD). CIM: EnergyConsumer / ConformLoad (IEC 61970-301)." },
+    { "@id": "deg:EnergyResourceNetwork",   "@type": "rdfs:Class", "rdfs:subClassOf": {"@id": "deg:EnergyResourceCommon"}, "rdfs:label": "Energy Resource — Network",     "rdfs:comment": "Distribution network topology element (DT, BUS, FEEDER, MICROGRID). CIM: PowerTransformer, BusbarSection, Feeder (IEC 61970-301)." },
+
+    { "@id": "deg:resourceType",   "@type": "rdf:Property", "rdfs:label": "Resource Type",   "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:string",
+      "rdfs:comment": "Asset class discriminator: METER, SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL, BESS, EV_CHARGER, EV_V2G, INVERTER, SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD, DT, BUS, FEEDER, MICROGRID. Deprecated: SOLAR, BATTERY." },
+    { "@id": "deg:subResources",   "@type": "rdf:Property", "rdfs:label": "Sub Resources",   "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:comment": "Child resources (topology: downward). Each item is an id string or inline EnergyResource. Recursive $ref valid in JSON Schema 2020-12." },
+    { "@id": "deg:parentResources","@type": "rdf:Property", "rdfs:label": "Parent Resources","rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:comment": "Parent resource ids (topology: upward). String references only to avoid cycles." },
+    { "@id": "deg:attributes",     "@type": "rdf:Property", "rdfs:label": "Attributes",      "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:comment": "Attribute bag containing EnergyResourceCommonAttributes (make, model, maxExportKw, maxImportKw, etc.) plus kind-specific fields." },
+
+    { "@id": "deg:make",              "@type": "rdf:Property", "rdfs:label": "Make",               "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:string",   "rdfs:comment": "Manufacturer (free text)." },
+    { "@id": "deg:model",             "@type": "rdf:Property", "rdfs:label": "Model",              "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:string",   "rdfs:comment": "Model (free text)." },
+    { "@id": "deg:ratedPowerKw",      "@type": "rdf:Property", "rdfs:label": "Rated Power (kW)",   "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:decimal",  "rdfs:comment": "Manufacturer-rated peak power in kW. Kept for backward compatibility. Prefer maxExportKw for new payloads." },
+    { "@id": "deg:maxImportKw",       "@type": "rdf:Property", "rdfs:label": "Max Import Power (kW)", "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Maximum power drawn from the grid (absorbed/charged), kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption direction)." },
+    { "@id": "deg:maxExportKw",       "@type": "rdf:Property", "rdfs:label": "Max Export Power (kW)", "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Maximum power injected to the grid (generated/discharged), kW. Always ≥0. Supersedes ratedPowerKw. CIM: GeneratingUnit.maxOperatingP." },
+    { "@id": "deg:telemetryProvider", "@type": "rdf:Property", "rdfs:label": "Telemetry Provider","rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:string",   "rdfs:comment": "Vendor API / data source identifier for telemetry." },
+    { "@id": "deg:commissioningDate", "@type": "rdf:Property", "rdfs:label": "Commissioning Date","rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:range": "xsd:dateTime", "rdfs:comment": "ISO 8601 date-time the asset was commissioned." },
+    { "@id": "deg:location",          "@type": "rdf:Property", "rdfs:label": "Location",          "rdfs:domain": {"@id": "deg:EnergyResourceCommon"}, "rdfs:comment": "Physical location: geo (GeoJSON Point, coordinates [lon, lat]) + optional postal address." },
+
+    { "@id": "deg:meterCapability",         "@type": "rdf:Property", "rdfs:label": "Meter Capability",          "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:range": "xsd:string", "rdfs:comment": "Communication/automation generation: Electromechanical, CMRI, AMR, AMI. CIM: AmiBillingReadyKind (IEC 61968-9)." },
+    { "@id": "deg:energyDirection",         "@type": "rdf:Property", "rdfs:label": "Energy Direction",          "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:range": "xsd:string", "rdfs:comment": "Energy flow direction: Forward, Reverse, Bidirectional, Net. CIM: FlowDirectionKind (ESPI NAESB REQ.21)." },
+    { "@id": "deg:functions",               "@type": "rdf:Property", "rdfs:label": "Functions",                 "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:comment": "Active meter capabilities (IEC 61968-9 EndDeviceFunction[0..*])." },
+    { "@id": "deg:feeder",                  "@type": "rdf:Property", "rdfs:label": "Feeder",                    "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:range": "xsd:string", "rdfs:comment": "Feeder identifier this meter is supplied from." },
+    { "@id": "deg:bus",                     "@type": "rdf:Property", "rdfs:label": "Bus",                       "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:range": "xsd:string", "rdfs:comment": "Busbar identifier." },
+    { "@id": "deg:communicationTechnology", "@type": "rdf:Property", "rdfs:label": "Communication Technology",  "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:range": "xsd:string", "rdfs:comment": "Last-mile physical layer: PLC, RF_Mesh, GPRS, NB-IoT, LoRa, ZigBee, Other." },
+    { "@id": "deg:applicationProtocol",     "@type": "rdf:Property", "rdfs:label": "Application Protocol",      "rdfs:domain": {"@id": "deg:EnergyResourceMeter"}, "rdfs:range": "xsd:string", "rdfs:comment": "Meter data application protocol: DLMS_COSEM, ANSI_C12_18, IEC_61850, Modbus, Other." },
+
+    { "@id": "deg:nominalPowerKw", "@type": "rdf:Property", "rdfs:label": "Nominal Power (kW)", "rdfs:domain": {"@id": "deg:EnergyResourceGenerator"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Nominal rated output power in kW. CIM: GeneratingUnit.nominalP." },
+    { "@id": "deg:efficiency",     "@type": "rdf:Property", "rdfs:label": "Efficiency (%)",    "rdfs:domain": {"@id": "deg:EnergyResourceGenerator"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Conversion efficiency, %. Relevant for FUEL_CELL and CHP." },
+
+    { "@id": "deg:storageCapacityKwh", "@type": "rdf:Property", "rdfs:label": "Storage Capacity (kWh)", "rdfs:domain": {"@id": "deg:EnergyResourceBESS"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Rated energy capacity in kWh. Exclusive to BESS. CIM: BatteryUnit.ratedE." },
+    { "@id": "deg:storageType",        "@type": "rdf:Property", "rdfs:label": "Storage Type",           "rdfs:domain": {"@id": "deg:EnergyResourceBESS"}, "rdfs:range": "xsd:string",  "rdfs:comment": "Storage chemistry or technology: LithiumIon, LeadAcid, FlowBattery, NaS, NiCd, Flywheel, Other." },
+    { "@id": "deg:stateOfHealthPct",   "@type": "rdf:Property", "rdfs:label": "State of Health (%)",   "rdfs:domain": {"@id": "deg:EnergyResourceBESS"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Battery state of health as % of original capacity." },
+
+    { "@id": "deg:connectorType",   "@type": "rdf:Property", "rdfs:label": "Connector Type",    "rdfs:domain": {"@id": "deg:EnergyResourceEVCharger"}, "rdfs:range": "xsd:string", "rdfs:comment": "Physical connector standard: Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other." },
+    { "@id": "deg:controlProtocol", "@type": "rdf:Property", "rdfs:label": "Control Protocol",  "rdfs:domain": {"@id": "deg:EnergyResourceEVCharger"}, "rdfs:range": "xsd:string", "rdfs:comment": "EVSE control protocol: OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other." },
+    { "@id": "deg:v2xProtocol",     "@type": "rdf:Property", "rdfs:label": "V2X Protocol",      "rdfs:domain": {"@id": "deg:EnergyResourceEVCharger"}, "rdfs:range": "xsd:string", "rdfs:comment": "V2G protocol for EV_V2G resources: CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other." },
+
+    { "@id": "deg:ratedApparentPowerKva",   "@type": "rdf:Property", "rdfs:label": "Rated Apparent Power (kVA)", "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:decimal",  "rdfs:comment": "Rated apparent power in kVA. SunSpec Model 702 maxVA." },
+    { "@id": "deg:maxReactivePowerKvar",    "@type": "rdf:Property", "rdfs:label": "Max Reactive Power (kVAr)", "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:decimal",  "rdfs:comment": "Max reactive power injection (leading/over-excited), kVAr. SunSpec Model 702 maxVar." },
+    { "@id": "deg:minReactivePowerKvar",    "@type": "rdf:Property", "rdfs:label": "Min Reactive Power (kVAr)", "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:decimal",  "rdfs:comment": "Max reactive power absorption (lagging/under-excited), kVAr. Usually negative. SunSpec Model 702 maxVarNeg." },
+    { "@id": "deg:rideThroughCategory",     "@type": "rdf:Property", "rdfs:label": "Ride-Through Category",    "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:string",   "rdfs:comment": "IEEE 1547-2018 abnormal operating performance category: CategoryI, CategoryII, CategoryIII." },
+    { "@id": "deg:operatingMode",           "@type": "rdf:Property", "rdfs:label": "Operating Mode",           "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:string",   "rdfs:comment": "Grid-interaction mode: GridFollowing, GridForming, Standby. CIM: PowerElectronicsConnection.inverterMode." },
+    { "@id": "deg:voltVarEnabled",          "@type": "rdf:Property", "rdfs:label": "Volt-VAr Enabled",         "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:boolean",  "rdfs:comment": "Volt-VAr curve active. IEEE 2030.5 opModVoltVar / SunSpec Model 705." },
+    { "@id": "deg:freqDroopEnabled",        "@type": "rdf:Property", "rdfs:label": "Freq-Droop Enabled",       "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:boolean",  "rdfs:comment": "Frequency-Watt droop active. SunSpec Model 711 / IEEE 1547 Freq-Watt." },
+    { "@id": "deg:enterServiceRampTimeSec", "@type": "rdf:Property", "rdfs:label": "Enter Service Ramp (s)",   "rdfs:domain": {"@id": "deg:EnergyResourceInverter"}, "rdfs:range": "xsd:decimal",  "rdfs:comment": "Ramp-up time in seconds after reconnection. SunSpec Model 703 ESRmpTms." },
+
+    { "@id": "deg:loadCategory", "@type": "rdf:Property", "rdfs:label": "Load Category", "rdfs:domain": {"@id": "deg:EnergyResourceLoad"}, "rdfs:range": "xsd:string", "rdfs:comment": "Load category for aggregation: Heating, Cooling, WaterHeating, Lighting, EV, Industrial, Other." },
+
+    { "@id": "deg:nominalVoltageKv", "@type": "rdf:Property", "rdfs:label": "Nominal Voltage (kV)", "rdfs:domain": {"@id": "deg:EnergyResourceNetwork"}, "rdfs:range": "xsd:decimal", "rdfs:comment": "Nominal voltage level in kV. CIM: BaseVoltage.nominalVoltage." },
+    { "@id": "deg:zone",             "@type": "rdf:Property", "rdfs:label": "Zone",                 "rdfs:domain": {"@id": "deg:EnergyResourceNetwork"}, "rdfs:range": "xsd:string",  "rdfs:comment": "Operating zone or region identifier." },
+    { "@id": "deg:substationId",     "@type": "rdf:Property", "rdfs:label": "Substation ID",        "rdfs:domain": {"@id": "deg:EnergyResourceNetwork"}, "rdfs:range": "xsd:string",  "rdfs:comment": "Parent substation identifier." },
+    { "@id": "deg:feederCode",       "@type": "rdf:Property", "rdfs:label": "Feeder Code",          "rdfs:domain": {"@id": "deg:EnergyResourceNetwork"}, "rdfs:range": "xsd:string",  "rdfs:comment": "Feeder code per utility network records." }
   ]
 }

--- a/specification/schema/EnergyResourceCommon/README.md
+++ b/specification/schema/EnergyResourceCommon/README.md
@@ -1,0 +1,26 @@
+# EnergyResourceCommon
+
+Canonical base schemas shared by all typed `EnergyResource` kinds.
+
+**Canonical IRI:** `https://schema.beckn.io/EnergyResourceCommon/v1.0`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial release. Contains `EnergyResourceCommon` (structural envelope) and `EnergyResourceCommonAttributes` (attributes bag base). |
+
+---
+
+## Purpose
+
+`EnergyResourceCommon` eliminates field duplication across the seven typed `EnergyResource` kind schemas by providing a single canonical home for:
+
+- **`EnergyResourceCommon`** — the structural envelope (`id`, `type`, `subResources`, `parentResources`, `attributes`)
+- **`EnergyResourceCommonAttributes`** — the attributes bag base (`make`, `model`, `ratedPowerKw`, `maxExportKw`, `maxImportKw`, `telemetryProvider`, `commissioningDate`, `location`)
+
+All kind schemas inherit these via `allOf` external `$ref` and only define their own kind-specific fields.
+
+See [v1.0/README.md](./v1.0/README.md) for the full field tables and inheritance pattern.

--- a/specification/schema/EnergyResourceCommon/v1.0/README.md
+++ b/specification/schema/EnergyResourceCommon/v1.0/README.md
@@ -1,0 +1,81 @@
+# EnergyResourceCommon v1.0
+
+Canonical base schemas shared by all typed `EnergyResource` kinds.
+
+**Canonical IRI:** `https://schema.beckn.io/EnergyResourceCommon/v1.0`
+
+---
+
+## Schemas
+
+### `EnergyResourceCommon`
+
+The structural envelope inherited by every kind via `allOf`. Defines:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Stable asset identifier (IES DID convention) |
+| `type` | string | Asset class discriminator — constrained to a kind-specific `enum` or `const` |
+| `subResources` | array | Downward topology — child resource ids or inline EnergyResource objects |
+| `parentResources` | array | Upward topology — ids of parent resources (string refs only) |
+| `attributes` | object | Attribute bag — inherits `EnergyResourceCommonAttributes` via `allOf` |
+
+### `EnergyResourceCommonAttributes`
+
+The attribute bag base inherited inside every kind's `<Kind>Attributes` object via `allOf`. No field is required at this level.
+
+| Field | Type | Description |
+|---|---|---|
+| `make` | string | Manufacturer (free text) |
+| `model` | string | Model (free text) |
+| `ratedPowerKw` | number ≥0 | Nameplate power in kW. Deprecated; prefer `maxExportKw` |
+| `maxExportKw` | number ≥0 | Max power injected to grid (discharge / generation), kW |
+| `maxImportKw` | number ≥0 | Max power drawn from grid (charge / load), kW |
+| `telemetryProvider` | string | Vendor API / data-source identifier |
+| `commissioningDate` | date-time | ISO 8601 asset commissioning date-time |
+| `location` | object | beckn Location/2.0 shape — `geo` (GeoJSON, required) + `address` (postal, optional) |
+
+---
+
+## Inheritance pattern
+
+**Kind envelope:**
+
+```yaml
+EnergyResourceMeter:
+  allOf:
+    - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+    - type: object
+      properties:
+        type:
+          const: "METER"
+        attributes:
+          $ref: "#/components/schemas/EnergyResourceMeterAttributes"
+```
+
+**Kind attributes bag:**
+
+```yaml
+EnergyResourceMeterAttributes:
+  allOf:
+    - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+    - type: object
+      additionalProperties: true
+      properties:
+        # Kind-specific fields only — common fields inherited above
+        meterCapability: ...
+```
+
+---
+
+## Kinds that inherit this schema
+
+| Kind | Canonical IRI | Types |
+|---|---|---|
+| EnergyResourceMeter | `schema.beckn.io/EnergyResourceMeter/v1.0` | `METER` |
+| EnergyResourceGenerator | `schema.beckn.io/EnergyResourceGenerator/v1.0` | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` |
+| EnergyResourceStorage | `schema.beckn.io/EnergyResourceStorage/v1.0` | `BESS` |
+| EnergyResourceEVCharger | `schema.beckn.io/EnergyResourceEVCharger/v1.0` | `EV_CHARGER`, `EV_V2G` |
+| EnergyResourceInverter | `schema.beckn.io/EnergyResourceInverter/v1.0` | `INVERTER` |
+| EnergyResourceLoad | `schema.beckn.io/EnergyResourceLoad/v1.0` | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` |
+| EnergyResourceNetwork | `schema.beckn.io/EnergyResourceNetwork/v1.0` | `DT`, `BUS`, `FEEDER`, `MICROGRID` |

--- a/specification/schema/EnergyResourceCommon/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceCommon/v1.0/attributes.yaml
@@ -1,0 +1,207 @@
+openapi: 3.1.1
+info:
+  title: EnergyResourceCommon
+  version: 1.0.0
+  description: |
+    Canonical base schemas shared by all typed EnergyResource kinds.
+
+    EnergyResourceCommonAttributes — the attributes bag base:
+      make, model, ratedPowerKw, maxExportKw, maxImportKw,
+      telemetryProvider, commissioningDate, location.
+      No field is required at this level; kind schemas may add required fields.
+
+    EnergyResourceCommon — the structural envelope inherited by every kind:
+      id, type, subResources, parentResources, attributes (allOf EnergyResourceCommonAttributes).
+
+    All seven EnergyResource kind schemas inherit these via allOf:
+      EnergyResourceMeter, EnergyResourceGenerator, EnergyResourceStorage,
+      EnergyResourceEVCharger, EnergyResourceInverter, EnergyResourceLoad,
+      EnergyResourceNetwork.
+
+    Canonical IRI: https://schema.beckn.io/EnergyResourceCommon/v1.0
+
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+servers:
+  - url: https://schema.beckn.io
+    description: Canonical schema registry
+paths: {}
+components:
+  schemas:
+
+    # ── Attribute bag base — inherited by every kind's attributes object ──
+
+    EnergyResourceCommonAttributes:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes
+      type: object
+      additionalProperties: true
+      description: >
+        Dimensioning and provenance fields shared by all resource kinds.
+        Inherited inside each kind's attributes bag via allOf. No field is
+        required at this level.
+      x-tags:
+        - energy-resource
+      properties:
+
+        make:
+          type: string
+          description: Manufacturer (free text).
+          x-jsonld:
+            "@id": deg:make
+
+        model:
+          type: string
+          description: Model (free text).
+          x-jsonld:
+            "@id": deg:model
+
+        ratedPowerKw:
+          type: number
+          minimum: 0
+          description: >
+            Manufacturer-rated peak power in kW (nameplate value in the
+            principal direction). Kept for backward compatibility.
+            Prefer maxExportKw for new payloads.
+          x-jsonld:
+            "@id": deg:ratedPowerKw
+
+        maxExportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum power this resource injects to the grid (generates /
+            discharges), kW. Always ≥0. Set for generators (SOLAR_PV, WIND,
+            CHP) and discharging storage. For bidirectional resources (BESS,
+            V2G) this is the max discharge rate. Supersedes ratedPowerKw.
+            CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP
+            (injection direction).
+          x-jsonld:
+            "@id": deg:maxExportKw
+
+        maxImportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum power this resource draws from the grid (absorbs /
+            charges), kW. Always ≥0. Set for loads, charging storage, and
+            EV chargers. For bidirectional resources (BESS, V2G) this is
+            the max charge rate. Omit or 0 for pure generators.
+            CIM: PowerElectronicsConnection.maxP (absorption direction).
+          x-jsonld:
+            "@id": deg:maxImportKw
+
+        telemetryProvider:
+          type: string
+          description: Vendor API / data source identifier for telemetry.
+          x-jsonld:
+            "@id": deg:telemetryProvider
+
+        commissioningDate:
+          type: string
+          format: date-time
+          description: ISO 8601 date-time the asset was commissioned.
+          x-jsonld:
+            "@id": deg:commissioningDate
+
+        location:
+          type: object
+          description: >
+            Physical location of the asset (beckn Location shape). geo
+            (required) is a GeoJSON geometry with coordinates [longitude,
+            latitude] per RFC 7946. address (optional) is a schema.org
+            PostalAddress-aligned object.
+          additionalProperties: true
+          required:
+            - geo
+          properties:
+            geo:
+              type: object
+              required: [type]
+              additionalProperties: true
+              properties:
+                type:
+                  type: string
+                  enum: [Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString, GeometryCollection]
+                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
+                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
+            address:
+              type: object
+              additionalProperties: false
+              properties:
+                streetAddress:   { type: string }
+                extendedAddress: { type: string }
+                addressLocality: { type: string }
+                addressRegion:   { type: string }
+                postalCode:      { type: string }
+                addressCountry:  { type: string, description: "ISO 3166-1 alpha-2 or country name." }
+          x-jsonld:
+            "@id": deg:location
+
+    # ── Structural envelope — inherited by every kind schema ─────────────
+
+    EnergyResourceCommon:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon
+      type: object
+      additionalProperties: true
+      description: >
+        Structural envelope inherited by every typed EnergyResource kind via
+        allOf. Defines top-level fields common to all kinds: id, type,
+        topology (subResources, parentResources), and the attributes bag.
+      x-tags:
+        - energy-resource
+      properties:
+
+        id:
+          type: string
+          description: >
+            Stable identifier for this resource. For METER resources the
+            meter serial number is conventional.
+          example: "did:web:bescom.karnataka.gov.in:assets:meter:MET-001"
+          x-jsonld:
+            "@id": "@id"
+
+        type:
+          type: string
+          description: >
+            Asset class discriminator. Constrained to a kind-specific enum or
+            const in each typed kind schema.
+          x-jsonld:
+            "@id": deg:resourceType
+
+        subResources:
+          type: array
+          description: >
+            Topology — child resources. Each item is EITHER a bare id string
+            (reference to a sibling EnergyResource) OR an inline EnergyResource
+            object.
+          items:
+            oneOf:
+              - type: string
+                description: id of a sibling EnergyResource.
+              - $ref: "https://schema.beckn.io/EnergyResource/v2.0#/components/schemas/EnergyResource"
+                description: Inline-nested EnergyResource.
+          x-jsonld:
+            "@id": deg:subResources
+
+        parentResources:
+          type: array
+          description: >
+            Upward topology — ids of parent resources (e.g. the meter this
+            DER sits behind). String references only; inlining parents would
+            create a definitional cycle.
+          items:
+            type: string
+          x-jsonld:
+            "@id": deg:parentResources
+
+        attributes:
+          type: object
+          additionalProperties: true
+          description: >
+            Attribute bag. Inherits EnergyResourceCommonAttributes (make,
+            model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider,
+            commissioningDate, location) via allOf plus kind-specific fields
+            defined by each typed subschema.
+          allOf:
+            - $ref: "#/components/schemas/EnergyResourceCommonAttributes"
+          x-jsonld:
+            "@id": deg:attributes

--- a/specification/schema/EnergyResourceCommon/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceCommon/v1.0/context.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "deg":   "https://schema.beckn.io/deg#",
+    "erDeg": "https://schema.beckn.io/erDeg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
+    "rdfs":  "http://www.w3.org/2000/01/rdf-schema#",
+
+    "EnergyResourceCommon": {
+      "@id": "deg:EnergyResourceCommon"
+    },
+    "EnergyResourceCommonAttributes": {
+      "@id": "deg:EnergyResourceCommonAttributes"
+    },
+
+    "id":              { "@id": "@id" },
+    "type":            { "@id": "deg:resourceType" },
+    "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+    "parentResources": { "@id": "deg:parentResources", "@container": "@set" },
+    "attributes":      { "@id": "deg:attributes" },
+
+    "make":              { "@id": "deg:make" },
+    "model":             { "@id": "deg:model" },
+    "ratedPowerKw":      { "@id": "deg:ratedPowerKw",      "@type": "xsd:decimal" },
+    "maxExportKw":       { "@id": "deg:maxExportKw",       "@type": "xsd:decimal" },
+    "maxImportKw":       { "@id": "deg:maxImportKw",       "@type": "xsd:decimal" },
+    "telemetryProvider": { "@id": "deg:telemetryProvider" },
+    "commissioningDate": { "@id": "deg:commissioningDate",  "@type": "xsd:dateTime" },
+    "location":          { "@id": "deg:location" },
+    "geo":               { "@id": "deg:geo" },
+    "address":           { "@id": "deg:address" }
+  }
+}

--- a/specification/schema/EnergyResourceCommon/v1.0/schema.json
+++ b/specification/schema/EnergyResourceCommon/v1.0/schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.beckn.io/EnergyResourceCommon/v1.0",
+  "title": "EnergyResourceCommon",
+  "description": "Canonical base schemas shared by all typed EnergyResource kinds. Contains EnergyResourceCommon (structural envelope: id, type, subResources, parentResources, attributes) and EnergyResourceCommonAttributes (attributes bag base: make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate, location).",
+  "$defs": {
+    "GeoJSONGeometry": {
+      "type": "object",
+      "description": "GeoJSON geometry per RFC 7946. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326).",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
+        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
+        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
+        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
+      },
+      "additionalProperties": true
+    },
+    "Address": {
+      "type": "object",
+      "description": "schema.org PostalAddress per beckn Address/2.0.",
+      "additionalProperties": false,
+      "properties": {
+        "streetAddress": { "type": "string" },
+        "extendedAddress": { "type": "string" },
+        "addressLocality": { "type": "string" },
+        "addressRegion": { "type": "string" },
+        "postalCode": { "type": "string" },
+        "addressCountry": { "type": "string", "description": "ISO 3166-1 alpha-2 or country name." }
+      }
+    },
+    "Location": {
+      "type": "object",
+      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
+      "required": ["geo"],
+      "additionalProperties": true,
+      "properties": {
+        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
+        "address": { "$ref": "#/$defs/Address" }
+      }
+    },
+    "EnergyResourceCommonAttributes": {
+      "$anchor": "EnergyResourceCommonAttributes",
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Dimensioning and provenance fields shared by all resource kinds. Inherited inside each kind's attributes bag via allOf. No field is required at this level.",
+      "properties": {
+        "make": { "type": "string", "description": "Manufacturer (free text)." },
+        "model": { "type": "string", "description": "Model (free text)." },
+        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power in kW. Kept for backward compatibility. Prefer maxExportKw." },
+        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum power injected to the grid (generates / discharges), kW. Always ≥0. CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP (injection)." },
+        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum power drawn from the grid (absorbs / charges), kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption)." },
+        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
+        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time the asset was commissioned." },
+        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." }
+      }
+    },
+    "EnergyResourceCommon": {
+      "$anchor": "EnergyResourceCommon",
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Structural envelope inherited by every typed EnergyResource kind via allOf. Defines id, type, topology (subResources, parentResources), and the attributes bag.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this resource. For METER resources the meter serial number is conventional.",
+          "example": "did:web:bescom.karnataka.gov.in:assets:meter:MET-001"
+        },
+        "type": {
+          "type": "string",
+          "description": "Asset class discriminator. Constrained to a kind-specific enum or const in each typed kind schema."
+        },
+        "subResources": {
+          "type": "array",
+          "description": "Topology — child resources. Each item is a bare id string or an inline EnergyResource object.",
+          "items": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              { "$ref": "https://schema.beckn.io/EnergyResource/v2.0#/components/schemas/EnergyResource" }
+            ]
+          }
+        },
+        "parentResources": {
+          "type": "array",
+          "description": "Upward topology — ids of parent resources. String references only.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attribute bag. Inherits EnergyResourceCommonAttributes via allOf plus kind-specific fields.",
+          "allOf": [
+            { "$ref": "#/$defs/EnergyResourceCommonAttributes" }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/schema/EnergyResourceCommon/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceCommon/v1.0/vocab.jsonld
@@ -1,0 +1,116 @@
+{
+  "@context": {
+    "deg":   "https://schema.beckn.io/deg#",
+    "rdfs":  "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
+    "owl":   "http://www.w3.org/2002/07/owl#"
+  },
+  "@graph": [
+    {
+      "@id": "deg:EnergyResourceCommon",
+      "@type": "rdfs:Class",
+      "rdfs:label": "EnergyResourceCommon",
+      "rdfs:comment": "Structural envelope shared by all typed EnergyResource kinds. Defines id, type, topology, and the attributes bag."
+    },
+    {
+      "@id": "deg:EnergyResourceCommonAttributes",
+      "@type": "rdfs:Class",
+      "rdfs:label": "EnergyResourceCommonAttributes",
+      "rdfs:comment": "Attribute bag base inherited by all EnergyResource kind attributes objects. Contains make, model, ratedPowerKw, maxExportKw, maxImportKw, telemetryProvider, commissioningDate, location."
+    },
+    {
+      "@id": "deg:resourceType",
+      "@type": "rdf:Property",
+      "rdfs:label": "resourceType",
+      "rdfs:comment": "Asset class discriminator string (METER, SOLAR_PV, BESS, EV_CHARGER, etc.).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
+      "rdfs:range": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:subResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "subResources",
+      "rdfs:comment": "Child resource ids or inline EnergyResource objects (downward topology).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" }
+    },
+    {
+      "@id": "deg:parentResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "parentResources",
+      "rdfs:comment": "Ids of parent resources (upward topology). String references only.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
+      "rdfs:range": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:attributes",
+      "@type": "rdf:Property",
+      "rdfs:label": "attributes",
+      "rdfs:comment": "Attribute bag object on a resource. Contains common attributes plus kind-specific fields.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommon" },
+      "rdfs:range": { "@id": "deg:EnergyResourceCommonAttributes" }
+    },
+    {
+      "@id": "deg:make",
+      "@type": "rdf:Property",
+      "rdfs:label": "make",
+      "rdfs:comment": "Manufacturer name (free text).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:model",
+      "@type": "rdf:Property",
+      "rdfs:label": "model",
+      "rdfs:comment": "Model number (free text).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:ratedPowerKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "ratedPowerKw",
+      "rdfs:comment": "Manufacturer-rated peak power in kW. Kept for backward compatibility; prefer maxExportKw.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "deg:maxExportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "maxExportKw",
+      "rdfs:comment": "Maximum power injected to the grid (discharge / generation), kW. Always ≥0.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "deg:maxImportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "maxImportKw",
+      "rdfs:comment": "Maximum power drawn from the grid (charge / load), kW. Always ≥0.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "deg:telemetryProvider",
+      "@type": "rdf:Property",
+      "rdfs:label": "telemetryProvider",
+      "rdfs:comment": "Vendor API / data source identifier for telemetry.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:commissioningDate",
+      "@type": "rdf:Property",
+      "rdfs:label": "commissioningDate",
+      "rdfs:comment": "ISO 8601 date-time the asset was commissioned.",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" },
+      "rdfs:range": { "@id": "xsd:dateTime" }
+    },
+    {
+      "@id": "deg:location",
+      "@type": "rdf:Property",
+      "rdfs:label": "location",
+      "rdfs:comment": "Physical location of the asset (beckn Location shape with GeoJSON geo and postal address).",
+      "rdfs:domain": { "@id": "deg:EnergyResourceCommonAttributes" }
+    }
+  ]
+}

--- a/specification/schema/EnergyResourceEVCharger/README.md
+++ b/specification/schema/EnergyResourceEVCharger/README.md
@@ -1,0 +1,36 @@
+# EnergyResourceEVCharger
+
+Typed energy resource schema for EV charging stations. An `EV_CHARGER` resource is the EVSE hardware at the grid connection point — a **flexible load**, not a storage resource. `EV_V2G` is a specialisation with ISO 15118-20 / OCPP 2.1 BPT Vehicle-to-Grid capability.
+
+**Canonical IRI:** `https://schema.beckn.io/EnergyResourceEVCharger/v1.0`
+
+**CIM alignment:** `ElectricVehicleChargingStation` (CIM17+)
+
+**Tags:** `energy-resource` · `ev-charger` · `energy` · `deg`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial typed kind for EV_CHARGER and EV_V2G resources. Introduces `connectorType`, `controlProtocol`, `v2xProtocol`. EV charging separated from storage (was previously grouped with BESS). |
+
+---
+
+## Type discriminator
+
+| `type` value | Description |
+|---|---|
+| `EV_CHARGER` | Unidirectional or AC bidirectional EVSE (flexible load) |
+| `EV_V2G` | Vehicle-to-Grid capable EVSE — `EV_CHARGER` specialisation |
+
+---
+
+## Usage
+
+- **ElectricityCredential/v1.2**: entries with `type: "EV_CHARGER"` or `type: "EV_V2G"` in `customerProfile.energyResources[]` conform to this schema.
+- For V2G: set `attributes.maxImportKw` (charge rate) and `attributes.maxExportKw` (V2G discharge rate), both ≥0.
+- Asset IDs follow the IES DID pattern: `did:web:<domain>:assets:evse:<local-id>`
+
+For full property tables and worked examples, see [v1.0/README.md](./v1.0/README.md).

--- a/specification/schema/EnergyResourceEVCharger/v1.0/README.md
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/README.md
@@ -1,0 +1,98 @@
+# EnergyResourceEVCharger v1.0
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceEVCharger/v1.0`
+**CIM:** `ElectricVehicleChargingStation` (CIM17+)
+**Status:** Current
+
+---
+
+## Overview
+
+`EnergyResourceEVCharger` is the typed attribute schema for EV charging station energy resources (`type = "EV_CHARGER"` or `type = "EV_V2G"`).
+
+An `EV_CHARGER` is the EVSE (Electric Vehicle Supply Equipment) hardware at the grid connection point. It is a **flexible load** — NOT a storage resource. The EV battery is storage; the EVSE is the charge/discharge interface.
+
+`EV_V2G` is a specialisation of `EV_CHARGER` with Vehicle-to-Grid capability per ISO 15118-20 / OCPP 2.1 BPT. For `EV_V2G`, set both `maxImportKw` (charge rate, ≥0) and `maxExportKw` (V2G discharge rate, ≥0) in the attributes bag.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema — EnergyResourceEVCharger and its Attributes object |
+| [`schema.json`](./schema.json) | Standalone JSON Schema 2020-12 (self-contained) |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context mapping terms to semantic IRIs |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary — class and property definitions |
+
+---
+
+## Type Discriminator
+
+| `type` value | Description |
+|---|---|
+| `EV_CHARGER` | Unidirectional or AC bidirectional EVSE |
+| `EV_V2G` | Vehicle-to-Grid capable EVSE (ISO 15118-20 / OCPP 2.1 BPT) |
+
+---
+
+## Attributes
+
+### Common attributes (EnergyResourceCommonAttributes — all kinds)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model number |
+| `ratedPowerKw` | number ≥0 | Rated peak power, kW — backward compat; prefer `maxImportKw` |
+| `maxImportKw` | number ≥0 | Max charge power drawn from grid, kW. CIM: `PowerElectronicsConnection.maxP` (absorption) |
+| `maxExportKw` | number ≥0 | Max V2G discharge power injected to grid, kW. Set for `EV_V2G` only |
+| `telemetryProvider` | string | Telemetry vendor / API identifier |
+| `commissioningDate` | string (ISO 8601 date-time) | Date-time commissioned |
+| `location` | object (beckn Location/2.0) | `geo` (GeoJSONGeometry) + `address` (PostalAddress) |
+
+### EV charger-specific attributes
+
+| Field | Type | Standard | Description |
+|-------|------|----------|-------------|
+| `connectorType` | enum | IEC 62196 / SAE J3400 | `Type1` · `Type2` · `CCS1` · `CCS2` · `CHAdeMO` · `GB_T` · `NACS` · `Other` |
+| `controlProtocol` | enum | OCPP / ISO 15118 | `OCPP_1.6` · `OCPP_2.0.1` · `OCPP_2.1` · `ISO_15118_2` · `ISO_15118_20` · `Other` |
+| `v2xProtocol` | enum | ISO 15118-20 | `CHAdeMO_V2G` · `CCS_BPT` · `ISO_15118_20_AC_BPT` · `ISO_15118_20_DC_BPT` · `Other` — present for `EV_V2G` only |
+
+---
+
+## Examples
+
+**AC EV charger (7.4 kW, unidirectional):**
+```json
+{
+  "id": "did:web:utility.com:assets:evse:EVSE-001",
+  "type": "EV_CHARGER",
+  "attributes": {
+    "make": "ABB", "model": "Terra AC W22",
+    "maxImportKw": 7.4,
+    "connectorType": "Type2",
+    "controlProtocol": "OCPP_2.0.1",
+    "commissioningDate": "2025-03-01T00:00:00+05:30",
+    "location": {"geo": {"type": "Point", "coordinates": [77.5946, 12.9716]}}
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```
+
+**V2G charger (11 kW charge / 7.4 kW discharge):**
+```json
+{
+  "id": "did:web:utility.com:assets:evse:EVSE-V2G-001",
+  "type": "EV_V2G",
+  "attributes": {
+    "make": "Wallbox", "model": "Quasar 2",
+    "maxImportKw": 11, "maxExportKw": 7.4,
+    "connectorType": "CCS2",
+    "controlProtocol": "ISO_15118_20",
+    "v2xProtocol": "ISO_15118_20_AC_BPT",
+    "commissioningDate": "2025-06-01T00:00:00+05:30"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/EnergyResourceEVCharger/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/attributes.yaml
@@ -1,0 +1,209 @@
+openapi: 3.1.1
+info:
+  title: EnergyResourceEVCharger
+  version: 1.0.0
+  description: |
+    Typed attribute schema for EV charging station energy resources
+    (type = EV_CHARGER or EV_V2G).
+
+    EV_CHARGER is the EVSE (Electric Vehicle Supply Equipment) hardware
+    at the grid connection point. It is a flexible load — NOT a storage
+    resource. The EV battery is storage; the EVSE is the charge/discharge
+    interface.
+
+    EV_V2G is a specialisation of EV_CHARGER with Vehicle-to-Grid
+    capability per ISO 15118-20 / OCPP 2.1 BPT. For EV_V2G, set both
+    maxImportKw (charge rate, ≥0) and maxExportKw (V2G discharge rate, ≥0)
+    in the attributes bag.
+
+    CIM alignment: ElectricVehicleChargingStation (CIM17+).
+
+components:
+  schemas:
+
+    EnergyResourceEVCharger:
+      type: object
+      required: [id, type]
+      additionalProperties: false
+      description: >
+        An EV charging station (EVSE) energy resource. A flexible load at the
+        grid connection point. EV_V2G adds bidirectional capability.
+        CIM: ElectricVehicleChargingStation (CIM17+).
+      x-tags:
+        - energy-resource
+        - ev-charger
+        - energy
+        - deg
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": EnergyResourceEVCharger
+      properties:
+        id:
+          type: string
+          description: >
+            IES asset DID. Format: did:web:<domain>:assets:evse:<local-id>
+            e.g. did:web:utility.com:assets:evse:EVSE-001
+          example: "did:web:utility.com:assets:evse:EVSE-001"
+          x-jsonld:
+            "@id": "@id"
+        type:
+          type: string
+          enum: [EV_CHARGER, EV_V2G]
+          description: >
+            Asset-class discriminator. EV_CHARGER: unidirectional or AC
+            bidirectional EVSE. EV_V2G: Vehicle-to-Grid capable EVSE with
+            ISO 15118-20 / OCPP 2.1 BPT support.
+          x-jsonld:
+            "@id": erDeg:resourceType
+        attributes:
+          $ref: "#/components/schemas/EnergyResourceEVChargerAttributes"
+        subResources:
+          type: array
+          description: Child resources (e.g. smart-load sub-circuits). Each item is a bare id string or inline resource.
+          items:
+            oneOf:
+              - type: string
+                description: id of a sibling EnergyResource.
+              - $ref: "#/components/schemas/EnergyResourceEVCharger"
+                description: Inline nested resource.
+        parentResources:
+          type: array
+          description: ids of parent resources (e.g. the meter this EVSE is behind).
+          items:
+            type: string
+
+    EnergyResourceEVChargerAttributes:
+      type: object
+      additionalProperties: true
+      description: >
+        Attributes for EV_CHARGER and EV_V2G resources. Includes
+        EnergyResourceCommonAttributes fields (make, model, maxExportKw,
+        maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate,
+        location) plus EVSE-specific fields.
+      x-jsonld:
+        "@id": erDeg:attributes
+      properties:
+
+        # ── Common attributes (EnergyResourceCommonAttributes) ────────────
+
+        make:
+          type: string
+          description: Manufacturer (free text).
+          x-jsonld:
+            "@id": erDeg:make
+
+        model:
+          type: string
+          description: Model number (free text).
+          x-jsonld:
+            "@id": erDeg:model
+
+        ratedPowerKw:
+          type: number
+          minimum: 0
+          description: >
+            Manufacturer-rated peak power, kW. Kept for backward
+            compatibility. Prefer maxImportKw for new payloads.
+          x-jsonld:
+            "@id": erDeg:ratedPowerKw
+
+        maxImportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum charge power drawn from the grid, kW. Always ≥0.
+            CIM: PowerElectronicsConnection.maxP (absorption direction).
+          x-jsonld:
+            "@id": erDeg:maxImportKw
+
+        maxExportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum V2G discharge power injected to the grid, kW. Always ≥0.
+            Set for EV_V2G only; omit or 0 for unidirectional EV_CHARGER.
+            CIM: PowerElectronicsConnection.maxP (injection direction).
+          x-jsonld:
+            "@id": erDeg:maxExportKw
+
+        telemetryProvider:
+          type: string
+          description: Vendor API / data source identifier for telemetry.
+          x-jsonld:
+            "@id": erDeg:telemetryProvider
+
+        commissioningDate:
+          type: string
+          format: date-time
+          description: ISO 8601 date-time when this EVSE was commissioned.
+          x-jsonld:
+            "@id": deg:commissioningDate
+
+        location:
+          type: object
+          description: >
+            Physical location of this asset per beckn Location/2.0.
+            geo (required) is a GeoJSON geometry; address is a postal address.
+          required: [geo]
+          properties:
+            geo:
+              type: object
+              required: [type]
+              properties:
+                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
+                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
+                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
+              additionalProperties: true
+            address:
+              type: object
+              additionalProperties: false
+              properties:
+                streetAddress:   { type: string }
+                extendedAddress: { type: string }
+                addressLocality: { type: string }
+                addressRegion:   { type: string }
+                postalCode:      { type: string }
+                addressCountry:  { type: string }
+          x-jsonld:
+            "@id": erDeg:location
+
+        # ── EV charger-specific attributes ───────────────────────────────
+
+        connectorType:
+          type: string
+          enum: [Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other]
+          description: >
+            Physical connector standard.
+            Type1: IEC 62196-2 Type 1 (J1772, single-phase AC, North America/Japan).
+            Type2: IEC 62196-2 Type 2 (Mennekes, single/three-phase AC, Europe).
+            CCS1: Combined Charging System with Type 1 inlet (DC fast charge, North America).
+            CCS2: Combined Charging System with Type 2 inlet (DC fast charge, Europe).
+            CHAdeMO: CHAdeMO Association DC fast charge; supports V2G.
+            GB_T: Chinese standard GB/T 20234 (AC and DC).
+            NACS: North American Charging Standard / SAE J3400.
+          x-jsonld:
+            "@id": erDeg:connectorType
+
+        controlProtocol:
+          type: string
+          enum: [OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other]
+          description: >
+            EVSE control and smart-charging protocol.
+            OCPP_1.6 / OCPP_2.0.1 / OCPP_2.1: Open Charge Point Protocol
+            (OCA). OCPP 2.1 adds ISO 15118-20 integration and BPT.
+            ISO_15118_2: V2G communication interface (AC/DC, no V2G).
+            ISO_15118_20: V2G communication interface with BPT (V2G capable).
+          x-jsonld:
+            "@id": erDeg:controlProtocol
+
+        v2xProtocol:
+          type: string
+          enum: [CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other]
+          description: >
+            Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources.
+            CHAdeMO_V2G: CHAdeMO V2G (CHAdeMO 2.0 / 3.0).
+            CCS_BPT: CCS Bidirectional Power Transfer (DIN SPEC / upcoming SAE).
+            ISO_15118_20_AC_BPT: ISO 15118-20 AC bidirectional.
+            ISO_15118_20_DC_BPT: ISO 15118-20 DC bidirectional.
+          x-jsonld:
+            "@id": erDeg:v2xProtocol

--- a/specification/schema/EnergyResourceEVCharger/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/attributes.yaml
@@ -18,13 +18,14 @@ info:
 
     CIM alignment: ElectricVehicleChargingStation (CIM17+).
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceEVCharger:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
         An EV charging station (EVSE) energy resource. A flexible load at the
         grid connection point. EV_V2G adds bidirectional capability.
@@ -37,173 +38,75 @@ components:
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceEVCharger
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<domain>:assets:evse:<local-id>
-            e.g. did:web:utility.com:assets:evse:EVSE-001
-          example: "did:web:utility.com:assets:evse:EVSE-001"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          enum: [EV_CHARGER, EV_V2G]
-          description: >
-            Asset-class discriminator. EV_CHARGER: unidirectional or AC
-            bidirectional EVSE. EV_V2G: Vehicle-to-Grid capable EVSE with
-            ISO 15118-20 / OCPP 2.1 BPT support.
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceEVChargerAttributes"
-        subResources:
-          type: array
-          description: Child resources (e.g. smart-load sub-circuits). Each item is a bare id string or inline resource.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource.
-              - $ref: "#/components/schemas/EnergyResourceEVCharger"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: ids of parent resources (e.g. the meter this EVSE is behind).
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              enum: [EV_CHARGER, EV_V2G]
+              description: >
+                Asset-class discriminator. EV_CHARGER: unidirectional or AC
+                bidirectional EVSE. EV_V2G: Vehicle-to-Grid capable EVSE with
+                ISO 15118-20 / OCPP 2.1 BPT support.
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceEVChargerAttributes"
 
     EnergyResourceEVChargerAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for EV_CHARGER and EV_V2G resources. Includes
-        EnergyResourceCommonAttributes fields (make, model, maxExportKw,
-        maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate,
-        location) plus EVSE-specific fields.
+        Attributes for EV_CHARGER and EV_V2G resources. Common fields (make,
+        model, ratedPowerKw, maxExportKw, maxImportKw, telemetryProvider,
+        commissioningDate, location) are inherited from
+        EnergyResourceCommonAttributes via allOf. Only EVSE-specific fields
+        are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ────────────
-
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power, kW. Kept for backward
-            compatibility. Prefer maxImportKw for new payloads.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        maxImportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum charge power drawn from the grid, kW. Always ≥0.
-            CIM: PowerElectronicsConnection.maxP (absorption direction).
-          x-jsonld:
-            "@id": erDeg:maxImportKw
-
-        maxExportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum V2G discharge power injected to the grid, kW. Always ≥0.
-            Set for EV_V2G only; omit or 0 for unidirectional EV_CHARGER.
-            CIM: PowerElectronicsConnection.maxP (injection direction).
-          x-jsonld:
-            "@id": erDeg:maxExportKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this EVSE was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              properties:
-                streetAddress:   { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion:   { type: string }
-                postalCode:      { type: string }
-                addressCountry:  { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── EV charger-specific attributes ───────────────────────────────
+            # ── EV charger-specific attributes ────────────────────────────────
 
-        connectorType:
-          type: string
-          enum: [Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other]
-          description: >
-            Physical connector standard.
-            Type1: IEC 62196-2 Type 1 (J1772, single-phase AC, North America/Japan).
-            Type2: IEC 62196-2 Type 2 (Mennekes, single/three-phase AC, Europe).
-            CCS1: Combined Charging System with Type 1 inlet (DC fast charge, North America).
-            CCS2: Combined Charging System with Type 2 inlet (DC fast charge, Europe).
-            CHAdeMO: CHAdeMO Association DC fast charge; supports V2G.
-            GB_T: Chinese standard GB/T 20234 (AC and DC).
-            NACS: North American Charging Standard / SAE J3400.
-          x-jsonld:
-            "@id": erDeg:connectorType
+            connectorType:
+              type: string
+              enum: [Type1, Type2, CCS1, CCS2, CHAdeMO, GB_T, NACS, Other]
+              description: >
+                Physical connector standard.
+                Type1: IEC 62196-2 Type 1 (J1772, single-phase AC, North America/Japan).
+                Type2: IEC 62196-2 Type 2 (Mennekes, single/three-phase AC, Europe).
+                CCS1: Combined Charging System with Type 1 inlet (DC fast charge, North America).
+                CCS2: Combined Charging System with Type 2 inlet (DC fast charge, Europe).
+                CHAdeMO: CHAdeMO Association DC fast charge; supports V2G.
+                GB_T: Chinese standard GB/T 20234 (AC and DC).
+                NACS: North American Charging Standard / SAE J3400.
+              x-jsonld:
+                "@id": erDeg:connectorType
 
-        controlProtocol:
-          type: string
-          enum: [OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other]
-          description: >
-            EVSE control and smart-charging protocol.
-            OCPP_1.6 / OCPP_2.0.1 / OCPP_2.1: Open Charge Point Protocol
-            (OCA). OCPP 2.1 adds ISO 15118-20 integration and BPT.
-            ISO_15118_2: V2G communication interface (AC/DC, no V2G).
-            ISO_15118_20: V2G communication interface with BPT (V2G capable).
-          x-jsonld:
-            "@id": erDeg:controlProtocol
+            controlProtocol:
+              type: string
+              enum: [OCPP_1.6, OCPP_2.0.1, OCPP_2.1, ISO_15118_2, ISO_15118_20, Other]
+              description: >
+                EVSE control and smart-charging protocol.
+                OCPP_1.6 / OCPP_2.0.1 / OCPP_2.1: Open Charge Point Protocol
+                (OCA). OCPP 2.1 adds ISO 15118-20 integration and BPT.
+                ISO_15118_2: V2G communication interface (AC/DC, no V2G).
+                ISO_15118_20: V2G communication interface with BPT (V2G capable).
+              x-jsonld:
+                "@id": erDeg:controlProtocol
 
-        v2xProtocol:
-          type: string
-          enum: [CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other]
-          description: >
-            Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources.
-            CHAdeMO_V2G: CHAdeMO V2G (CHAdeMO 2.0 / 3.0).
-            CCS_BPT: CCS Bidirectional Power Transfer (DIN SPEC / upcoming SAE).
-            ISO_15118_20_AC_BPT: ISO 15118-20 AC bidirectional.
-            ISO_15118_20_DC_BPT: ISO 15118-20 DC bidirectional.
-          x-jsonld:
-            "@id": erDeg:v2xProtocol
+            v2xProtocol:
+              type: string
+              enum: [CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT, Other]
+              description: >
+                Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources.
+                CHAdeMO_V2G: CHAdeMO V2G (CHAdeMO 2.0 / 3.0).
+                CCS_BPT: CCS Bidirectional Power Transfer (DIN SPEC / upcoming SAE).
+                ISO_15118_20_AC_BPT: ISO 15118-20 AC bidirectional.
+                ISO_15118_20_DC_BPT: ISO 15118-20 DC bidirectional.
+              x-jsonld:
+                "@id": erDeg:v2xProtocol

--- a/specification/schema/EnergyResourceEVCharger/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/context.jsonld
@@ -1,0 +1,34 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
+    "deg":   "https://schema.beckn.io/deg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
+    "EnergyResourceEVCharger": {
+      "@id": "erDeg:EnergyResourceEVCharger",
+      "@context": {
+        "@version": 1.1,
+        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
+        "attributes": {
+          "@id": "erDeg:attributes",
+          "@type": "@id",
+          "@context": {
+            "make":              { "@id": "erDeg:make",              "@type": "xsd:string"   },
+            "model":             { "@id": "erDeg:model",             "@type": "xsd:string"   },
+            "ratedPowerKw":      { "@id": "erDeg:ratedPowerKw",      "@type": "xsd:decimal"  },
+            "maxImportKw":       { "@id": "erDeg:maxImportKw",       "@type": "xsd:decimal"  },
+            "maxExportKw":       { "@id": "erDeg:maxExportKw",       "@type": "xsd:decimal"  },
+            "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string"   },
+            "commissioningDate": { "@id": "deg:commissioningDate",   "@type": "xsd:dateTime" },
+            "location":          { "@id": "erDeg:location",          "@type": "@id"          },
+            "connectorType":     { "@id": "erDeg:connectorType",     "@type": "xsd:string"   },
+            "controlProtocol":   { "@id": "erDeg:controlProtocol",   "@type": "xsd:string"   },
+            "v2xProtocol":       { "@id": "erDeg:v2xProtocol",       "@type": "xsd:string"   }
+          }
+        },
+        "subResources":    { "@id": "erDeg:subResources",    "@container": "@list" },
+        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+      }
+    }
+  }
+}

--- a/specification/schema/EnergyResourceEVCharger/v1.0/schema.json
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.beckn.io/EnergyResourceEVCharger/v1.0",
+  "title": "EnergyResourceEVCharger",
+  "description": "Typed schema for EV charging station energy resources (type = EV_CHARGER or EV_V2G). EV_CHARGER is a flexible load at the grid connection point — NOT a storage resource. EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+).",
+  "type": "object",
+  "required": ["id", "type"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "IES asset DID. Format: did:web:<domain>:assets:evse:<local-id>. Example: did:web:utility.com:assets:evse:EVSE-001"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["EV_CHARGER", "EV_V2G"],
+      "description": "Asset-class discriminator. EV_CHARGER: unidirectional or AC bidirectional EVSE. EV_V2G: Vehicle-to-Grid capable EVSE (ISO 15118-20 / OCPP 2.1 BPT)."
+    },
+    "attributes": {
+      "$ref": "#/$defs/EnergyResourceEVChargerAttributes"
+    },
+    "subResources": {
+      "type": "array",
+      "description": "Child resources. Each item is a bare id string or an inline EnergyResourceEVCharger object.",
+      "items": {
+        "oneOf": [
+          { "type": "string", "minLength": 1 },
+          { "$ref": "#" }
+        ]
+      }
+    },
+    "parentResources": {
+      "type": "array",
+      "description": "ids of parent resources (e.g. the meter this EVSE is behind).",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "GeoJSONGeometry": {
+      "type": "object",
+      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326).",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
+        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
+        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
+        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
+      },
+      "additionalProperties": true
+    },
+    "Address": {
+      "type": "object",
+      "description": "schema.org PostalAddress per beckn Address/2.0.",
+      "additionalProperties": false,
+      "properties": {
+        "streetAddress": { "type": "string" },
+        "extendedAddress": { "type": "string" },
+        "addressLocality": { "type": "string" },
+        "addressRegion": { "type": "string" },
+        "postalCode": { "type": "string" },
+        "addressCountry": { "type": "string" }
+      }
+    },
+    "Location": {
+      "type": "object",
+      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address.",
+      "required": ["geo"],
+      "properties": {
+        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
+        "address": { "$ref": "#/$defs/Address" }
+      }
+    },
+    "EnergyResourceEVChargerAttributes": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Attributes for EV_CHARGER and EV_V2G resources. Includes common fields (make, model, maxImportKw, maxExportKw, ratedPowerKw, telemetryProvider, commissioningDate, location) plus EVSE-specific fields.",
+      "properties": {
+        "make": { "type": "string", "description": "Manufacturer (free text)." },
+        "model": { "type": "string", "description": "Model number (free text)." },
+        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. Kept for backward compatibility. Prefer maxImportKw." },
+        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum charge power drawn from the grid, kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption)." },
+        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum V2G discharge power injected to the grid, kW. Always ≥0. Set for EV_V2G; omit or 0 for unidirectional EV_CHARGER. CIM: PowerElectronicsConnection.maxP (injection)." },
+        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
+        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this EVSE was commissioned." },
+        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
+        "connectorType": {
+          "type": "string",
+          "enum": ["Type1", "Type2", "CCS1", "CCS2", "CHAdeMO", "GB_T", "NACS", "Other"],
+          "description": "Physical connector standard. Type1/Type2: IEC 62196. CCS1/CCS2: Combined Charging System (DC fast). CHAdeMO: CHAdeMO Association (DC, supports V2G). GB_T: Chinese GB/T 20234. NACS: North American Charging Standard (SAE J3400)."
+        },
+        "controlProtocol": {
+          "type": "string",
+          "enum": ["OCPP_1.6", "OCPP_2.0.1", "OCPP_2.1", "ISO_15118_2", "ISO_15118_20", "Other"],
+          "description": "EVSE control and smart-charging protocol. OCPP 2.1 adds ISO 15118-20 integration and BPT. ISO_15118_20 enables Plug-and-Charge and V2G."
+        },
+        "v2xProtocol": {
+          "type": "string",
+          "enum": ["CHAdeMO_V2G", "CCS_BPT", "ISO_15118_20_AC_BPT", "ISO_15118_20_DC_BPT", "Other"],
+          "description": "V2G / V2X protocol. Present only for EV_V2G resources. CHAdeMO_V2G: CHAdeMO 2.0/3.0. CCS_BPT: CCS bidirectional. ISO_15118_20_AC/DC_BPT: ISO 15118-20 AC or DC bidirectional power transfer."
+        }
+      }
+    }
+  }
+}

--- a/specification/schema/EnergyResourceEVCharger/v1.0/schema.json
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/schema.json
@@ -2,104 +2,49 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceEVCharger/v1.0",
   "title": "EnergyResourceEVCharger",
-  "description": "Typed schema for EV charging station energy resources (type = EV_CHARGER or EV_V2G). EV_CHARGER is a flexible load at the grid connection point — NOT a storage resource. EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+).",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<domain>:assets:evse:<local-id>. Example: did:web:utility.com:assets:evse:EVSE-001"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["EV_CHARGER", "EV_V2G"],
-      "description": "Asset-class discriminator. EV_CHARGER: unidirectional or AC bidirectional EVSE. EV_V2G: Vehicle-to-Grid capable EVSE (ISO 15118-20 / OCPP 2.1 BPT)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceEVChargerAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources. Each item is a bare id string or an inline EnergyResourceEVCharger object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
+  "description": "Typed schema for EV charging station energy resources (EV_CHARGER, EV_V2G). EV_CHARGER is a flexible load (EVSE hardware), not storage. EV_V2G adds Vehicle-to-Grid capability per ISO 15118-20 / OCPP 2.1 BPT. CIM: ElectricVehicleChargingStation (CIM17+). Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["EV_CHARGER", "EV_V2G"],
+          "description": "Asset-class discriminator. EV_CHARGER: unidirectional or AC bidirectional EVSE. EV_V2G: Vehicle-to-Grid capable EVSE with ISO 15118-20 / OCPP 2.1 BPT support."
+        },
+        "attributes": { "$ref": "#/$defs/EnergyResourceEVChargerAttributes" }
       }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent resources (e.g. the meter this EVSE is behind).",
-      "items": { "type": "string", "minLength": 1 }
     }
-  },
+  ],
   "$defs": {
-    "GeoJSONGeometry": {
-      "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326).",
-      "required": ["type"],
-      "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
     "EnergyResourceEVChargerAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for EV_CHARGER and EV_V2G resources. Includes common fields (make, model, maxImportKw, maxExportKw, ratedPowerKw, telemetryProvider, commissioningDate, location) plus EVSE-specific fields.",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. Kept for backward compatibility. Prefer maxImportKw." },
-        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum charge power drawn from the grid, kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption)." },
-        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum V2G discharge power injected to the grid, kW. Always ≥0. Set for EV_V2G; omit or 0 for unidirectional EV_CHARGER. CIM: PowerElectronicsConnection.maxP (injection)." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this EVSE was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "connectorType": {
-          "type": "string",
-          "enum": ["Type1", "Type2", "CCS1", "CCS2", "CHAdeMO", "GB_T", "NACS", "Other"],
-          "description": "Physical connector standard. Type1/Type2: IEC 62196. CCS1/CCS2: Combined Charging System (DC fast). CHAdeMO: CHAdeMO Association (DC, supports V2G). GB_T: Chinese GB/T 20234. NACS: North American Charging Standard (SAE J3400)."
-        },
-        "controlProtocol": {
-          "type": "string",
-          "enum": ["OCPP_1.6", "OCPP_2.0.1", "OCPP_2.1", "ISO_15118_2", "ISO_15118_20", "Other"],
-          "description": "EVSE control and smart-charging protocol. OCPP 2.1 adds ISO 15118-20 integration and BPT. ISO_15118_20 enables Plug-and-Charge and V2G."
-        },
-        "v2xProtocol": {
-          "type": "string",
-          "enum": ["CHAdeMO_V2G", "CCS_BPT", "ISO_15118_20_AC_BPT", "ISO_15118_20_DC_BPT", "Other"],
-          "description": "V2G / V2X protocol. Present only for EV_V2G resources. CHAdeMO_V2G: CHAdeMO 2.0/3.0. CCS_BPT: CCS bidirectional. ISO_15118_20_AC/DC_BPT: ISO 15118-20 AC or DC bidirectional power transfer."
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for EV_CHARGER and EV_V2G resources. Common fields inherited. EVSE-specific fields below.",
+          "properties": {
+            "connectorType": {
+              "type": "string",
+              "enum": ["Type1", "Type2", "CCS1", "CCS2", "CHAdeMO", "GB_T", "NACS", "Other"],
+              "description": "Physical connector standard. Type1: IEC 62196-2 Type 1 (J1772). Type2: IEC 62196-2 Type 2 (Mennekes). CCS1/CCS2: Combined Charging System. CHAdeMO: DC fast charge with V2G support. GB_T: GB/T 20234 (China). NACS: SAE J3400."
+            },
+            "controlProtocol": {
+              "type": "string",
+              "enum": ["OCPP_1.6", "OCPP_2.0.1", "OCPP_2.1", "ISO_15118_2", "ISO_15118_20", "Other"],
+              "description": "EVSE control and smart-charging protocol. OCPP_2.1 adds ISO 15118-20 BPT. ISO_15118_20: V2G communication interface with bidirectional power transfer."
+            },
+            "v2xProtocol": {
+              "type": "string",
+              "enum": ["CHAdeMO_V2G", "CCS_BPT", "ISO_15118_20_AC_BPT", "ISO_15118_20_DC_BPT", "Other"],
+              "description": "Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources."
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceEVCharger/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/vocab.jsonld
@@ -1,0 +1,123 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "erDeg":  "https://schema.beckn.io/deg/EnergyResource/",
+    "deg":    "https://schema.beckn.io/deg#",
+    "rdf":    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":   "http://www.w3.org/2000/01/rdf-schema#",
+    "owl":    "http://www.w3.org/2002/07/owl#",
+    "xsd":    "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/",
+    "skos":   "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "erDeg:EnergyResourceEVCharger",
+      "@type": "rdfs:Class",
+      "rdfs:label": "EnergyResource — EV Charger",
+      "rdfs:comment": "An EV charging station (EVSE) energy resource. A flexible load at the grid connection point — NOT a storage resource. EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+)."
+    },
+    {
+      "@id": "erDeg:resourceType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Resource type discriminator",
+      "rdfs:comment": "Asset-class discriminator. For EnergyResourceEVCharger: EV_CHARGER or EV_V2G.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceEVCharger" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:make",
+      "@type": "rdf:Property",
+      "rdfs:label": "Manufacturer",
+      "rdfs:comment": "Manufacturer name of the energy resource.",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:model",
+      "@type": "rdf:Property",
+      "rdfs:label": "Model",
+      "rdfs:comment": "Model number of the energy resource.",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:ratedPowerKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Rated power (kW)",
+      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. Kept for backward compatibility. Prefer maxImportKw for EV chargers.",
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:maxImportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max import power (kW)",
+      "rdfs:comment": "Maximum charge power drawn from the grid, kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption direction).",
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:maxExportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max export power (kW)",
+      "rdfs:comment": "Maximum V2G discharge power injected to the grid, kW. Always ≥0. Set for EV_V2G. CIM: PowerElectronicsConnection.maxP (injection direction).",
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:telemetryProvider",
+      "@type": "rdf:Property",
+      "rdfs:label": "Telemetry provider",
+      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:commissioningDate",
+      "@type": "rdf:Property",
+      "rdfs:label": "Commissioning date",
+      "rdfs:comment": "ISO 8601 date-time when the asset was commissioned.",
+      "schema:rangeIncludes": { "@id": "xsd:dateTime" }
+    },
+    {
+      "@id": "erDeg:location",
+      "@type": "rdf:Property",
+      "rdfs:label": "Location",
+      "rdfs:comment": "Physical location per beckn Location/2.0: geo (GeoJSON Point, coordinates [lon, lat]) + optional postal address.",
+      "schema:rangeIncludes": { "@id": "schema:Place" }
+    },
+    {
+      "@id": "erDeg:connectorType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Connector type",
+      "rdfs:comment": "Physical connector standard. Type1/Type2: IEC 62196. CCS1/CCS2: Combined Charging System (DC). CHAdeMO: CHAdeMO Association (DC, V2G capable). GB_T: Chinese GB/T 20234. NACS: North American Charging Standard (SAE J3400).",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceEVCharger" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:controlProtocol",
+      "@type": "rdf:Property",
+      "rdfs:label": "Control protocol",
+      "rdfs:comment": "EVSE control and smart-charging protocol. OCPP_1.6/2.0.1/2.1: Open Charge Point Protocol (OCA). ISO_15118_2: V2G communication (AC/DC). ISO_15118_20: V2G with BPT (bidirectional power transfer).",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceEVCharger" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:v2xProtocol",
+      "@type": "rdf:Property",
+      "rdfs:label": "V2X protocol",
+      "rdfs:comment": "Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources. CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceEVCharger" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:subResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "Sub-resources",
+      "rdfs:comment": "Child resources in the topology tree.",
+      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceEVCharger" }
+    },
+    {
+      "@id": "erDeg:parentResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "Parent resources",
+      "rdfs:comment": "ids of parent resources (e.g. the meter this EVSE is behind).",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    }
+  ]
+}

--- a/specification/schema/EnergyResourceGenerator/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceGenerator/v1.0/attributes.yaml
@@ -16,13 +16,14 @@ info:
 
     SOLAR is a deprecated alias for SOLAR_PV; new payloads should use SOLAR_PV.
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceGenerator:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
         A generation DER energy resource (solar PV, wind, hydro, biogas, CHP,
         fuel cell). Corresponds to GeneratingUnit and its CIM subtypes
@@ -36,147 +37,64 @@ components:
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceGenerator
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>
-            e.g. did:web:bescom.karnataka.gov.in:assets:solar:SOL-001
-          example: "did:web:bescom.karnataka.gov.in:assets:solar:SOL-001"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          enum:
-            - SOLAR_PV
-            - SOLAR
-            - WIND
-            - HYDRO
-            - BIOGAS
-            - CHP
-            - FUEL_CELL
-          description: >
-            Asset-class discriminator. SOLAR is a deprecated alias for SOLAR_PV;
-            new payloads should use SOLAR_PV.
-            CIM classes: SOLAR_PV/SOLAR → PhotovoltaicUnit,
-            WIND → WindGeneratingUnit, HYDRO → HydroGeneratingUnit,
-            BIOGAS/CHP → ThermalGeneratingUnit, FUEL_CELL → IEC 62933-2.
-          x-cim-class: cim:GeneratingUnit
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceGeneratorAttributes"
-        subResources:
-          type: array
-          description: >
-            Child resources (e.g. inverters, tracking units). Each item is a
-            bare id string or an inline EnergyResourceGenerator object.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource in the same payload.
-              - $ref: "#/components/schemas/EnergyResourceGenerator"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: >
-            ids of parent resources (e.g. the meter this DER sits behind).
-            String references only.
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              enum:
+                - SOLAR_PV
+                - SOLAR
+                - WIND
+                - HYDRO
+                - BIOGAS
+                - CHP
+                - FUEL_CELL
+              description: >
+                Asset-class discriminator. SOLAR is a deprecated alias for SOLAR_PV;
+                new payloads should use SOLAR_PV.
+                CIM classes: SOLAR_PV/SOLAR → PhotovoltaicUnit,
+                WIND → WindGeneratingUnit, HYDRO → HydroGeneratingUnit,
+                BIOGAS/CHP → ThermalGeneratingUnit, FUEL_CELL → IEC 62933-2.
+              x-cim-class: cim:GeneratingUnit
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceGeneratorAttributes"
 
     EnergyResourceGeneratorAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for generation DER resources. Includes EnergyResourceCommonAttributes
-        fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location)
-        plus generator-specific fields (nominalPowerKw, efficiency).
+        Attributes for generation DER resources. Common fields (make, model,
+        ratedPowerKw, maxExportKw, maxImportKw, telemetryProvider, commissioningDate,
+        location) are inherited from EnergyResourceCommonAttributes via allOf.
+        Only generator-specific fields are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ──────────────
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power, kW. CIM: GeneratingUnit.maxOperatingP.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this generator was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              description: GeoJSON geometry — coordinates are [longitude, latitude].
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                geometries: { type: array }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              description: schema.org PostalAddress fields.
-              properties:
-                streetAddress: { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion: { type: string }
-                postalCode: { type: string }
-                addressCountry: { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── Generator-specific attributes ────────────────────────────────────
-        nominalPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Nominal (nameplate) power output, kW. CIM: GeneratingUnit.nominalP.
-            Typically equals the DC STC rating for solar PV.
-          x-jsonld:
-            "@id": erDeg:nominalPowerKw
+            # ── Generator-specific attributes ────────────────────────────────
 
-        efficiency:
-          type: number
-          minimum: 0
-          maximum: 100
-          description: >
-            Conversion efficiency as a percentage (0–100). Most relevant for
-            FUEL_CELL and CHP resources.
-          x-jsonld:
-            "@id": erDeg:efficiency
+            nominalPowerKw:
+              type: number
+              minimum: 0
+              description: >
+                Nominal (nameplate) power output, kW. CIM: GeneratingUnit.nominalP.
+                Typically equals the DC STC rating for solar PV.
+              x-jsonld:
+                "@id": erDeg:nominalPowerKw
+
+            efficiency:
+              type: number
+              minimum: 0
+              maximum: 100
+              description: >
+                Conversion efficiency as a percentage (0–100). Most relevant for
+                FUEL_CELL and CHP resources.
+              x-jsonld:
+                "@id": erDeg:efficiency

--- a/specification/schema/EnergyResourceGenerator/v1.0/schema.json
+++ b/specification/schema/EnergyResourceGenerator/v1.0/schema.json
@@ -2,98 +2,45 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceGenerator/v1.0",
   "title": "EnergyResourceGenerator",
-  "description": "Typed schema for generation DER energy resources (solar PV, wind, hydro, biogas, CHP, fuel cell). CIM: GeneratingUnit and subtypes — SOLAR_PV/SOLAR → PhotovoltaicUnit, WIND → WindGeneratingUnit, HYDRO → HydroGeneratingUnit, BIOGAS/CHP → ThermalGeneratingUnit (IEC 61970-301/302). SOLAR is a deprecated alias for SOLAR_PV.",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>. Example: did:web:bescom.karnataka.gov.in:assets:solar:SOL-001"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["SOLAR_PV", "SOLAR", "WIND", "HYDRO", "BIOGAS", "CHP", "FUEL_CELL"],
-      "description": "Asset-class discriminator. SOLAR is deprecated; use SOLAR_PV. CIM: PhotovoltaicUnit, WindGeneratingUnit, HydroGeneratingUnit, ThermalGeneratingUnit (IEC 61970-302)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceGeneratorAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources (e.g. inverters, tracking units). Each item is a bare id string or an inline EnergyResource object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
-      }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent resources (e.g. the meter this DER sits behind).",
-      "items": { "type": "string", "minLength": 1 }
-    }
-  },
-  "$defs": {
-    "GeoJSONGeometry": {
+  "description": "Typed schema for generation DER energy resources (solar PV, wind, hydro, biogas, CHP, fuel cell). CIM: GeneratingUnit and subtypes — SOLAR_PV/SOLAR → PhotovoltaicUnit, WIND → WindGeneratingUnit, HYDRO → HydroGeneratingUnit, BIOGAS/CHP → ThermalGeneratingUnit (IEC 61970-301/302). SOLAR is a deprecated alias for SOLAR_PV. Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
       "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326). For a point: {type: 'Point', coordinates: [lon, lat]}.",
-      "required": ["type"],
+      "required": ["id", "type"],
       "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
-    "EnergyResourceGeneratorAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for generation DER resources. Includes common fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location) plus generator-specific fields (nominalPowerKw, efficiency).",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. CIM: GeneratingUnit.maxOperatingP." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this generator was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "nominalPowerKw": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Nominal (nameplate) power output, kW. CIM: GeneratingUnit.nominalP. Typically equals DC STC rating for solar PV."
+        "type": {
+          "type": "string",
+          "enum": ["SOLAR_PV", "SOLAR", "WIND", "HYDRO", "BIOGAS", "CHP", "FUEL_CELL"],
+          "description": "Asset-class discriminator. SOLAR is deprecated; use SOLAR_PV. CIM: PhotovoltaicUnit, WindGeneratingUnit, HydroGeneratingUnit, ThermalGeneratingUnit (IEC 61970-302)."
         },
-        "efficiency": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "description": "Conversion efficiency as a percentage (0–100). Most relevant for FUEL_CELL and CHP resources."
-        }
+        "attributes": { "$ref": "#/$defs/EnergyResourceGeneratorAttributes" }
       }
+    }
+  ],
+  "$defs": {
+    "EnergyResourceGeneratorAttributes": {
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for generation DER resources. Common fields inherited. Generator-specific fields below.",
+          "properties": {
+            "nominalPowerKw": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Nominal (nameplate) power output, kW. CIM: GeneratingUnit.nominalP. Typically equals DC STC rating for solar PV."
+            },
+            "efficiency": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "description": "Conversion efficiency as a percentage (0–100). Most relevant for FUEL_CELL and CHP resources."
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceInverter/README.md
+++ b/specification/schema/EnergyResourceInverter/README.md
@@ -1,0 +1,35 @@
+# EnergyResourceInverter
+
+Typed energy resource schema for grid-connected power-electronics inverters. An `INVERTER` resource is a grid-connected converter without a dedicated fuel source — capturing reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702–714.
+
+**Canonical IRI:** `https://schema.beckn.io/EnergyResourceInverter/v1.0`
+
+**CIM alignment:** `PowerElectronicsConnection` (IEC 61970-302)
+
+**Tags:** `energy-resource` · `inverter` · `energy` · `deg`
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Initial typed kind for INVERTER resources. Introduces IEEE 1547-2018 ride-through categories, `operatingMode` (GridFollowing / GridForming / Standby), `voltVarEnabled`, `freqDroopEnabled`, reactive power fields, and `enterServiceRampTimeSec`. |
+
+---
+
+## Type discriminator
+
+| `type` value | CIM class | Description |
+|---|---|---|
+| `INVERTER` | `PowerElectronicsConnection` (IEC 61970-302) | Grid-connected power-electronics converter |
+
+---
+
+## Usage
+
+- **ElectricityCredential/v1.2**: entries with `type: "INVERTER"` in `customerProfile.energyResources[]` conform to this schema.
+- Typical use cases: standalone battery inverters, VPP aggregation points, grid-forming inverters for microgrid islanding.
+- Asset IDs follow the IES DID pattern: `did:web:<domain>:assets:inverter:<local-id>`
+
+For full property tables and worked examples, see [v1.0/README.md](./v1.0/README.md).

--- a/specification/schema/EnergyResourceInverter/v1.0/README.md
+++ b/specification/schema/EnergyResourceInverter/v1.0/README.md
@@ -1,0 +1,110 @@
+# EnergyResourceInverter v1.0
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceInverter/v1.0`
+**CIM:** `PowerElectronicsConnection` (IEC 61970-302)
+**Status:** Current
+
+---
+
+## Overview
+
+`EnergyResourceInverter` is the typed attribute schema for grid-connected power-electronics inverter energy resources (`type = "INVERTER"`).
+
+An `INVERTER` resource is a grid-connected power-electronics converter without a dedicated fuel source. It captures reactive-power and frequency-support capabilities per **IEEE 1547-2018** and **SunSpec DER Models 702–714**.
+
+Typical use cases:
+- Standalone battery inverters
+- Virtual power plant (VPP) aggregation points
+- Grid-forming inverters for microgrid islanding
+- Reactive power compensation (STATCOM-like operation)
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema — EnergyResourceInverter and its Attributes object |
+| [`schema.json`](./schema.json) | Standalone JSON Schema 2020-12 (self-contained) |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context mapping terms to semantic IRIs |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary — class and property definitions with CIM / standards seeAlso links |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class | Description |
+|---|---|---|
+| `INVERTER` | `PowerElectronicsConnection` (IEC 61970-302) | Grid-connected power-electronics converter |
+
+---
+
+## Attributes
+
+### Common attributes (EnergyResourceCommonAttributes — all kinds)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model number |
+| `ratedPowerKw` | number ≥0 | Rated peak active power, kW — backward compat; prefer `maxExportKw` |
+| `maxExportKw` | number ≥0 | Max active power injected to grid, kW. SunSpec 702 `maxW`. CIM: `PowerElectronicsConnection.maxP` (injection) |
+| `maxImportKw` | number ≥0 | Max active power absorbed from grid, kW. Set for four-quadrant inverters. CIM: `PowerElectronicsConnection.maxP` (absorption) |
+| `telemetryProvider` | string | Telemetry vendor / API identifier |
+| `commissioningDate` | string (ISO 8601 date-time) | Date-time commissioned |
+| `location` | object (beckn Location/2.0) | `geo` (GeoJSONGeometry) + `address` (PostalAddress) |
+
+### Inverter-specific attributes (IEEE 1547-2018 / SunSpec)
+
+| Field | Type | Standard | Description |
+|-------|------|----------|-------------|
+| `ratedApparentPowerKva` | number ≥0 | SunSpec 702 `maxVA` | Rated apparent power, kVA. CIM: `ratedS` |
+| `maxReactivePowerKvar` | number ≥0 | SunSpec 702 `maxVar` | Max reactive injection (leading / over-excited), kVAr. CIM: `maxQ` |
+| `minReactivePowerKvar` | number | SunSpec 702 `maxVarNeg` | Max reactive absorption (lagging); usually negative. CIM: `minQ` |
+| `rideThroughCategory` | enum | IEEE 1547-2018 | `CategoryI` (basic) · `CategoryII` (enhanced) · `CategoryIII` (advanced) |
+| `operatingMode` | enum | CIM `inverterMode` | `GridFollowing` · `GridForming` · `Standby` |
+| `voltVarEnabled` | boolean | IEEE 2030.5 `opModVoltVar` / SunSpec 705 | Volt-VAr curve active |
+| `freqDroopEnabled` | boolean | SunSpec 711 / IEEE 1547 Freq-Watt | Frequency-Watt droop active |
+| `enterServiceRampTimeSec` | number ≥0 | SunSpec 703 `ESRmpTms` | Ramp-up time after reconnect, seconds |
+
+---
+
+## Examples
+
+**Grid-following inverter (10 kW export, VAr support):**
+```json
+{
+  "id": "did:web:utility.com:assets:inverter:INV-001",
+  "type": "INVERTER",
+  "attributes": {
+    "make": "SMA", "model": "Sunny Tripower 10.0",
+    "maxExportKw": 10,
+    "ratedApparentPowerKva": 10, "maxReactivePowerKvar": 4.8,
+    "operatingMode": "GridFollowing",
+    "voltVarEnabled": true,
+    "rideThroughCategory": "CategoryII",
+    "commissioningDate": "2025-01-15T00:00:00+05:30"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```
+
+**Grid-forming inverter (microgrid, four-quadrant, full IEEE 1547 CategoryIII):**
+```json
+{
+  "id": "did:web:utility.com:assets:inverter:INV-GF-001",
+  "type": "INVERTER",
+  "attributes": {
+    "make": "Schneider Electric", "model": "Conext XW Pro 6848",
+    "maxExportKw": 10, "maxImportKw": 10,
+    "ratedApparentPowerKva": 12,
+    "maxReactivePowerKvar": 6, "minReactivePowerKvar": -6,
+    "operatingMode": "GridForming",
+    "voltVarEnabled": true, "freqDroopEnabled": true,
+    "rideThroughCategory": "CategoryIII",
+    "enterServiceRampTimeSec": 30,
+    "commissioningDate": "2025-04-01T00:00:00+05:30"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/EnergyResourceInverter/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceInverter/v1.0/attributes.yaml
@@ -19,13 +19,14 @@ info:
 
     CIM alignment: PowerElectronicsConnection (IEC 61970-302).
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceInverter:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
         A grid-connected power-electronics inverter energy resource. Captures
         IEEE 1547-2018 ride-through categories, operating mode, and reactive /
@@ -39,220 +40,120 @@ components:
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceInverter
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<domain>:assets:inverter:<local-id>
-            e.g. did:web:utility.com:assets:inverter:INV-001
-          example: "did:web:utility.com:assets:inverter:INV-001"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          const: "INVERTER"
-          description: >
-            Asset-class discriminator. Must be "INVERTER".
-            CIM: PowerElectronicsConnection (IEC 61970-302).
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceInverterAttributes"
-        subResources:
-          type: array
-          description: Child resources. Each item is a bare id string or inline resource.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource.
-              - $ref: "#/components/schemas/EnergyResourceInverter"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: ids of parent resources (e.g. the meter this inverter is behind).
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              const: "INVERTER"
+              description: >
+                Asset-class discriminator. Must be "INVERTER".
+                CIM: PowerElectronicsConnection (IEC 61970-302).
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceInverterAttributes"
 
     EnergyResourceInverterAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for INVERTER resources. Includes
-        EnergyResourceCommonAttributes fields (make, model, maxExportKw,
-        maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate,
-        location) plus IEEE 1547-2018 / SunSpec DER Model inverter-specific
-        fields.
+        Attributes for INVERTER resources. Common fields (make, model,
+        ratedPowerKw, maxExportKw, maxImportKw, telemetryProvider,
+        commissioningDate, location) are inherited from
+        EnergyResourceCommonAttributes via allOf. Only IEEE 1547-2018 /
+        SunSpec DER Model inverter-specific fields are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ────────────
-
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak active power, kW. Kept for backward
-            compatibility. Prefer maxExportKw for new payloads.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        maxExportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum active power injected to the grid, kW. Always ≥0.
-            CIM: PowerElectronicsConnection.maxP (injection direction).
-            SunSpec Model 702 maxW.
-          x-jsonld:
-            "@id": erDeg:maxExportKw
-
-        maxImportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum active power absorbed from the grid, kW. Always ≥0.
-            Set for four-quadrant inverters (grid-forming or storage-backed).
-            CIM: PowerElectronicsConnection.maxP (absorption direction).
-          x-jsonld:
-            "@id": erDeg:maxImportKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this inverter was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              properties:
-                streetAddress:   { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion:   { type: string }
-                postalCode:      { type: string }
-                addressCountry:  { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── Inverter-specific attributes (IEEE 1547 / SunSpec) ────────────
+            # ── Inverter-specific attributes (IEEE 1547 / SunSpec) ────────────
 
-        ratedApparentPowerKva:
-          type: number
-          minimum: 0
-          description: >
-            Rated apparent power in kVA.
-            SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS.
-          x-jsonld:
-            "@id": erDeg:ratedApparentPowerKva
+            ratedApparentPowerKva:
+              type: number
+              minimum: 0
+              description: >
+                Rated apparent power in kVA.
+                SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS.
+              x-jsonld:
+                "@id": erDeg:ratedApparentPowerKva
 
-        maxReactivePowerKvar:
-          type: number
-          minimum: 0
-          description: >
-            Maximum reactive power injection (leading / over-excited), kVAr.
-            SunSpec Model 702 maxVar.
-            CIM: PowerElectronicsConnection.maxQ.
-          x-jsonld:
-            "@id": erDeg:maxReactivePowerKvar
+            maxReactivePowerKvar:
+              type: number
+              minimum: 0
+              description: >
+                Maximum reactive power injection (leading / over-excited), kVAr.
+                SunSpec Model 702 maxVar.
+                CIM: PowerElectronicsConnection.maxQ.
+              x-jsonld:
+                "@id": erDeg:maxReactivePowerKvar
 
-        minReactivePowerKvar:
-          type: number
-          description: >
-            Maximum reactive power absorption (lagging / under-excited), kVAr.
-            Usually expressed as a negative value (e.g. -4 for 4 kVAr absorption).
-            SunSpec Model 702 maxVarNeg.
-            CIM: PowerElectronicsConnection.minQ.
-          x-jsonld:
-            "@id": erDeg:minReactivePowerKvar
+            minReactivePowerKvar:
+              type: number
+              description: >
+                Maximum reactive power absorption (lagging / under-excited), kVAr.
+                Usually expressed as a negative value (e.g. -4 for 4 kVAr absorption).
+                SunSpec Model 702 maxVarNeg.
+                CIM: PowerElectronicsConnection.minQ.
+              x-jsonld:
+                "@id": erDeg:minReactivePowerKvar
 
-        rideThroughCategory:
-          type: string
-          enum: [CategoryI, CategoryII, CategoryIII]
-          description: >
-            IEEE 1547-2018 abnormal operating performance category.
-            Defines voltage and frequency ride-through requirements.
-            CategoryI: basic — suitable for small DER with low grid impact.
-            CategoryII: enhanced — for distribution-connected DER where
-              ride-through improves system reliability.
-            CategoryIII: advanced — for large or transmission-connected DER
-              where grid support during disturbances is critical.
-          x-jsonld:
-            "@id": erDeg:rideThroughCategory
+            rideThroughCategory:
+              type: string
+              enum: [CategoryI, CategoryII, CategoryIII]
+              description: >
+                IEEE 1547-2018 abnormal operating performance category.
+                Defines voltage and frequency ride-through requirements.
+                CategoryI: basic — suitable for small DER with low grid impact.
+                CategoryII: enhanced — for distribution-connected DER where
+                  ride-through improves system reliability.
+                CategoryIII: advanced — for large or transmission-connected DER
+                  where grid support during disturbances is critical.
+              x-jsonld:
+                "@id": erDeg:rideThroughCategory
 
-        operatingMode:
-          type: string
-          enum: [GridFollowing, GridForming, Standby]
-          description: >
-            Inverter grid-interaction mode.
-            GridFollowing: synchronises phase angle and frequency to existing
-              grid voltage/frequency reference (PLL-based; typical for DER).
-            GridForming: establishes its own V/f reference without external
-              synchronisation — enables microgrid islanding and black-start.
-            Standby: inverter energised but not injecting real power.
-            CIM: PowerElectronicsConnection.inverterMode.
-          x-jsonld:
-            "@id": erDeg:operatingMode
+            operatingMode:
+              type: string
+              enum: [GridFollowing, GridForming, Standby]
+              description: >
+                Inverter grid-interaction mode.
+                GridFollowing: synchronises phase angle and frequency to existing
+                  grid voltage/frequency reference (PLL-based; typical for DER).
+                GridForming: establishes its own V/f reference without external
+                  synchronisation — enables microgrid islanding and black-start.
+                Standby: inverter energised but not injecting real power.
+                CIM: PowerElectronicsConnection.inverterMode.
+              x-jsonld:
+                "@id": erDeg:operatingMode
 
-        voltVarEnabled:
-          type: boolean
-          description: >
-            Volt-VAr curve active — autonomous reactive power response as a
-            function of terminal voltage. IEEE 2030.5 opModVoltVar /
-            SunSpec Model 705 (Volt-VAr).
-          x-jsonld:
-            "@id": erDeg:voltVarEnabled
+            voltVarEnabled:
+              type: boolean
+              description: >
+                Volt-VAr curve active — autonomous reactive power response as a
+                function of terminal voltage. IEEE 2030.5 opModVoltVar /
+                SunSpec Model 705 (Volt-VAr).
+              x-jsonld:
+                "@id": erDeg:voltVarEnabled
 
-        freqDroopEnabled:
-          type: boolean
-          description: >
-            Frequency-Watt droop active — active power output reduced
-            proportionally to over-frequency deviation.
-            SunSpec Model 711 (Freq-Watt) / IEEE 1547-2018 Frequency-Watt.
-          x-jsonld:
-            "@id": erDeg:freqDroopEnabled
+            freqDroopEnabled:
+              type: boolean
+              description: >
+                Frequency-Watt droop active — active power output reduced
+                proportionally to over-frequency deviation.
+                SunSpec Model 711 (Freq-Watt) / IEEE 1547-2018 Frequency-Watt.
+              x-jsonld:
+                "@id": erDeg:freqDroopEnabled
 
-        enterServiceRampTimeSec:
-          type: number
-          minimum: 0
-          description: >
-            Time in seconds to ramp from 0 to rated power after reconnection
-            to the grid. Controls inrush on re-energisation.
-            SunSpec Model 703 ESRmpTms.
-          x-jsonld:
-            "@id": erDeg:enterServiceRampTimeSec
+            enterServiceRampTimeSec:
+              type: number
+              minimum: 0
+              description: >
+                Time in seconds to ramp from 0 to rated power after reconnection
+                to the grid. Controls inrush on re-energisation.
+                SunSpec Model 703 ESRmpTms.
+              x-jsonld:
+                "@id": erDeg:enterServiceRampTimeSec

--- a/specification/schema/EnergyResourceInverter/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceInverter/v1.0/attributes.yaml
@@ -1,0 +1,258 @@
+openapi: 3.1.1
+info:
+  title: EnergyResourceInverter
+  version: 1.0.0
+  description: |
+    Typed attribute schema for grid-connected power-electronics inverter
+    energy resources (type = INVERTER).
+
+    An INVERTER resource is a grid-connected power-electronics converter
+    without a dedicated fuel source. It captures reactive-power and
+    frequency-support capabilities per IEEE 1547-2018 and SunSpec DER
+    Models 702–714.
+
+    Typical use cases:
+      - Standalone battery inverters
+      - Virtual power plant (VPP) aggregation points
+      - Grid-forming inverters for microgrid islanding
+      - Reactive power compensation (STATCOM-like)
+
+    CIM alignment: PowerElectronicsConnection (IEC 61970-302).
+
+components:
+  schemas:
+
+    EnergyResourceInverter:
+      type: object
+      required: [id, type]
+      additionalProperties: false
+      description: >
+        A grid-connected power-electronics inverter energy resource. Captures
+        IEEE 1547-2018 ride-through categories, operating mode, and reactive /
+        frequency-support capabilities.
+        CIM: PowerElectronicsConnection (IEC 61970-302).
+      x-tags:
+        - energy-resource
+        - inverter
+        - energy
+        - deg
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": EnergyResourceInverter
+      properties:
+        id:
+          type: string
+          description: >
+            IES asset DID. Format: did:web:<domain>:assets:inverter:<local-id>
+            e.g. did:web:utility.com:assets:inverter:INV-001
+          example: "did:web:utility.com:assets:inverter:INV-001"
+          x-jsonld:
+            "@id": "@id"
+        type:
+          type: string
+          const: "INVERTER"
+          description: >
+            Asset-class discriminator. Must be "INVERTER".
+            CIM: PowerElectronicsConnection (IEC 61970-302).
+          x-jsonld:
+            "@id": erDeg:resourceType
+        attributes:
+          $ref: "#/components/schemas/EnergyResourceInverterAttributes"
+        subResources:
+          type: array
+          description: Child resources. Each item is a bare id string or inline resource.
+          items:
+            oneOf:
+              - type: string
+                description: id of a sibling EnergyResource.
+              - $ref: "#/components/schemas/EnergyResourceInverter"
+                description: Inline nested resource.
+        parentResources:
+          type: array
+          description: ids of parent resources (e.g. the meter this inverter is behind).
+          items:
+            type: string
+
+    EnergyResourceInverterAttributes:
+      type: object
+      additionalProperties: true
+      description: >
+        Attributes for INVERTER resources. Includes
+        EnergyResourceCommonAttributes fields (make, model, maxExportKw,
+        maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate,
+        location) plus IEEE 1547-2018 / SunSpec DER Model inverter-specific
+        fields.
+      x-jsonld:
+        "@id": erDeg:attributes
+      properties:
+
+        # ── Common attributes (EnergyResourceCommonAttributes) ────────────
+
+        make:
+          type: string
+          description: Manufacturer (free text).
+          x-jsonld:
+            "@id": erDeg:make
+
+        model:
+          type: string
+          description: Model number (free text).
+          x-jsonld:
+            "@id": erDeg:model
+
+        ratedPowerKw:
+          type: number
+          minimum: 0
+          description: >
+            Manufacturer-rated peak active power, kW. Kept for backward
+            compatibility. Prefer maxExportKw for new payloads.
+          x-jsonld:
+            "@id": erDeg:ratedPowerKw
+
+        maxExportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum active power injected to the grid, kW. Always ≥0.
+            CIM: PowerElectronicsConnection.maxP (injection direction).
+            SunSpec Model 702 maxW.
+          x-jsonld:
+            "@id": erDeg:maxExportKw
+
+        maxImportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum active power absorbed from the grid, kW. Always ≥0.
+            Set for four-quadrant inverters (grid-forming or storage-backed).
+            CIM: PowerElectronicsConnection.maxP (absorption direction).
+          x-jsonld:
+            "@id": erDeg:maxImportKw
+
+        telemetryProvider:
+          type: string
+          description: Vendor API / data source identifier for telemetry.
+          x-jsonld:
+            "@id": erDeg:telemetryProvider
+
+        commissioningDate:
+          type: string
+          format: date-time
+          description: ISO 8601 date-time when this inverter was commissioned.
+          x-jsonld:
+            "@id": deg:commissioningDate
+
+        location:
+          type: object
+          description: >
+            Physical location of this asset per beckn Location/2.0.
+            geo (required) is a GeoJSON geometry; address is a postal address.
+          required: [geo]
+          properties:
+            geo:
+              type: object
+              required: [type]
+              properties:
+                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
+                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
+                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
+              additionalProperties: true
+            address:
+              type: object
+              additionalProperties: false
+              properties:
+                streetAddress:   { type: string }
+                extendedAddress: { type: string }
+                addressLocality: { type: string }
+                addressRegion:   { type: string }
+                postalCode:      { type: string }
+                addressCountry:  { type: string }
+          x-jsonld:
+            "@id": erDeg:location
+
+        # ── Inverter-specific attributes (IEEE 1547 / SunSpec) ────────────
+
+        ratedApparentPowerKva:
+          type: number
+          minimum: 0
+          description: >
+            Rated apparent power in kVA.
+            SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS.
+          x-jsonld:
+            "@id": erDeg:ratedApparentPowerKva
+
+        maxReactivePowerKvar:
+          type: number
+          minimum: 0
+          description: >
+            Maximum reactive power injection (leading / over-excited), kVAr.
+            SunSpec Model 702 maxVar.
+            CIM: PowerElectronicsConnection.maxQ.
+          x-jsonld:
+            "@id": erDeg:maxReactivePowerKvar
+
+        minReactivePowerKvar:
+          type: number
+          description: >
+            Maximum reactive power absorption (lagging / under-excited), kVAr.
+            Usually expressed as a negative value (e.g. -4 for 4 kVAr absorption).
+            SunSpec Model 702 maxVarNeg.
+            CIM: PowerElectronicsConnection.minQ.
+          x-jsonld:
+            "@id": erDeg:minReactivePowerKvar
+
+        rideThroughCategory:
+          type: string
+          enum: [CategoryI, CategoryII, CategoryIII]
+          description: >
+            IEEE 1547-2018 abnormal operating performance category.
+            Defines voltage and frequency ride-through requirements.
+            CategoryI: basic — suitable for small DER with low grid impact.
+            CategoryII: enhanced — for distribution-connected DER where
+              ride-through improves system reliability.
+            CategoryIII: advanced — for large or transmission-connected DER
+              where grid support during disturbances is critical.
+          x-jsonld:
+            "@id": erDeg:rideThroughCategory
+
+        operatingMode:
+          type: string
+          enum: [GridFollowing, GridForming, Standby]
+          description: >
+            Inverter grid-interaction mode.
+            GridFollowing: synchronises phase angle and frequency to existing
+              grid voltage/frequency reference (PLL-based; typical for DER).
+            GridForming: establishes its own V/f reference without external
+              synchronisation — enables microgrid islanding and black-start.
+            Standby: inverter energised but not injecting real power.
+            CIM: PowerElectronicsConnection.inverterMode.
+          x-jsonld:
+            "@id": erDeg:operatingMode
+
+        voltVarEnabled:
+          type: boolean
+          description: >
+            Volt-VAr curve active — autonomous reactive power response as a
+            function of terminal voltage. IEEE 2030.5 opModVoltVar /
+            SunSpec Model 705 (Volt-VAr).
+          x-jsonld:
+            "@id": erDeg:voltVarEnabled
+
+        freqDroopEnabled:
+          type: boolean
+          description: >
+            Frequency-Watt droop active — active power output reduced
+            proportionally to over-frequency deviation.
+            SunSpec Model 711 (Freq-Watt) / IEEE 1547-2018 Frequency-Watt.
+          x-jsonld:
+            "@id": erDeg:freqDroopEnabled
+
+        enterServiceRampTimeSec:
+          type: number
+          minimum: 0
+          description: >
+            Time in seconds to ramp from 0 to rated power after reconnection
+            to the grid. Controls inrush on re-energisation.
+            SunSpec Model 703 ESRmpTms.
+          x-jsonld:
+            "@id": erDeg:enterServiceRampTimeSec

--- a/specification/schema/EnergyResourceInverter/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceInverter/v1.0/context.jsonld
@@ -1,0 +1,39 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
+    "deg":   "https://schema.beckn.io/deg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
+    "EnergyResourceInverter": {
+      "@id": "erDeg:EnergyResourceInverter",
+      "@context": {
+        "@version": 1.1,
+        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
+        "attributes": {
+          "@id": "erDeg:attributes",
+          "@type": "@id",
+          "@context": {
+            "make":                    { "@id": "erDeg:make",                    "@type": "xsd:string"   },
+            "model":                   { "@id": "erDeg:model",                   "@type": "xsd:string"   },
+            "ratedPowerKw":            { "@id": "erDeg:ratedPowerKw",            "@type": "xsd:decimal"  },
+            "maxExportKw":             { "@id": "erDeg:maxExportKw",             "@type": "xsd:decimal"  },
+            "maxImportKw":             { "@id": "erDeg:maxImportKw",             "@type": "xsd:decimal"  },
+            "telemetryProvider":       { "@id": "erDeg:telemetryProvider",       "@type": "xsd:string"   },
+            "commissioningDate":       { "@id": "deg:commissioningDate",         "@type": "xsd:dateTime" },
+            "location":                { "@id": "erDeg:location",                "@type": "@id"          },
+            "ratedApparentPowerKva":   { "@id": "erDeg:ratedApparentPowerKva",   "@type": "xsd:decimal"  },
+            "maxReactivePowerKvar":    { "@id": "erDeg:maxReactivePowerKvar",    "@type": "xsd:decimal"  },
+            "minReactivePowerKvar":    { "@id": "erDeg:minReactivePowerKvar",    "@type": "xsd:decimal"  },
+            "rideThroughCategory":     { "@id": "erDeg:rideThroughCategory",     "@type": "xsd:string"   },
+            "operatingMode":           { "@id": "erDeg:operatingMode",           "@type": "xsd:string"   },
+            "voltVarEnabled":          { "@id": "erDeg:voltVarEnabled",          "@type": "xsd:boolean"  },
+            "freqDroopEnabled":        { "@id": "erDeg:freqDroopEnabled",        "@type": "xsd:boolean"  },
+            "enterServiceRampTimeSec": { "@id": "erDeg:enterServiceRampTimeSec", "@type": "xsd:decimal"  }
+          }
+        },
+        "subResources":    { "@id": "erDeg:subResources",    "@container": "@list" },
+        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+      }
+    }
+  }
+}

--- a/specification/schema/EnergyResourceInverter/v1.0/schema.json
+++ b/specification/schema/EnergyResourceInverter/v1.0/schema.json
@@ -2,123 +2,71 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceInverter/v1.0",
   "title": "EnergyResourceInverter",
-  "description": "Typed schema for grid-connected power-electronics inverter energy resources (type = INVERTER). Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302).",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<domain>:assets:inverter:<local-id>. Example: did:web:utility.com:assets:inverter:INV-001"
-    },
-    "type": {
-      "type": "string",
-      "const": "INVERTER",
-      "description": "Asset-class discriminator. Must be \"INVERTER\". CIM: PowerElectronicsConnection (IEC 61970-302)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceInverterAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources. Each item is a bare id string or an inline EnergyResourceInverter object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
+  "description": "Typed schema for grid-connected power-electronics inverter energy resources (type = INVERTER). Captures IEEE 1547-2018 ride-through categories, operating mode, and reactive/frequency-support capabilities per SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302). Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "INVERTER",
+          "description": "Asset-class discriminator. Must be \"INVERTER\". CIM: PowerElectronicsConnection (IEC 61970-302)."
+        },
+        "attributes": { "$ref": "#/$defs/EnergyResourceInverterAttributes" }
       }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent resources (e.g. the meter this inverter is behind).",
-      "items": { "type": "string", "minLength": 1 }
     }
-  },
+  ],
   "$defs": {
-    "GeoJSONGeometry": {
-      "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326).",
-      "required": ["type"],
-      "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
     "EnergyResourceInverterAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for INVERTER resources. Includes common fields (make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate, location) plus IEEE 1547-2018 / SunSpec DER inverter-specific fields.",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak active power, kW. Kept for backward compatibility. Prefer maxExportKw." },
-        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum active power injected to the grid, kW. Always ≥0. SunSpec Model 702 maxW. CIM: PowerElectronicsConnection.maxP (injection)." },
-        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum active power absorbed from the grid, kW. Always ≥0. Set for four-quadrant inverters. CIM: PowerElectronicsConnection.maxP (absorption)." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this inverter was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "ratedApparentPowerKva": {
-          "type": "number", "minimum": 0,
-          "description": "Rated apparent power in kVA. SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS."
-        },
-        "maxReactivePowerKvar": {
-          "type": "number", "minimum": 0,
-          "description": "Maximum reactive power injection (leading / over-excited), kVAr. SunSpec Model 702 maxVar. CIM: PowerElectronicsConnection.maxQ."
-        },
-        "minReactivePowerKvar": {
-          "type": "number",
-          "description": "Maximum reactive power absorption (lagging / under-excited), kVAr. Usually negative. SunSpec Model 702 maxVarNeg. CIM: PowerElectronicsConnection.minQ."
-        },
-        "rideThroughCategory": {
-          "type": "string",
-          "enum": ["CategoryI", "CategoryII", "CategoryIII"],
-          "description": "IEEE 1547-2018 abnormal operating performance category. CategoryI: basic. CategoryII: enhanced (distribution DER). CategoryIII: advanced (large/transmission-connected DER)."
-        },
-        "operatingMode": {
-          "type": "string",
-          "enum": ["GridFollowing", "GridForming", "Standby"],
-          "description": "Grid-interaction mode. GridFollowing: PLL-based synchronisation to existing grid (typical DER). GridForming: establishes V/f reference for microgrid islanding. Standby: energised but not injecting. CIM: PowerElectronicsConnection.inverterMode."
-        },
-        "voltVarEnabled": {
-          "type": "boolean",
-          "description": "Volt-VAr curve active — autonomous reactive power response vs. terminal voltage. IEEE 2030.5 opModVoltVar / SunSpec Model 705."
-        },
-        "freqDroopEnabled": {
-          "type": "boolean",
-          "description": "Frequency-Watt droop active — active power reduced proportionally to over-frequency deviation. SunSpec Model 711 / IEEE 1547-2018 Frequency-Watt."
-        },
-        "enterServiceRampTimeSec": {
-          "type": "number", "minimum": 0,
-          "description": "Ramp time in seconds from 0 to rated power after reconnection. SunSpec Model 703 ESRmpTms."
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for INVERTER resources. Common fields inherited. IEEE 1547-2018 / SunSpec inverter-specific fields below.",
+          "properties": {
+            "ratedApparentPowerKva": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Rated apparent power in kVA. SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS."
+            },
+            "maxReactivePowerKvar": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Maximum reactive power injection (leading / over-excited), kVAr. SunSpec Model 702 maxVar. CIM: PowerElectronicsConnection.maxQ."
+            },
+            "minReactivePowerKvar": {
+              "type": "number",
+              "description": "Maximum reactive power absorption (lagging / under-excited), kVAr. Usually expressed as a negative value. SunSpec Model 702 maxVarNeg. CIM: PowerElectronicsConnection.minQ."
+            },
+            "rideThroughCategory": {
+              "type": "string",
+              "enum": ["CategoryI", "CategoryII", "CategoryIII"],
+              "description": "IEEE 1547-2018 abnormal operating performance category. CategoryI: basic. CategoryII: enhanced for distribution-connected DER. CategoryIII: advanced for large/transmission-connected DER."
+            },
+            "operatingMode": {
+              "type": "string",
+              "enum": ["GridFollowing", "GridForming", "Standby"],
+              "description": "Inverter grid-interaction mode. GridFollowing: PLL-based sync to grid. GridForming: establishes own V/f reference (microgrid islanding, black-start). Standby: energised but not injecting. CIM: PowerElectronicsConnection.inverterMode."
+            },
+            "voltVarEnabled": {
+              "type": "boolean",
+              "description": "Volt-VAr curve active — autonomous reactive power response as function of terminal voltage. IEEE 2030.5 opModVoltVar / SunSpec Model 705."
+            },
+            "freqDroopEnabled": {
+              "type": "boolean",
+              "description": "Frequency-Watt droop active — active power reduced proportionally to over-frequency deviation. SunSpec Model 711 / IEEE 1547-2018 Frequency-Watt."
+            },
+            "enterServiceRampTimeSec": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Time in seconds to ramp from 0 to rated power after reconnection to the grid. SunSpec Model 703 ESRmpTms."
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceInverter/v1.0/schema.json
+++ b/specification/schema/EnergyResourceInverter/v1.0/schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.beckn.io/EnergyResourceInverter/v1.0",
+  "title": "EnergyResourceInverter",
+  "description": "Typed schema for grid-connected power-electronics inverter energy resources (type = INVERTER). Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302).",
+  "type": "object",
+  "required": ["id", "type"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "IES asset DID. Format: did:web:<domain>:assets:inverter:<local-id>. Example: did:web:utility.com:assets:inverter:INV-001"
+    },
+    "type": {
+      "type": "string",
+      "const": "INVERTER",
+      "description": "Asset-class discriminator. Must be \"INVERTER\". CIM: PowerElectronicsConnection (IEC 61970-302)."
+    },
+    "attributes": {
+      "$ref": "#/$defs/EnergyResourceInverterAttributes"
+    },
+    "subResources": {
+      "type": "array",
+      "description": "Child resources. Each item is a bare id string or an inline EnergyResourceInverter object.",
+      "items": {
+        "oneOf": [
+          { "type": "string", "minLength": 1 },
+          { "$ref": "#" }
+        ]
+      }
+    },
+    "parentResources": {
+      "type": "array",
+      "description": "ids of parent resources (e.g. the meter this inverter is behind).",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "GeoJSONGeometry": {
+      "type": "object",
+      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326).",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
+        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
+        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
+        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
+      },
+      "additionalProperties": true
+    },
+    "Address": {
+      "type": "object",
+      "description": "schema.org PostalAddress per beckn Address/2.0.",
+      "additionalProperties": false,
+      "properties": {
+        "streetAddress": { "type": "string" },
+        "extendedAddress": { "type": "string" },
+        "addressLocality": { "type": "string" },
+        "addressRegion": { "type": "string" },
+        "postalCode": { "type": "string" },
+        "addressCountry": { "type": "string" }
+      }
+    },
+    "Location": {
+      "type": "object",
+      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address.",
+      "required": ["geo"],
+      "properties": {
+        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
+        "address": { "$ref": "#/$defs/Address" }
+      }
+    },
+    "EnergyResourceInverterAttributes": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Attributes for INVERTER resources. Includes common fields (make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate, location) plus IEEE 1547-2018 / SunSpec DER inverter-specific fields.",
+      "properties": {
+        "make": { "type": "string", "description": "Manufacturer (free text)." },
+        "model": { "type": "string", "description": "Model number (free text)." },
+        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak active power, kW. Kept for backward compatibility. Prefer maxExportKw." },
+        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum active power injected to the grid, kW. Always ≥0. SunSpec Model 702 maxW. CIM: PowerElectronicsConnection.maxP (injection)." },
+        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum active power absorbed from the grid, kW. Always ≥0. Set for four-quadrant inverters. CIM: PowerElectronicsConnection.maxP (absorption)." },
+        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
+        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this inverter was commissioned." },
+        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
+        "ratedApparentPowerKva": {
+          "type": "number", "minimum": 0,
+          "description": "Rated apparent power in kVA. SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS."
+        },
+        "maxReactivePowerKvar": {
+          "type": "number", "minimum": 0,
+          "description": "Maximum reactive power injection (leading / over-excited), kVAr. SunSpec Model 702 maxVar. CIM: PowerElectronicsConnection.maxQ."
+        },
+        "minReactivePowerKvar": {
+          "type": "number",
+          "description": "Maximum reactive power absorption (lagging / under-excited), kVAr. Usually negative. SunSpec Model 702 maxVarNeg. CIM: PowerElectronicsConnection.minQ."
+        },
+        "rideThroughCategory": {
+          "type": "string",
+          "enum": ["CategoryI", "CategoryII", "CategoryIII"],
+          "description": "IEEE 1547-2018 abnormal operating performance category. CategoryI: basic. CategoryII: enhanced (distribution DER). CategoryIII: advanced (large/transmission-connected DER)."
+        },
+        "operatingMode": {
+          "type": "string",
+          "enum": ["GridFollowing", "GridForming", "Standby"],
+          "description": "Grid-interaction mode. GridFollowing: PLL-based synchronisation to existing grid (typical DER). GridForming: establishes V/f reference for microgrid islanding. Standby: energised but not injecting. CIM: PowerElectronicsConnection.inverterMode."
+        },
+        "voltVarEnabled": {
+          "type": "boolean",
+          "description": "Volt-VAr curve active — autonomous reactive power response vs. terminal voltage. IEEE 2030.5 opModVoltVar / SunSpec Model 705."
+        },
+        "freqDroopEnabled": {
+          "type": "boolean",
+          "description": "Frequency-Watt droop active — active power reduced proportionally to over-frequency deviation. SunSpec Model 711 / IEEE 1547-2018 Frequency-Watt."
+        },
+        "enterServiceRampTimeSec": {
+          "type": "number", "minimum": 0,
+          "description": "Ramp time in seconds from 0 to rated power after reconnection. SunSpec Model 703 ESRmpTms."
+        }
+      }
+    }
+  }
+}

--- a/specification/schema/EnergyResourceInverter/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceInverter/v1.0/vocab.jsonld
@@ -1,0 +1,165 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "erDeg":  "https://schema.beckn.io/deg/EnergyResource/",
+    "deg":    "https://schema.beckn.io/deg#",
+    "rdf":    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":   "http://www.w3.org/2000/01/rdf-schema#",
+    "owl":    "http://www.w3.org/2002/07/owl#",
+    "xsd":    "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/",
+    "skos":   "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "erDeg:EnergyResourceInverter",
+      "@type": "rdfs:Class",
+      "rdfs:label": "EnergyResource — Inverter",
+      "rdfs:comment": "Grid-connected power-electronics converter without a dedicated fuel source. Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302).",
+      "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#PowerElectronicsConnection" }
+    },
+    {
+      "@id": "erDeg:resourceType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Resource type discriminator",
+      "rdfs:comment": "Asset-class discriminator. For EnergyResourceInverter the value is always INVERTER.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:make",
+      "@type": "rdf:Property",
+      "rdfs:label": "Manufacturer",
+      "rdfs:comment": "Manufacturer name of the energy resource.",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:model",
+      "@type": "rdf:Property",
+      "rdfs:label": "Model",
+      "rdfs:comment": "Model number of the energy resource.",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:ratedPowerKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Rated power (kW)",
+      "rdfs:comment": "Manufacturer-rated peak active power in kilowatts. Kept for backward compatibility. Prefer maxExportKw.",
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:maxExportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max export power (kW)",
+      "rdfs:comment": "Maximum active power injected to the grid, kW. Always ≥0. SunSpec Model 702 maxW. CIM: PowerElectronicsConnection.maxP (injection direction).",
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:maxImportKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max import power (kW)",
+      "rdfs:comment": "Maximum active power absorbed from the grid, kW. Always ≥0. Set for four-quadrant inverters. CIM: PowerElectronicsConnection.maxP (absorption direction).",
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:telemetryProvider",
+      "@type": "rdf:Property",
+      "rdfs:label": "Telemetry provider",
+      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:commissioningDate",
+      "@type": "rdf:Property",
+      "rdfs:label": "Commissioning date",
+      "rdfs:comment": "ISO 8601 date-time when the asset was commissioned.",
+      "schema:rangeIncludes": { "@id": "xsd:dateTime" }
+    },
+    {
+      "@id": "erDeg:location",
+      "@type": "rdf:Property",
+      "rdfs:label": "Location",
+      "rdfs:comment": "Physical location per beckn Location/2.0: geo (GeoJSON Point, coordinates [lon, lat]) + optional postal address.",
+      "schema:rangeIncludes": { "@id": "schema:Place" }
+    },
+    {
+      "@id": "erDeg:ratedApparentPowerKva",
+      "@type": "rdf:Property",
+      "rdfs:label": "Rated apparent power (kVA)",
+      "rdfs:comment": "Rated apparent power in kVA. SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:maxReactivePowerKvar",
+      "@type": "rdf:Property",
+      "rdfs:label": "Max reactive power (kVAr)",
+      "rdfs:comment": "Maximum reactive power injection (leading / over-excited), kVAr. SunSpec Model 702 maxVar. CIM: PowerElectronicsConnection.maxQ.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:minReactivePowerKvar",
+      "@type": "rdf:Property",
+      "rdfs:label": "Min reactive power (kVAr)",
+      "rdfs:comment": "Maximum reactive power absorption (lagging / under-excited), kVAr. Usually negative. SunSpec Model 702 maxVarNeg. CIM: PowerElectronicsConnection.minQ.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:rideThroughCategory",
+      "@type": "rdf:Property",
+      "rdfs:label": "Ride-through category",
+      "rdfs:comment": "IEEE 1547-2018 abnormal operating performance category. CategoryI: basic. CategoryII: enhanced (distribution DER). CategoryIII: advanced (large/transmission-connected DER).",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:string" },
+      "rdfs:seeAlso": { "@id": "https://standards.ieee.org/ieee/1547/6616/" }
+    },
+    {
+      "@id": "erDeg:operatingMode",
+      "@type": "rdf:Property",
+      "rdfs:label": "Operating mode",
+      "rdfs:comment": "Grid-interaction mode. GridFollowing: PLL-based synchronisation (typical DER). GridForming: establishes V/f reference for islanding. Standby: energised, not injecting. CIM: PowerElectronicsConnection.inverterMode.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "erDeg:voltVarEnabled",
+      "@type": "rdf:Property",
+      "rdfs:label": "Volt-VAr enabled",
+      "rdfs:comment": "Volt-VAr curve active — autonomous reactive power response vs. terminal voltage. IEEE 2030.5 opModVoltVar / SunSpec Model 705.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:boolean" }
+    },
+    {
+      "@id": "erDeg:freqDroopEnabled",
+      "@type": "rdf:Property",
+      "rdfs:label": "Freq-droop enabled",
+      "rdfs:comment": "Frequency-Watt droop active — active power reduced proportionally to over-frequency deviation. SunSpec Model 711 / IEEE 1547-2018 Frequency-Watt.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:boolean" }
+    },
+    {
+      "@id": "erDeg:enterServiceRampTimeSec",
+      "@type": "rdf:Property",
+      "rdfs:label": "Enter service ramp time (s)",
+      "rdfs:comment": "Ramp time in seconds from 0 to rated power after reconnection. SunSpec Model 703 ESRmpTms.",
+      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "erDeg:subResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "Sub-resources",
+      "rdfs:comment": "Child resources in the topology tree.",
+      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceInverter" }
+    },
+    {
+      "@id": "erDeg:parentResources",
+      "@type": "rdf:Property",
+      "rdfs:label": "Parent resources",
+      "rdfs:comment": "ids of parent resources (e.g. the meter this inverter is behind).",
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    }
+  ]
+}

--- a/specification/schema/EnergyResourceLoad/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceLoad/v1.0/attributes.yaml
@@ -14,13 +14,14 @@ info:
     programs, responding to OpenADR, OCPP, SunSpec Modbus, EEBus, or
     Modbus control signals.
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceLoad:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
         A controllable load energy resource (smart HVAC, smart water heater,
         or generic controllable load). Corresponds to cim:EnergyConsumer /
@@ -35,151 +36,68 @@ components:
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceLoad
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>
-            e.g. did:web:bescom.karnataka.gov.in:assets:load:HVAC-001
-          example: "did:web:bescom.karnataka.gov.in:assets:load:HVAC-001"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          enum:
-            - SMART_HVAC
-            - SMART_WATER_HEATER
-            - CONTROLLABLE_LOAD
-          description: >
-            Asset-class discriminator. CIM: EnergyConsumer / ConformLoad
-            (IEC 61970-301).
-          x-cim-class: cim:ConformLoad
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceLoadAttributes"
-        subResources:
-          type: array
-          description: >
-            Child resources (e.g. individual zones of an HVAC system). Each
-            item is a bare id string or an inline EnergyResourceLoad object.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource in the same payload.
-              - $ref: "#/components/schemas/EnergyResourceLoad"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: >
-            ids of parent resources (e.g. the meter this load sits behind).
-            String references only.
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              enum:
+                - SMART_HVAC
+                - SMART_WATER_HEATER
+                - CONTROLLABLE_LOAD
+              description: >
+                Asset-class discriminator. CIM: EnergyConsumer / ConformLoad
+                (IEC 61970-301).
+              x-cim-class: cim:ConformLoad
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceLoadAttributes"
 
     EnergyResourceLoadAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for controllable load resources. Includes EnergyResourceCommonAttributes
-        fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location)
-        plus load-specific fields (controlProtocol, loadCategory).
+        Attributes for controllable load resources. Common fields (make, model,
+        ratedPowerKw, maxExportKw, maxImportKw, telemetryProvider, commissioningDate,
+        location) are inherited from EnergyResourceCommonAttributes via allOf.
+        Only load-specific fields are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ──────────────
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power draw, kW. CIM: GeneratingUnit.maxOperatingP.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this load was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              description: GeoJSON geometry — coordinates are [longitude, latitude].
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                geometries: { type: array }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              description: schema.org PostalAddress fields.
-              properties:
-                streetAddress: { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion: { type: string }
-                postalCode: { type: string }
-                addressCountry: { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── Load-specific attributes ─────────────────────────────────────────
-        controlProtocol:
-          type: string
-          enum:
-            - OpenADR_2.0b
-            - OCPP_2.0.1
-            - SunSpec_Modbus
-            - EEBus
-            - Modbus
-            - Other
-          description: >
-            Demand-response / control protocol supported by this load device.
-          x-jsonld:
-            "@id": erDeg:controlProtocol
+            # ── Load-specific attributes ──────────────────────────────────────
 
-        loadCategory:
-          type: string
-          enum:
-            - Heating
-            - Cooling
-            - WaterHeating
-            - Lighting
-            - EV
-            - Industrial
-            - Other
-          description: >
-            Functional category of this load. CIM: ConformLoad.conformLoadSchedule /
-            load classification.
-          x-jsonld:
-            "@id": erDeg:loadCategory
+            controlProtocol:
+              type: string
+              enum:
+                - OpenADR_2.0b
+                - OCPP_2.0.1
+                - SunSpec_Modbus
+                - EEBus
+                - Modbus
+                - Other
+              description: >
+                Demand-response / control protocol supported by this load device.
+              x-jsonld:
+                "@id": erDeg:controlProtocol
+
+            loadCategory:
+              type: string
+              enum:
+                - Heating
+                - Cooling
+                - WaterHeating
+                - Lighting
+                - EV
+                - Industrial
+                - Other
+              description: >
+                Functional category of this load. CIM: ConformLoad.conformLoadSchedule /
+                load classification.
+              x-jsonld:
+                "@id": erDeg:loadCategory

--- a/specification/schema/EnergyResourceLoad/v1.0/schema.json
+++ b/specification/schema/EnergyResourceLoad/v1.0/schema.json
@@ -2,97 +2,44 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceLoad/v1.0",
   "title": "EnergyResourceLoad",
-  "description": "Typed schema for controllable load energy resources (smart HVAC, smart water heater, generic controllable load). These assets participate in demand-response and demand-flexibility programs. CIM: cim:EnergyConsumer / cim:ConformLoad (IEC 61970-301).",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>. Example: did:web:bescom.karnataka.gov.in:assets:load:HVAC-001"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["SMART_HVAC", "SMART_WATER_HEATER", "CONTROLLABLE_LOAD"],
-      "description": "Asset-class discriminator. CIM: EnergyConsumer / ConformLoad (IEC 61970-301)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceLoadAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources (e.g. individual zones of an HVAC system). Each item is a bare id string or an inline EnergyResource object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
-      }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent resources (e.g. the meter this load sits behind).",
-      "items": { "type": "string", "minLength": 1 }
-    }
-  },
-  "$defs": {
-    "GeoJSONGeometry": {
+  "description": "Typed schema for controllable load energy resources (smart HVAC, smart water heater, generic controllable load). Participate in demand-response and demand-flexibility programs. CIM: cim:EnergyConsumer / cim:ConformLoad (IEC 61970-301). Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
       "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326). For a point: {type: 'Point', coordinates: [lon, lat]}.",
-      "required": ["type"],
+      "required": ["id", "type"],
       "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
-    "EnergyResourceLoadAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for controllable load resources. Includes common fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location) plus load-specific fields (controlProtocol, loadCategory).",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power draw, kW. CIM: GeneratingUnit.maxOperatingP." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this load was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "controlProtocol": {
+        "type": {
           "type": "string",
-          "enum": ["OpenADR_2.0b", "OCPP_2.0.1", "SunSpec_Modbus", "EEBus", "Modbus", "Other"],
-          "description": "Demand-response / control protocol supported by this load device."
+          "enum": ["SMART_HVAC", "SMART_WATER_HEATER", "CONTROLLABLE_LOAD"],
+          "description": "Asset-class discriminator. CIM: EnergyConsumer / ConformLoad (IEC 61970-301)."
         },
-        "loadCategory": {
-          "type": "string",
-          "enum": ["Heating", "Cooling", "WaterHeating", "Lighting", "EV", "Industrial", "Other"],
-          "description": "Functional category of this load. CIM: ConformLoad.conformLoadSchedule / load classification."
-        }
+        "attributes": { "$ref": "#/$defs/EnergyResourceLoadAttributes" }
       }
+    }
+  ],
+  "$defs": {
+    "EnergyResourceLoadAttributes": {
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for controllable load resources. Common fields inherited. Load-specific fields below.",
+          "properties": {
+            "controlProtocol": {
+              "type": "string",
+              "enum": ["OpenADR_2.0b", "OCPP_2.0.1", "SunSpec_Modbus", "EEBus", "Modbus", "Other"],
+              "description": "Demand-response / control protocol supported by this load device."
+            },
+            "loadCategory": {
+              "type": "string",
+              "enum": ["Heating", "Cooling", "WaterHeating", "Lighting", "EV", "Industrial", "Other"],
+              "description": "Functional category of this load. CIM: ConformLoad.conformLoadSchedule / load classification."
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceMeter/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceMeter/v1.0/attributes.yaml
@@ -12,13 +12,14 @@ info:
 
     Type discriminator: type must equal "METER".
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceMeter:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
         A metering-point energy resource. Anchors all DER sub-resources behind
         it in the topology tree. Corresponds to cim:Meter (IEC 61968-9).
@@ -30,242 +31,157 @@ components:
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceMeter
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>
-            e.g. did:web:bescom.karnataka.gov.in:assets:meter:MET-001
-          example: "did:web:bescom.karnataka.gov.in:assets:meter:MET-001"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          const: "METER"
-          description: >
-            Asset-class discriminator. Must be "METER". CIM: cim:Meter
-            (IEC 61968-9 EndDevice subtype).
-          x-cim-class: cim:Meter
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceMeterAttributes"
-        subResources:
-          type: array
-          description: >
-            Child resources behind this meter (DERs, storage, loads).
-            Each item is a bare id string or an inline EnergyResourceMeter object.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource in the same payload.
-              - $ref: "#/components/schemas/EnergyResourceMeter"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: >
-            ids of parent resources (e.g. feeder or substation this meter
-            is supplied from). String references only.
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              const: "METER"
+              description: >
+                Asset-class discriminator. Must be "METER". CIM: cim:Meter
+                (IEC 61968-9 EndDevice subtype).
+              x-cim-class: cim:Meter
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceMeterAttributes"
 
     EnergyResourceMeterAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for METER resources. Includes EnergyResourceCommonAttributes
-        fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location)
-        plus meter-specific fields (meterCapability, energyDirection, functions,
-        feeder, bus, communicationTechnology).
+        Attributes for METER resources. Common fields (make, model, ratedPowerKw,
+        maxExportKw, maxImportKw, telemetryProvider, commissioningDate, location)
+        are inherited from EnergyResourceCommonAttributes via allOf.
+        Only meter-specific fields are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ──────────────
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power, kW. CIM: GeneratingUnit.maxOperatingP.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this meter was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              description: GeoJSON geometry — coordinates are [longitude, latitude].
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                geometries: { type: array }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              description: schema.org PostalAddress fields.
-              properties:
-                streetAddress: { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion: { type: string }
-                postalCode: { type: string }
-                addressCountry: { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── Meter-specific attributes ────────────────────────────────────────
+            # ── Meter-specific attributes ──────────────────────────────────────
 
-        meterCapability:
-          type: string
-          enum:
-            - Electromechanical
-            - CMRI
-            - AMR
-            - AMI
-          description: >
-            Communication/automation generation of the meter hardware.
-            Electromechanical: induction-disc, no remote comms.
-            CMRI: static solid-state, manual optical-port read via Common Meter
-            Reading Instrument (India legacy AMR).
-            AMR: one-way automated read (periodic push); no remote commands.
-            AMI: two-way smart meter; supports remote disconnect, OTA, real-time
-            data. CIM alignment: maps to IEC 61968-9 AmiBillingReadyKind
-            (nonAmi → Electromechanical/CMRI, amiCapable/operable → AMR,
-            enabled/billingApproved → AMI).
-          x-cim-class: cim:AmiBillingReadyKind
-          x-jsonld:
-            "@id": erDeg:meterCapability
+            meterCapability:
+              type: string
+              enum:
+                - Electromechanical
+                - CMRI
+                - AMR
+                - AMI
+              description: >
+                Communication/automation generation of the meter hardware.
+                Electromechanical: induction-disc, no remote comms.
+                CMRI: static solid-state, manual optical-port read via Common Meter
+                Reading Instrument (India legacy AMR).
+                AMR: one-way automated read (periodic push); no remote commands.
+                AMI: two-way smart meter; supports remote disconnect, OTA, real-time
+                data. CIM alignment: maps to IEC 61968-9 AmiBillingReadyKind
+                (nonAmi → Electromechanical/CMRI, amiCapable/operable → AMR,
+                enabled/billingApproved → AMI).
+              x-cim-class: cim:AmiBillingReadyKind
+              x-jsonld:
+                "@id": erDeg:meterCapability
 
-        energyDirection:
-          type: string
-          enum:
-            - Forward
-            - Reverse
-            - Bidirectional
-            - Net
-          default: Forward
-          description: >
-            Direction(s) of energy flow metered at this point.
-            Forward: import from grid to customer only (default; standard load meter).
-            Reverse: export from customer to grid only (e.g. dedicated gross-export
-            meter in a solar feed-in tariff scheme).
-            Bidirectional: import and export measured in separate registers on the
-            same meter (prosumer / net-metering installation with separate kWh
-            registers for each direction).
-            Net: algebraically netted register — |import| − |export| — meter stores
-            only the running net balance.
-            CIM: maps to IEC 61968-9 / ESPI NAESB REQ.21 FlowDirectionKind
-            (1=Forward, 19=Reverse, 4=Net; Bidirectional implies both 1 and 19).
-          x-cim-class: cim:FlowDirectionKind
-          x-jsonld:
-            "@id": erDeg:energyDirection
+            energyDirection:
+              type: string
+              enum:
+                - Forward
+                - Reverse
+                - Bidirectional
+                - Net
+              default: Forward
+              description: >
+                Direction(s) of energy flow metered at this point.
+                Forward: import from grid to customer only (default; standard load meter).
+                Reverse: export from customer to grid only (e.g. dedicated gross-export
+                meter in a solar feed-in tariff scheme).
+                Bidirectional: import and export measured in separate registers on the
+                same meter (prosumer / net-metering installation with separate kWh
+                registers for each direction).
+                Net: algebraically netted register — |import| − |export| — meter stores
+                only the running net balance.
+                CIM: maps to IEC 61968-9 / ESPI NAESB REQ.21 FlowDirectionKind
+                (1=Forward, 19=Reverse, 4=Net; Bidirectional implies both 1 and 19).
+              x-cim-class: cim:FlowDirectionKind
+              x-jsonld:
+                "@id": erDeg:energyDirection
 
-        functions:
-          type: array
-          uniqueItems: true
-          description: >
-            Set of optional capabilities or features active on this meter.
-            Modelled as a bag (unordered, no duplicates) per IEC 61968-9
-            EndDeviceFunction[0..*] pattern. Multiple values are valid simultaneously
-            (e.g. ["ToU", "NetMetering", "MaxDemand"]).
-          items:
-            type: string
-            enum:
-              - ToU
-              - NetMetering
-              - MaxDemand
-              - LoadControl
-              - TamperDetection
-              - PowerQuality
-              - EventLogging
-            description: >
-              ToU: time-of-use / time-of-day tariff registers.
-              NetMetering: net-metering tariff scheme active (prosumer).
-              MaxDemand: maximum demand register (kW or kVA, 15/30-min interval).
-              LoadControl: demand-response relay / remote load control capability.
-              TamperDetection: anti-tamper magnetic/optical detection.
-              PowerQuality: harmonics, voltage sag/swell, power factor monitoring.
-              EventLogging: tamper/connect/disconnect audit log.
-          x-cim-class: cim:EndDeviceFunctionKind
-          x-jsonld:
-            "@id": erDeg:functions
+            functions:
+              type: array
+              uniqueItems: true
+              description: >
+                Set of optional capabilities or features active on this meter.
+                Modelled as a bag (unordered, no duplicates) per IEC 61968-9
+                EndDeviceFunction[0..*] pattern. Multiple values are valid simultaneously
+                (e.g. ["ToU", "NetMetering", "MaxDemand"]).
+              items:
+                type: string
+                enum:
+                  - ToU
+                  - NetMetering
+                  - MaxDemand
+                  - LoadControl
+                  - TamperDetection
+                  - PowerQuality
+                  - EventLogging
+                description: >
+                  ToU: time-of-use / time-of-day tariff registers.
+                  NetMetering: net-metering tariff scheme active (prosumer).
+                  MaxDemand: maximum demand register (kW or kVA, 15/30-min interval).
+                  LoadControl: demand-response relay / remote load control capability.
+                  TamperDetection: anti-tamper magnetic/optical detection.
+                  PowerQuality: harmonics, voltage sag/swell, power factor monitoring.
+                  EventLogging: tamper/connect/disconnect audit log.
+              x-cim-class: cim:EndDeviceFunctionKind
+              x-jsonld:
+                "@id": erDeg:functions
 
-        feeder:
-          type: string
-          description: Feeder identifier this meter is supplied from.
-          x-jsonld:
-            "@id": erDeg:feeder
+            feeder:
+              type: string
+              description: Feeder identifier this meter is supplied from.
+              x-jsonld:
+                "@id": erDeg:feeder
 
-        bus:
-          type: string
-          description: Busbar identifier at the meter's connection point.
-          x-jsonld:
-            "@id": erDeg:bus
+            bus:
+              type: string
+              description: Busbar identifier at the meter's connection point.
+              x-jsonld:
+                "@id": erDeg:bus
 
-        communicationTechnology:
-          type: string
-          enum:
-            - PLC
-            - RF_Mesh
-            - GPRS
-            - NB-IoT
-            - LoRa
-            - ZigBee
-            - Other
-          description: >
-            Last-mile (physical layer) communication technology used by this meter's head-end system.
-            Orthogonal to applicationProtocol (application layer).
-          x-jsonld:
-            "@id": erDeg:communicationTechnology
+            communicationTechnology:
+              type: string
+              enum:
+                - PLC
+                - RF_Mesh
+                - GPRS
+                - NB-IoT
+                - LoRa
+                - ZigBee
+                - Other
+              description: >
+                Last-mile (physical layer) communication technology used by this meter's head-end system.
+                Orthogonal to applicationProtocol (application layer).
+              x-jsonld:
+                "@id": erDeg:communicationTechnology
 
-        applicationProtocol:
-          type: string
-          enum:
-            - DLMS_COSEM
-            - ANSI_C12_18
-            - IEC_61850
-            - Modbus
-            - Other
-          description: >
-            Application-layer protocol used to read/communicate meter data.
-            DLMS_COSEM: IEC 62056, dominant in India and Europe; mandatory for
-            India AMI per BIS IS 16444 / CEA specification.
-            ANSI_C12_18: North American optical-port / table-data model (ANSI C12.18/C12.19).
-            IEC_61850: substation automation and smart grid messaging.
-            Modbus: legacy industrial serial protocol.
-            Orthogonal to communicationTechnology (physical layer).
-          x-jsonld:
-            "@id": erDeg:applicationProtocol
+            applicationProtocol:
+              type: string
+              enum:
+                - DLMS_COSEM
+                - ANSI_C12_18
+                - IEC_61850
+                - Modbus
+                - Other
+              description: >
+                Application-layer protocol used to read/communicate meter data.
+                DLMS_COSEM: IEC 62056, dominant in India and Europe; mandatory for
+                India AMI per BIS IS 16444 / CEA specification.
+                ANSI_C12_18: North American optical-port / table-data model (ANSI C12.18/C12.19).
+                IEC_61850: substation automation and smart grid messaging.
+                Modbus: legacy industrial serial protocol.
+                Orthogonal to communicationTechnology (physical layer).
+              x-jsonld:
+                "@id": erDeg:applicationProtocol

--- a/specification/schema/EnergyResourceMeter/v1.0/schema.json
+++ b/specification/schema/EnergyResourceMeter/v1.0/schema.json
@@ -2,119 +2,66 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceMeter/v1.0",
   "title": "EnergyResourceMeter",
-  "description": "Typed schema for metering-point energy resources (type = METER). CIM: cim:Meter / cim:EndDevice (IEC 61968-9). A METER anchors all DER sub-resources topologically and carries the physical installation location, feeder/bus references, and communication technology.",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<discom-domain>:assets:meter:<local-id>. Example: did:web:bescom.karnataka.gov.in:assets:meter:MET-001"
-    },
-    "type": {
-      "type": "string",
-      "const": "METER",
-      "description": "Asset-class discriminator. Must be \"METER\". CIM: cim:Meter (IEC 61968-9 EndDevice subtype)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceMeterAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources behind this meter (DERs, storage, loads). Each item is a bare id string or an inline EnergyResource object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
+  "description": "Typed schema for metering-point energy resources (type = METER). CIM: cim:Meter / cim:EndDevice (IEC 61968-9). Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "METER",
+          "description": "Asset-class discriminator. Must be \"METER\". CIM: cim:Meter (IEC 61968-9 EndDevice subtype)."
+        },
+        "attributes": { "$ref": "#/$defs/EnergyResourceMeterAttributes" }
       }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent resources (e.g. feeder or substation this meter is supplied from).",
-      "items": { "type": "string", "minLength": 1 }
     }
-  },
+  ],
   "$defs": {
-    "GeoJSONGeometry": {
-      "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326). For a point: {type: 'Point', coordinates: [lon, lat]}.",
-      "required": ["type"],
-      "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
     "EnergyResourceMeterAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for METER resources. Includes common fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location) plus meter-specific fields.",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. CIM: GeneratingUnit.maxOperatingP." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this meter was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "meterCapability": {
-          "type": "string",
-          "enum": ["Electromechanical", "CMRI", "AMR", "AMI"],
-          "description": "Communication/automation generation. Electromechanical=induction disc, no comms. CMRI=static with manual optical-port read (India legacy). AMR=one-way automated read. AMI=two-way smart meter. CIM: AmiBillingReadyKind (IEC 61968-9)."
-        },
-        "energyDirection": {
-          "type": "string",
-          "enum": ["Forward", "Reverse", "Bidirectional", "Net"],
-          "default": "Forward",
-          "description": "Energy flow direction metered. Forward=import only (default). Reverse=export only. Bidirectional=import and export in separate registers. Net=algebraically netted register. CIM: FlowDirectionKind (ESPI NAESB REQ.21)."
-        },
-        "functions": {
-          "type": "array",
-          "uniqueItems": true,
-          "description": "Bag of optional capabilities active on this meter, per IEC 61968-9 EndDeviceFunction[0..*] pattern. Multiple values valid simultaneously.",
-          "items": {
-            "type": "string",
-            "enum": ["ToU", "NetMetering", "MaxDemand", "LoadControl", "TamperDetection", "PowerQuality", "EventLogging"]
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for METER resources. Common fields inherited. Meter-specific fields below.",
+          "properties": {
+            "meterCapability": {
+              "type": "string",
+              "enum": ["Electromechanical", "CMRI", "AMR", "AMI"],
+              "description": "Communication/automation generation. Electromechanical=induction disc, no comms. CMRI=static with manual optical-port read (India legacy). AMR=one-way automated read. AMI=two-way smart meter. CIM: AmiBillingReadyKind (IEC 61968-9)."
+            },
+            "energyDirection": {
+              "type": "string",
+              "enum": ["Forward", "Reverse", "Bidirectional", "Net"],
+              "default": "Forward",
+              "description": "Energy flow direction metered. Forward=import only (default). Reverse=export only. Bidirectional=import and export in separate registers. Net=algebraically netted register. CIM: FlowDirectionKind (ESPI NAESB REQ.21)."
+            },
+            "functions": {
+              "type": "array",
+              "uniqueItems": true,
+              "description": "Bag of optional capabilities active on this meter, per IEC 61968-9 EndDeviceFunction[0..*] pattern.",
+              "items": {
+                "type": "string",
+                "enum": ["ToU", "NetMetering", "MaxDemand", "LoadControl", "TamperDetection", "PowerQuality", "EventLogging"]
+              }
+            },
+            "feeder": { "type": "string", "description": "Feeder identifier this meter is supplied from." },
+            "bus": { "type": "string", "description": "Busbar identifier at the meter's connection point." },
+            "communicationTechnology": {
+              "type": "string",
+              "enum": ["PLC", "RF_Mesh", "GPRS", "NB-IoT", "LoRa", "ZigBee", "Other"],
+              "description": "Last-mile (physical layer) communication technology used by this meter's head-end system."
+            },
+            "applicationProtocol": {
+              "type": "string",
+              "enum": ["DLMS_COSEM", "ANSI_C12_18", "IEC_61850", "Modbus", "Other"],
+              "description": "Application-layer protocol used to read/communicate meter data. DLMS_COSEM: IEC 62056 (mandatory for India AMI per BIS IS 16444). ANSI_C12_18: North American optical-port / table-data model. IEC_61850: substation automation. Modbus: legacy industrial."
+            }
           }
-        },
-        "feeder": { "type": "string", "description": "Feeder identifier this meter is supplied from." },
-        "bus": { "type": "string", "description": "Busbar identifier at the meter's connection point." },
-        "communicationTechnology": {
-          "type": "string",
-          "enum": ["PLC", "RF_Mesh", "GPRS", "NB-IoT", "LoRa", "ZigBee", "Other"],
-          "description": "Last-mile (physical layer) communication technology used by this meter's head-end system."
-        },
-        "applicationProtocol": {
-          "type": "string",
-          "enum": ["DLMS_COSEM", "ANSI_C12_18", "IEC_61850", "Modbus", "Other"],
-          "description": "Application-layer protocol used to read/communicate meter data. DLMS_COSEM: IEC 62056 (mandatory for India AMI per BIS IS 16444). ANSI_C12_18: North American optical-port / table-data model. IEC_61850: substation automation / smart grid. Modbus: legacy industrial. Orthogonal to communicationTechnology (physical layer)."
         }
-      }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceNetwork/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceNetwork/v1.0/attributes.yaml
@@ -14,13 +14,14 @@ info:
     Network resources act as topology anchors in the EnergyResource graph;
     they carry metering points and DER resources as subResources.
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceNetwork:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
         A grid-network infrastructure energy resource (distribution transformer,
         busbar, feeder, or microgrid). These are topology containers that anchor
@@ -36,151 +37,66 @@ components:
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceNetwork
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>
-            e.g. did:web:bescom.karnataka.gov.in:assets:feeder:FDR-BLR-042
-          example: "did:web:bescom.karnataka.gov.in:assets:feeder:FDR-BLR-042"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          enum:
-            - DT
-            - BUS
-            - FEEDER
-            - MICROGRID
-          description: >
-            Asset-class discriminator. CIM: DT → PowerTransformer,
-            BUS → BusbarSection, FEEDER → Feeder (EquipmentContainer),
-            MICROGRID → Substation / custom microgrid container (IEC 61970-301).
-          x-cim-class: cim:EquipmentContainer
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceNetworkAttributes"
-        subResources:
-          type: array
-          description: >
-            Child resources anchored to this network element (meters, DTs,
-            buses, feeders). Each item is a bare id string or an inline
-            EnergyResourceNetwork object.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource in the same payload.
-              - $ref: "#/components/schemas/EnergyResourceNetwork"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: >
-            ids of parent network elements (e.g. the substation or feeder
-            this DT belongs to). String references only.
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              enum:
+                - DT
+                - BUS
+                - FEEDER
+                - MICROGRID
+              description: >
+                Asset-class discriminator. CIM: DT → PowerTransformer,
+                BUS → BusbarSection, FEEDER → Feeder (EquipmentContainer),
+                MICROGRID → Substation / custom microgrid container (IEC 61970-301).
+              x-cim-class: cim:EquipmentContainer
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceNetworkAttributes"
 
     EnergyResourceNetworkAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for grid-network infrastructure resources. Includes
-        EnergyResourceCommonAttributes fields (make, model, ratedPowerKw,
-        telemetryProvider, commissioningDate, location) plus network-specific
-        fields (nominalVoltageKv, zone, substationId, feederCode).
+        Attributes for grid-network infrastructure resources. Common fields (make,
+        model, ratedPowerKw, maxExportKw, maxImportKw, telemetryProvider,
+        commissioningDate, location) are inherited from EnergyResourceCommonAttributes
+        via allOf. Only network-specific fields are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ──────────────
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power capacity, kW. CIM: GeneratingUnit.maxOperatingP.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this network element was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              description: GeoJSON geometry — coordinates are [longitude, latitude].
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                geometries: { type: array }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              description: schema.org PostalAddress fields.
-              properties:
-                streetAddress: { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion: { type: string }
-                postalCode: { type: string }
-                addressCountry: { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── Network-specific attributes ──────────────────────────────────────
-        nominalVoltageKv:
-          type: number
-          minimum: 0
-          description: >
-            Nominal operating voltage, kV. CIM: BaseVoltage.nominalVoltage.
-          x-jsonld:
-            "@id": erDeg:nominalVoltageKv
+            # ── Network-specific attributes ────────────────────────────────────
 
-        zone:
-          type: string
-          description: Operating zone or region identifier used by the utility.
-          x-jsonld:
-            "@id": erDeg:zone
+            nominalVoltageKv:
+              type: number
+              minimum: 0
+              description: >
+                Nominal operating voltage, kV. CIM: BaseVoltage.nominalVoltage.
+              x-jsonld:
+                "@id": erDeg:nominalVoltageKv
 
-        substationId:
-          type: string
-          description: Parent substation identifier per utility records.
-          x-jsonld:
-            "@id": erDeg:substationId
+            zone:
+              type: string
+              description: Operating zone or region identifier used by the utility.
+              x-jsonld:
+                "@id": erDeg:zone
 
-        feederCode:
-          type: string
-          description: Feeder code per utility records. Relevant for FEEDER and DT resources.
-          x-jsonld:
-            "@id": erDeg:feederCode
+            substationId:
+              type: string
+              description: Parent substation identifier per utility records.
+              x-jsonld:
+                "@id": erDeg:substationId
+
+            feederCode:
+              type: string
+              description: Feeder code per utility records. Relevant for FEEDER and DT resources.
+              x-jsonld:
+                "@id": erDeg:feederCode

--- a/specification/schema/EnergyResourceNetwork/v1.0/schema.json
+++ b/specification/schema/EnergyResourceNetwork/v1.0/schema.json
@@ -2,104 +2,51 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceNetwork/v1.0",
   "title": "EnergyResourceNetwork",
-  "description": "Typed schema for grid-network infrastructure energy resources acting as topology anchors (distribution transformer, busbar, feeder, microgrid). CIM: DT → cim:PowerTransformer, BUS → cim:BusbarSection, FEEDER → cim:Feeder (EquipmentContainer), MICROGRID → cim:Substation (IEC 61970-301).",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>. Example: did:web:bescom.karnataka.gov.in:assets:feeder:FDR-BLR-042"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["DT", "BUS", "FEEDER", "MICROGRID"],
-      "description": "Asset-class discriminator. CIM: DT → PowerTransformer, BUS → BusbarSection, FEEDER → Feeder, MICROGRID → Substation/microgrid container (IEC 61970-301)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceNetworkAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources anchored to this network element (meters, DTs, buses, feeders). Each item is a bare id string or an inline EnergyResource object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
+  "description": "Typed schema for grid-network infrastructure energy resources acting as topology anchors (distribution transformer, busbar, feeder, microgrid). CIM: DT → cim:PowerTransformer, BUS → cim:BusbarSection, FEEDER → cim:Feeder, MICROGRID → cim:Substation (IEC 61970-301). Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DT", "BUS", "FEEDER", "MICROGRID"],
+          "description": "Asset-class discriminator. CIM: DT → PowerTransformer, BUS → BusbarSection, FEEDER → Feeder, MICROGRID → Substation/microgrid container (IEC 61970-301)."
+        },
+        "attributes": { "$ref": "#/$defs/EnergyResourceNetworkAttributes" }
       }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent network elements (e.g. the substation or feeder this DT belongs to).",
-      "items": { "type": "string", "minLength": 1 }
     }
-  },
+  ],
   "$defs": {
-    "GeoJSONGeometry": {
-      "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326). For a point: {type: 'Point', coordinates: [lon, lat]}.",
-      "required": ["type"],
-      "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
     "EnergyResourceNetworkAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for grid-network infrastructure resources. Includes common fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location) plus network-specific fields (nominalVoltageKv, zone, substationId, feederCode).",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power capacity, kW. CIM: GeneratingUnit.maxOperatingP." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this network element was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "nominalVoltageKv": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Nominal operating voltage, kV. CIM: BaseVoltage.nominalVoltage."
-        },
-        "zone": {
-          "type": "string",
-          "description": "Operating zone or region identifier used by the utility."
-        },
-        "substationId": {
-          "type": "string",
-          "description": "Parent substation identifier per utility records."
-        },
-        "feederCode": {
-          "type": "string",
-          "description": "Feeder code per utility records. Relevant for FEEDER and DT resources."
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for grid-network infrastructure resources. Common fields inherited. Network-specific fields below.",
+          "properties": {
+            "nominalVoltageKv": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Nominal operating voltage, kV. CIM: BaseVoltage.nominalVoltage."
+            },
+            "zone": {
+              "type": "string",
+              "description": "Operating zone or region identifier used by the utility."
+            },
+            "substationId": {
+              "type": "string",
+              "description": "Parent substation identifier per utility records."
+            },
+            "feederCode": {
+              "type": "string",
+              "description": "Feeder code per utility records. Relevant for FEEDER and DT resources."
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceStorage/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceStorage/v1.0/attributes.yaml
@@ -16,194 +16,91 @@ info:
     maxExportKw (discharge rate, ≥0) and maxImportKw (charge rate, ≥0)
     replace maxDischargeRateKw / maxChargeRateKw.
 
+    Common attributes (make, model, ratedPowerKw, maxExportKw, maxImportKw,
+    telemetryProvider, commissioningDate, location) are inherited from
+    EnergyResourceCommon/v1.0 via allOf.
+
 components:
   schemas:
 
     EnergyResourceStorage:
-      type: object
-      required: [id, type]
-      additionalProperties: false
       description: >
-        A storage DER energy resource (BESS, EV charger, V2G). Corresponds to
-        cim:BatteryUnit and cim:ElectricVehicleChargingStation (IEC 61970-302).
+        A stationary battery energy storage resource (BESS).
+        Corresponds to cim:BatteryUnit (IEC 61970-302).
+        EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G).
       x-tags:
         - energy-resource
         - energy
         - deg
         - storage
         - bess
-        - ev
       x-jsonld:
         "@context": ./context.jsonld
         "@type": EnergyResourceStorage
-      properties:
-        id:
-          type: string
-          description: >
-            IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>
-            e.g. did:web:bescom.karnataka.gov.in:assets:bess:BESS-001
-          example: "did:web:bescom.karnataka.gov.in:assets:bess:BESS-001"
-          x-jsonld:
-            "@id": "@id"
-        type:
-          type: string
-          enum:
-            - BESS
-            - BATTERY
-          description: >
-            Asset-class discriminator. BATTERY is a deprecated alias for BESS;
-            new payloads should use BESS.
-            CIM: cim:BatteryUnit (IEC 61970-302).
-            EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G).
-          x-cim-class: cim:BatteryUnit
-          x-jsonld:
-            "@id": erDeg:resourceType
-        attributes:
-          $ref: "#/components/schemas/EnergyResourceStorageAttributes"
-        subResources:
-          type: array
-          description: >
-            Child resources (e.g. battery modules, charger ports). Each item is a
-            bare id string or an inline EnergyResourceStorage object.
-          items:
-            oneOf:
-              - type: string
-                description: id of a sibling EnergyResource in the same payload.
-              - $ref: "#/components/schemas/EnergyResourceStorage"
-                description: Inline nested resource.
-        parentResources:
-          type: array
-          description: >
-            ids of parent resources (e.g. the meter this DER sits behind).
-            String references only.
-          items:
-            type: string
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - type: object
+          required: [id, type]
+          properties:
+            type:
+              type: string
+              enum:
+                - BESS
+                - BATTERY
+              description: >
+                Asset-class discriminator. BATTERY is a deprecated alias for BESS;
+                new payloads should use BESS.
+                CIM: cim:BatteryUnit (IEC 61970-302).
+                EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G).
+              x-cim-class: cim:BatteryUnit
+              x-jsonld:
+                "@id": erDeg:resourceType
+            attributes:
+              $ref: "#/components/schemas/EnergyResourceStorageAttributes"
 
     EnergyResourceStorageAttributes:
-      type: object
-      additionalProperties: true
       description: >
-        Attributes for BESS resources. Includes EnergyResourceCommonAttributes
-        fields (make, model, maxExportKw, maxImportKw, ratedPowerKw,
-        telemetryProvider, commissioningDate, location) plus storage-specific
-        fields (storageCapacityKwh, storageType, stateOfHealthPct).
+        Attributes for BESS resources. Common fields (make, model, ratedPowerKw,
+        maxExportKw, maxImportKw, telemetryProvider, commissioningDate, location)
+        are inherited from EnergyResourceCommonAttributes via allOf.
+        Only storage-specific fields are defined here.
       x-jsonld:
         "@id": erDeg:attributes
-      properties:
-
-        # ── Common attributes (EnergyResourceCommonAttributes) ──────────────
-        make:
-          type: string
-          description: Manufacturer (free text).
-          x-jsonld:
-            "@id": erDeg:make
-
-        model:
-          type: string
-          description: Model number (free text).
-          x-jsonld:
-            "@id": erDeg:model
-
-        ratedPowerKw:
-          type: number
-          minimum: 0
-          description: >
-            Manufacturer-rated peak power, kW. Kept for backward compatibility.
-            Prefer maxExportKw for new payloads.
-          x-jsonld:
-            "@id": erDeg:ratedPowerKw
-
-        maxExportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum discharge power injected to the grid, kW. Always ≥0.
-            CIM: BatteryUnit / PowerElectronicsConnection.maxP (injection direction).
-          x-jsonld:
-            "@id": erDeg:maxExportKw
-
-        maxImportKw:
-          type: number
-          minimum: 0
-          description: >
-            Maximum charge power drawn from the grid, kW. Always ≥0.
-            CIM: BatteryUnit / PowerElectronicsConnection.maxP (absorption direction).
-          x-jsonld:
-            "@id": erDeg:maxImportKw
-
-        telemetryProvider:
-          type: string
-          description: Vendor API / data source identifier for telemetry.
-          x-jsonld:
-            "@id": erDeg:telemetryProvider
-
-        commissioningDate:
-          type: string
-          format: date-time
-          description: ISO 8601 date-time when this storage asset was commissioned.
-          x-jsonld:
-            "@id": deg:commissioningDate
-
-        location:
-          type: object
-          description: >
-            Physical location of this asset per beckn Location/2.0.
-            geo (required) is a GeoJSON geometry; address is a postal address.
-          required: [geo]
+      allOf:
+        - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - type: object
+          additionalProperties: true
           properties:
-            geo:
-              type: object
-              description: GeoJSON geometry — coordinates are [longitude, latitude].
-              required: [type]
-              properties:
-                type: { type: string, enum: [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection] }
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                geometries: { type: array }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-              additionalProperties: true
-            address:
-              type: object
-              additionalProperties: false
-              description: schema.org PostalAddress fields.
-              properties:
-                streetAddress: { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion: { type: string }
-                postalCode: { type: string }
-                addressCountry: { type: string }
-          x-jsonld:
-            "@id": erDeg:location
 
-        # ── Storage-specific attributes ──────────────────────────────────────
-        storageCapacityKwh:
-          type: number
-          minimum: 0
-          description: >
-            Rated stored-energy capacity, kWh. CIM: BatteryUnit.ratedE.
-            Replaces energyCapacityKwh used in EnergyResource v1.1.
-          x-jsonld:
-            "@id": erDeg:storageCapacityKwh
+            # ── Storage-specific attributes ────────────────────────────────────
 
-        storageType:
-          type: string
-          enum:
-            - LithiumIon
-            - LeadAcid
-            - FlowBattery
-            - NaS
-            - NiCd
-            - Flywheel
-            - Other
-          description: Battery storage technology type.
-          x-jsonld:
-            "@id": erDeg:storageType
+            storageCapacityKwh:
+              type: number
+              minimum: 0
+              description: >
+                Rated stored-energy capacity, kWh. CIM: BatteryUnit.ratedE.
+                Replaces energyCapacityKwh used in EnergyResource v1.1.
+              x-jsonld:
+                "@id": erDeg:storageCapacityKwh
 
-        stateOfHealthPct:
-          type: number
-          minimum: 0
-          maximum: 100
-          description: Battery state-of-health as a percentage (0–100).
-          x-jsonld:
-            "@id": erDeg:stateOfHealthPct
+            storageType:
+              type: string
+              enum:
+                - LithiumIon
+                - LeadAcid
+                - FlowBattery
+                - NaS
+                - NiCd
+                - Flywheel
+                - Other
+              description: Battery storage technology type.
+              x-jsonld:
+                "@id": erDeg:storageType
 
+            stateOfHealthPct:
+              type: number
+              minimum: 0
+              maximum: 100
+              description: Battery state-of-health as a percentage (0–100).
+              x-jsonld:
+                "@id": erDeg:stateOfHealthPct

--- a/specification/schema/EnergyResourceStorage/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceStorage/v1.0/attributes.yaml
@@ -3,19 +3,18 @@ info:
   title: EnergyResourceStorage
   version: 1.0.0
   description: |
-    Typed attribute schema for storage DER energy resources.
+    Typed attribute schema for stationary battery energy storage resources.
 
     CIM alignment (IEC 61970-302):
-      BESS        → cim:BatteryUnit
-      BATTERY     → cim:BatteryUnit (deprecated alias for BESS)
-      EV_CHARGER  → cim:ElectricVehicleChargingStation (unidirectional)
-      EV_V2G      → cim:ElectricVehicleChargingStation (bidirectional V2G capable)
+      BESS   → cim:BatteryUnit
+      BATTERY → cim:BatteryUnit (deprecated alias; use BESS)
 
-    BATTERY is a deprecated alias for BESS; new payloads should use BESS.
-    EV_V2G represents a bidirectional vehicle-to-grid capable EV charger.
+    EV charging stations (EV_CHARGER, EV_V2G) are a separate kind —
+    see EnergyResourceEVCharger/v1.0.
 
-    Note: storageCapacityKwh in this schema replaces energyCapacityKwh
-    used in EnergyResource v1.1.
+    storageCapacityKwh replaces energyCapacityKwh from EnergyResource v1.1.
+    maxExportKw (discharge rate, ≥0) and maxImportKw (charge rate, ≥0)
+    replace maxDischargeRateKw / maxChargeRateKw.
 
 components:
   schemas:
@@ -51,14 +50,11 @@ components:
           enum:
             - BESS
             - BATTERY
-            - EV_CHARGER
-            - EV_V2G
           description: >
             Asset-class discriminator. BATTERY is a deprecated alias for BESS;
-            new payloads should use BESS. EV_V2G denotes a bidirectional
-            vehicle-to-grid capable EV charger.
-            CIM: BESS/BATTERY → BatteryUnit,
-            EV_CHARGER/EV_V2G → ElectricVehicleChargingStation (IEC 61970-302).
+            new payloads should use BESS.
+            CIM: cim:BatteryUnit (IEC 61970-302).
+            EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G).
           x-cim-class: cim:BatteryUnit
           x-jsonld:
             "@id": erDeg:resourceType
@@ -87,10 +83,10 @@ components:
       type: object
       additionalProperties: true
       description: >
-        Attributes for storage DER resources. Includes EnergyResourceCommonAttributes
-        fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location)
-        plus storage-specific fields (storageCapacityKwh, storageType,
-        stateOfHealthPct, maxChargeRateKw, maxDischargeRateKw).
+        Attributes for BESS resources. Includes EnergyResourceCommonAttributes
+        fields (make, model, maxExportKw, maxImportKw, ratedPowerKw,
+        telemetryProvider, commissioningDate, location) plus storage-specific
+        fields (storageCapacityKwh, storageType, stateOfHealthPct).
       x-jsonld:
         "@id": erDeg:attributes
       properties:
@@ -112,9 +108,28 @@ components:
           type: number
           minimum: 0
           description: >
-            Manufacturer-rated peak power, kW. CIM: GeneratingUnit.maxOperatingP.
+            Manufacturer-rated peak power, kW. Kept for backward compatibility.
+            Prefer maxExportKw for new payloads.
           x-jsonld:
             "@id": erDeg:ratedPowerKw
+
+        maxExportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum discharge power injected to the grid, kW. Always ≥0.
+            CIM: BatteryUnit / PowerElectronicsConnection.maxP (injection direction).
+          x-jsonld:
+            "@id": erDeg:maxExportKw
+
+        maxImportKw:
+          type: number
+          minimum: 0
+          description: >
+            Maximum charge power drawn from the grid, kW. Always ≥0.
+            CIM: BatteryUnit / PowerElectronicsConnection.maxP (absorption direction).
+          x-jsonld:
+            "@id": erDeg:maxImportKw
 
         telemetryProvider:
           type: string
@@ -192,16 +207,3 @@ components:
           x-jsonld:
             "@id": erDeg:stateOfHealthPct
 
-        maxChargeRateKw:
-          type: number
-          minimum: 0
-          description: Maximum charge rate, kW.
-          x-jsonld:
-            "@id": erDeg:maxChargeRateKw
-
-        maxDischargeRateKw:
-          type: number
-          minimum: 0
-          description: Maximum discharge rate, kW.
-          x-jsonld:
-            "@id": erDeg:maxDischargeRateKw

--- a/specification/schema/EnergyResourceStorage/v1.0/schema.json
+++ b/specification/schema/EnergyResourceStorage/v1.0/schema.json
@@ -2,105 +2,50 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceStorage/v1.0",
   "title": "EnergyResourceStorage",
-  "description": "Typed schema for stationary battery energy storage resources (BESS). CIM: cim:BatteryUnit (IEC 61970-302). BATTERY is a deprecated alias for BESS. EV charging stations (EV_CHARGER, EV_V2G) moved to EnergyResourceEVCharger/v1.0. storageCapacityKwh is exclusive to this kind. maxExportKw (discharge, ≥0) and maxImportKw (charge, ≥0) replace maxDischargeRateKw / maxChargeRateKw.",
-  "type": "object",
-  "required": ["id", "type"],
-  "additionalProperties": false,
-  "properties": {
-    "id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "IES asset DID. Format: did:web:<discom-domain>:assets:<asset-class>:<local-id>. Example: did:web:bescom.karnataka.gov.in:assets:bess:BESS-001"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["BESS", "BATTERY"],
-      "description": "Asset-class discriminator. BATTERY is deprecated; use BESS. CIM: cim:BatteryUnit (IEC 61970-302). EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G)."
-    },
-    "attributes": {
-      "$ref": "#/$defs/EnergyResourceStorageAttributes"
-    },
-    "subResources": {
-      "type": "array",
-      "description": "Child resources (e.g. battery modules, charger ports). Each item is a bare id string or an inline EnergyResource object.",
-      "items": {
-        "oneOf": [
-          { "type": "string", "minLength": 1 },
-          { "$ref": "#" }
-        ]
-      }
-    },
-    "parentResources": {
-      "type": "array",
-      "description": "ids of parent resources (e.g. the meter this DER sits behind).",
-      "items": { "type": "string", "minLength": 1 }
-    }
-  },
-  "$defs": {
-    "GeoJSONGeometry": {
+  "description": "Typed schema for stationary battery energy storage resources (BESS). CIM: cim:BatteryUnit (IEC 61970-302). BATTERY is a deprecated alias for BESS. EV charging stations (EV_CHARGER, EV_V2G) moved to EnergyResourceEVCharger/v1.0. storageCapacityKwh is exclusive to this kind. Common fields inherited from EnergyResourceCommon/v1.0.",
+  "allOf": [
+    { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommon" },
+    {
       "type": "object",
-      "description": "GeoJSON geometry per RFC 7946 / beckn GeoJSONGeometry/v2.0. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326). For a point: {type: 'Point', coordinates: [lon, lat]}.",
-      "required": ["type"],
+      "required": ["id", "type"],
       "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string" }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
-      "required": ["geo"],
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
-    "EnergyResourceStorageAttributes": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Attributes for BESS resources. Includes common fields (make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate, location) plus storage-specific fields (storageCapacityKwh, storageType, stateOfHealthPct).",
-      "properties": {
-        "make": { "type": "string", "description": "Manufacturer (free text)." },
-        "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. Kept for backward compatibility. Prefer maxExportKw." },
-        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum discharge power injected to the grid, kW. Always ≥0. CIM: BatteryUnit / PowerElectronicsConnection.maxP (injection)." },
-        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum charge power drawn from the grid, kW. Always ≥0. CIM: BatteryUnit / PowerElectronicsConnection.maxP (absorption)." },
-        "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
-        "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this storage asset was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
-        "storageCapacityKwh": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Rated stored-energy capacity, kWh. CIM: BatteryUnit.ratedE. Exclusive to EnergyResourceStorage — replaces energyCapacityKwh from EnergyResource v1.1."
-        },
-        "storageType": {
+        "type": {
           "type": "string",
-          "enum": ["LithiumIon", "LeadAcid", "FlowBattery", "NaS", "NiCd", "Flywheel", "Other"],
-          "description": "Battery storage technology type."
+          "enum": ["BESS", "BATTERY"],
+          "description": "Asset-class discriminator. BATTERY is deprecated; use BESS. CIM: cim:BatteryUnit (IEC 61970-302). EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G)."
         },
-        "stateOfHealthPct": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "description": "Battery state-of-health as a percentage (0–100)."
-        }
+        "attributes": { "$ref": "#/$defs/EnergyResourceStorageAttributes" }
       }
+    }
+  ],
+  "$defs": {
+    "EnergyResourceStorageAttributes": {
+      "allOf": [
+        { "$ref": "https://schema.beckn.io/EnergyResourceCommon/v1.0#EnergyResourceCommonAttributes" },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Attributes for BESS resources. Common fields inherited. Storage-specific fields below.",
+          "properties": {
+            "storageCapacityKwh": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Rated stored-energy capacity, kWh. CIM: BatteryUnit.ratedE. Exclusive to EnergyResourceStorage — replaces energyCapacityKwh from EnergyResource v1.1."
+            },
+            "storageType": {
+              "type": "string",
+              "enum": ["LithiumIon", "LeadAcid", "FlowBattery", "NaS", "NiCd", "Flywheel", "Other"],
+              "description": "Battery storage technology type."
+            },
+            "stateOfHealthPct": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "description": "Battery state-of-health as a percentage (0–100)."
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/specification/schema/EnergyResourceStorage/v1.0/schema.json
+++ b/specification/schema/EnergyResourceStorage/v1.0/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.beckn.io/EnergyResourceStorage/v1.0",
   "title": "EnergyResourceStorage",
-  "description": "Typed schema for storage DER energy resources (BESS, EV charger, V2G). CIM: BESS/BATTERY → cim:BatteryUnit, EV_CHARGER/EV_V2G → cim:ElectricVehicleChargingStation (IEC 61970-302). BATTERY is a deprecated alias for BESS. EV_V2G denotes a bidirectional vehicle-to-grid capable charger. storageCapacityKwh is exclusive to this kind (replaces energyCapacityKwh from EnergyResource v1.1).",
+  "description": "Typed schema for stationary battery energy storage resources (BESS). CIM: cim:BatteryUnit (IEC 61970-302). BATTERY is a deprecated alias for BESS. EV charging stations (EV_CHARGER, EV_V2G) moved to EnergyResourceEVCharger/v1.0. storageCapacityKwh is exclusive to this kind. maxExportKw (discharge, ≥0) and maxImportKw (charge, ≥0) replace maxDischargeRateKw / maxChargeRateKw.",
   "type": "object",
   "required": ["id", "type"],
   "additionalProperties": false,
@@ -14,8 +14,8 @@
     },
     "type": {
       "type": "string",
-      "enum": ["BESS", "BATTERY", "EV_CHARGER", "EV_V2G"],
-      "description": "Asset-class discriminator. BATTERY is deprecated; use BESS. EV_V2G is bidirectional V2G capable. CIM: BESS/BATTERY → BatteryUnit, EV_CHARGER/EV_V2G → ElectricVehicleChargingStation (IEC 61970-302)."
+      "enum": ["BESS", "BATTERY"],
+      "description": "Asset-class discriminator. BATTERY is deprecated; use BESS. CIM: cim:BatteryUnit (IEC 61970-302). EV charging stations use EnergyResourceEVCharger (EV_CHARGER, EV_V2G)."
     },
     "attributes": {
       "$ref": "#/$defs/EnergyResourceStorageAttributes"
@@ -74,11 +74,13 @@
     "EnergyResourceStorageAttributes": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Attributes for storage DER resources. Includes common fields (make, model, ratedPowerKw, telemetryProvider, commissioningDate, location) plus storage-specific fields (storageCapacityKwh, storageType, stateOfHealthPct, maxChargeRateKw, maxDischargeRateKw).",
+      "description": "Attributes for BESS resources. Includes common fields (make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate, location) plus storage-specific fields (storageCapacityKwh, storageType, stateOfHealthPct).",
       "properties": {
         "make": { "type": "string", "description": "Manufacturer (free text)." },
         "model": { "type": "string", "description": "Model number (free text)." },
-        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. CIM: GeneratingUnit.maxOperatingP." },
+        "ratedPowerKw": { "type": "number", "minimum": 0, "description": "Manufacturer-rated peak power, kW. Kept for backward compatibility. Prefer maxExportKw." },
+        "maxExportKw": { "type": "number", "minimum": 0, "description": "Maximum discharge power injected to the grid, kW. Always ≥0. CIM: BatteryUnit / PowerElectronicsConnection.maxP (injection)." },
+        "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum charge power drawn from the grid, kW. Always ≥0. CIM: BatteryUnit / PowerElectronicsConnection.maxP (absorption)." },
         "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
         "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time when this storage asset was commissioned." },
         "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." },
@@ -97,16 +99,6 @@
           "minimum": 0,
           "maximum": 100,
           "description": "Battery state-of-health as a percentage (0–100)."
-        },
-        "maxChargeRateKw": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Maximum charge rate, kW."
-        },
-        "maxDischargeRateKw": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Maximum discharge rate, kW."
         }
       }
     }


### PR DESCRIPTION
## Summary

- **EnergyResource/v2.0 redesigned** — seven typed kinds, each in its own `specification/schema/<Kind>/v1.0/` folder; `EnergyResource/v2.0` owns the discriminated union (`oneOf`) and `$ref`-aliases to each kind's canonical URL at `schema.beckn.io/<Kind>/v1.0`
- **EnergyResourceCommon/v1.0 introduced** — single canonical home for shared structural and attribute fields, eliminating duplication across all 7 kind schemas:
  - `EnergyResourceCommon` — structural envelope: `id`, `type`, `subResources`, `parentResources`, `attributes`
  - `EnergyResourceCommonAttributes` — attribute bag base: `make`, `model`, `maxExportKw`, `maxImportKw`, `ratedPowerKw`, `telemetryProvider`, `commissioningDate`, `location`
  - All 7 kind schemas inherit via `allOf: [$ref schema.beckn.io/EnergyResourceCommon/v1.0]` and only define kind-specific fields
- **Power fields** — `ratedPowerKw` retained for backward compat; two new explicit-direction fields: `maxExportKw` (power injected to grid, ≥0) and `maxImportKw` (power drawn from grid, ≥0) — no sign conventions, both always ≥0
- **INVERTER kind added** — `EnergyResourceInverter/v1.0` — grid-connected power-electronics converter with IEEE 1547-2018 / SunSpec DER Models 702–714 capabilities: `ratedApparentPowerKva`, `maxReactivePowerKvar`, `rideThroughCategory` (CategoryI/II/III), `operatingMode` (GridFollowing/GridForming/Standby), `voltVarEnabled`, `freqDroopEnabled`, `enterServiceRampTimeSec`
- **EV kind separated** — `EnergyResourceEVCharger/v1.0` — `EV_CHARGER` and `EV_V2G` moved out of `EnergyResourceStorage`; EV_CHARGER is a flexible load (EVSE hardware), not storage; EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT V2G capability; EVSE-specific fields: `connectorType`, `controlProtocol`, `v2xProtocol`
- **EnergyResourceStorage** — now BESS-only (`BESS`, `BATTERY` deprecated alias); storage-specific fields: `storageCapacityKwh`, `storageType`, `stateOfHealthPct`
- **DEG hourglass architecture** references removed from all `specification/schema/` files

## Files changed

| File | Change |
|------|--------|
| `EnergyResourceCommon/v1.0/` _(new)_ | `attributes.yaml`, `schema.json`, `context.jsonld`, `vocab.jsonld`, `README.md` — canonical base schemas |
| `EnergyResource/v2.0/attributes.yaml` | Inline `EnergyResourceCommon`/`EnergyResourceCommonAttributes` replaced with `$ref` aliases to `EnergyResourceCommon/v1.0`; kind schemas replaced with canonical `$ref` aliases |
| `EnergyResource/v2.0/{context,vocab}.jsonld` | Sync to new field names (`storageCapacityKwh`, `maxExportKw`, `maxImportKw`) |
| `EnergyResource/v2.0/README.md` | Updated docs with 7-kind table, per-kind attribute tables, topology notes, corrected examples |
| `EnergyResourceMeter/v1.0/` | `attributes.yaml` + `schema.json` — inherit from `EnergyResourceCommon/v1.0` via `allOf`; only meter-specific fields inline |
| `EnergyResourceGenerator/v1.0/` | `attributes.yaml` + `schema.json` — same pattern; only `nominalPowerKw`, `efficiency` inline |
| `EnergyResourceStorage/v1.0/` | `attributes.yaml` + `schema.json` — EV types removed; inherit from `EnergyResourceCommon/v1.0`; only `storageCapacityKwh`, `storageType`, `stateOfHealthPct` inline |
| `EnergyResourceLoad/v1.0/` | `attributes.yaml` + `schema.json` — inherit from `EnergyResourceCommon/v1.0`; only `controlProtocol`, `loadCategory` inline |
| `EnergyResourceNetwork/v1.0/` | `attributes.yaml` + `schema.json` — inherit from `EnergyResourceCommon/v1.0`; only `nominalVoltageKv`, `zone`, `substationId`, `feederCode` inline |
| `EnergyResourceEVCharger/v1.0/` _(new)_ | Full kind schema — `attributes.yaml`, `schema.json`, `context.jsonld`, `vocab.jsonld`, `README.md` |
| `EnergyResourceInverter/v1.0/` _(new)_ | Full kind schema — `attributes.yaml`, `schema.json`, `context.jsonld`, `vocab.jsonld`, `README.md` |
| `ElectricityCredential/v1.2/` | `schema.json`, `attributes.yaml`, `README.md`, `{context,vocab}.jsonld`, examples updated for new kinds and power fields |

## Migration guide (ratedPowerKw)

`ratedPowerKw` is still accepted. For new payloads:
- Generators (solar, wind, CHP): `ratedPowerKw` → `maxExportKw`
- Loads (EV charger, HVAC): add `maxImportKw`
- Bidirectional (BESS, V2G): `maxExportKw` (discharge rate) + `maxImportKw` (charge rate)

## Schema publication

Once merged, kind schemas at `specification/schema/<Kind>/v1.0/` should be published to `schema.beckn.io/<Kind>/v1.0` to activate the external `$ref` resolution used by all kind schemas and `EnergyResource/v2.0`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)