### PR TITLE
refactor(schema): context dedup, location $ref, MeterServiceProfile

### DIFF
--- a/specification/schema/ElectricityCredential/v1.2/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.2/attributes.yaml
@@ -37,6 +37,8 @@ info:
     energyResources[*].type enum "SOLAR"   → deprecated; use SOLAR_PV
     energyResources[*].type enum "BATTERY" → deprecated; use BESS
 
+    consumptionProfiles[] items are now MeterServiceProfile (formerly ConsumptionProfile).
+
 jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 servers:
   - url: https://schema.beckn.io
@@ -145,85 +147,11 @@ components:
             "@id": deg:subjectId
 
     ConsumptionProfile:
-      type: object
+      $ref: "https://schema.beckn.io/MeterServiceProfile/v1.0#/components/schemas/MeterServiceProfile"
       description: >
         Tariff and regulatory load profile for one meter connection.
-        meterId links to a METER entry's id in energyResources[].
-      required:
-        - meterId
-        - sanctionedLoadKw
-        - tariffCategoryCode
-      x-jsonld:
-        "@id": deg:ConsumptionProfile
-      properties:
-        meterId:
-          type: string
-          minLength: 1
-          description: Matches the id of a METER entry in customerProfile.energyResources[].
-          x-jsonld:
-            "@id": deg:meterId
-        sanctionedLoadKw:
-          type: number
-          minimum: 0.5
-          maximum: 10000
-          description: Sanctioned/approved electrical load in kW.
-          x-jsonld:
-            "@id": deg:sanctionedLoadKw
-        sanctionedExportLoadKw:
-          type: number
-          minimum: 0
-          description: Sanctioned/approved grid export limit in kW.
-          x-jsonld:
-            "@id": deg:sanctionedExportLoadKw
-        billingCycleDay:
-          type: integer
-          minimum: 1
-          maximum: 31
-          description: Day of month on which the billing cycle resets.
-          x-jsonld:
-            "@id": deg:billingCycleDay
-        contractMaxDemandKw:
-          type: number
-          minimum: 0
-          description: Maximum demand contracted with the utility for this connection, in kW.
-          x-jsonld:
-            "@id": deg:contractMaxDemandKw
-        tariffCategoryCode:
-          type: string
-          minLength: 1
-          description: Billing/tariff category code assigned by the utility.
-          x-jsonld:
-            "@id": deg:tariffCategoryCode
-        premisesType:
-          type: string
-          enum:
-            - Residential
-            - Commercial
-            - Industrial
-            - Agricultural
-          x-jsonld:
-            "@id": deg:premisesType
-        connectionType:
-          type: string
-          enum:
-            - Single-phase
-            - Three-phase
-          x-jsonld:
-            "@id": deg:connectionType
-        paymentMode:
-          type: string
-          enum:
-            - POSTPAID
-            - PREPAID
-          description: >
-            Billing/payment modality for this connection. POSTPAID: standard
-            credit-based (consume now, pay later). PREPAID: pay-before-use;
-            supply is disconnected when credit is exhausted. Administrative
-            attribute — placed here (not on the meter) because it can change
-            via firmware without hardware replacement. Aligns with ESPI
-            AmiBillingReadyKind on UsagePoint (IEC 61968-9).
-          x-jsonld:
-            "@id": deg:paymentMode
+        meterId links to a METER entry in customerProfile.energyResources[].
+        Alias for MeterServiceProfile/v1.0 — kept for backward compatibility.
 
     CustomerDetails:
       type: object

--- a/specification/schema/ElectricityCredential/v1.2/schema.json
+++ b/specification/schema/ElectricityCredential/v1.2/schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/beckn/DEG/blob/main/specification/schema/ElectricityCredential/v1.2/schema.json",
     "title": "ElectricityCredential v1.2",
-    "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.2. EnergyResource is composable: oneOf [EnergyResourceMeter | EnergyResourceGenerator | EnergyResourceStorage | EnergyResourceEVCharger | EnergyResourceInverter | EnergyResourceLoad | EnergyResourceNetwork]. Each kind is also published as a standalone schema at schema.beckn.io/<Kind>/v1.0. $defs here mirror those external schemas. storageCapacityKwh is restricted to EnergyResourceStorage. EV_CHARGER and EV_V2G are their own kind (not storage). INVERTER captures reactive-power and frequency-support capabilities per IEEE 1547. CIM alignment per IEC 61970-301/302 and IEC 61968-9.",
+    "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.2. EnergyResource is composable: oneOf [EnergyResourceMeter | EnergyResourceGenerator | EnergyResourceStorage | EnergyResourceEVCharger | EnergyResourceInverter | EnergyResourceLoad | EnergyResourceNetwork]. Each kind is also published as a standalone schema at schema.beckn.io/<Kind>/v1.0. $defs here mirror those external schemas. storageCapacityKwh is restricted to EnergyResourceStorage. EV_CHARGER and EV_V2G are their own kind (not storage). INVERTER captures reactive-power and frequency-support capabilities per IEEE 1547. CIM alignment per IEC 61970-301/302 and IEC 61968-9. consumptionProfiles[] items are now MeterServiceProfile/v1.0 (formerly ConsumptionProfile).",
     "type": "object",
     "required": ["@context", "id", "type", "issuer", "validFrom", "credentialSubject"],
     "properties": {
@@ -94,20 +94,8 @@
             }
         },
         "ConsumptionProfile": {
-            "type": "object",
-            "description": "Tariff and load characteristics for one meter. meterId matches the id of a METER entry in energyResources[].",
-            "required": ["meterId", "sanctionedLoadKw", "tariffCategoryCode"],
-            "properties": {
-                "meterId": { "type": "string", "minLength": 1 },
-                "sanctionedLoadKw": { "type": "number", "minimum": 0.5, "maximum": 10000 },
-                "sanctionedExportLoadKw": { "type": "number", "minimum": 0, "description": "Sanctioned/approved grid export limit in kW." },
-                "billingCycleDay": { "type": "integer", "minimum": 1, "maximum": 31, "description": "Day of month on which the billing cycle resets." },
-                "contractMaxDemandKw": { "type": "number", "minimum": 0 },
-                "tariffCategoryCode": { "type": "string", "minLength": 1 },
-                "premisesType": { "type": "string", "enum": ["Residential", "Commercial", "Industrial", "Agricultural"] },
-                "connectionType": { "type": "string", "enum": ["Single-phase", "Three-phase"] },
-                "paymentMode": { "type": "string", "enum": ["POSTPAID", "PREPAID"], "description": "Billing/payment modality for this connection. Administrative: placed on ConsumptionProfile (not the meter) because it can change via firmware. CIM: EndDeviceFunction kind=prepayment / ESPI AmiBillingReadyKind (IEC 61968-9)." }
-            }
+            "$ref": "https://schema.beckn.io/MeterServiceProfile/v1.0#MeterServiceProfile",
+            "description": "Alias for MeterServiceProfile/v1.0. Kept for backward compatibility."
         },
         "CustomerDetails": {
             "type": "object",

--- a/specification/schema/EnergyResourceCommon/v1.0/attributes-context.jsonld
+++ b/specification/schema/EnergyResourceCommon/v1.0/attributes-context.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "deg": "https://schema.beckn.io/deg#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "make":              { "@id": "deg:make" },
+    "model":             { "@id": "deg:model" },
+    "ratedPowerKw":      { "@id": "deg:ratedPowerKw",      "@type": "xsd:decimal" },
+    "maxExportKw":       { "@id": "deg:maxExportKw",       "@type": "xsd:decimal" },
+    "maxImportKw":       { "@id": "deg:maxImportKw",       "@type": "xsd:decimal" },
+    "telemetryProvider": { "@id": "deg:telemetryProvider" },
+    "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
+    "location":          { "@id": "deg:location" },
+    "geo":               { "@id": "deg:geo" },
+    "address":           { "@id": "deg:address" }
+  }
+}

--- a/specification/schema/EnergyResourceCommon/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceCommon/v1.0/attributes.yaml
@@ -103,36 +103,8 @@ components:
             "@id": deg:commissioningDate
 
         location:
-          type: object
-          description: >
-            Physical location of the asset (beckn Location shape). geo
-            (required) is a GeoJSON geometry with coordinates [longitude,
-            latitude] per RFC 7946. address (optional) is a schema.org
-            PostalAddress-aligned object.
-          additionalProperties: true
-          required:
-            - geo
-          properties:
-            geo:
-              type: object
-              required: [type]
-              additionalProperties: true
-              properties:
-                type:
-                  type: string
-                  enum: [Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString, GeometryCollection]
-                coordinates: { type: array, description: "For a Point: [longitude, latitude]." }
-                bbox: { type: array, minItems: 4, maxItems: 4, items: { type: number } }
-            address:
-              type: object
-              additionalProperties: false
-              properties:
-                streetAddress:   { type: string }
-                extendedAddress: { type: string }
-                addressLocality: { type: string }
-                addressRegion:   { type: string }
-                postalCode:      { type: string }
-                addressCountry:  { type: string, description: "ISO 3166-1 alpha-2 or country name." }
+          $ref: "https://schema.beckn.io/Location/2.0/attributes.yaml#/components/schemas/Location"
+          description: Physical location of this asset.
           x-jsonld:
             "@id": deg:location
 

--- a/specification/schema/EnergyResourceCommon/v1.0/schema.json
+++ b/specification/schema/EnergyResourceCommon/v1.0/schema.json
@@ -4,41 +4,6 @@
   "title": "EnergyResourceCommon",
   "description": "Canonical base schemas shared by all typed EnergyResource kinds. Contains EnergyResourceCommon (structural envelope: id, type, subResources, parentResources, attributes) and EnergyResourceCommonAttributes (attributes bag base: make, model, maxExportKw, maxImportKw, ratedPowerKw, telemetryProvider, commissioningDate, location).",
   "$defs": {
-    "GeoJSONGeometry": {
-      "type": "object",
-      "description": "GeoJSON geometry per RFC 7946. Coordinates are [longitude, latitude] in WGS-84 (EPSG:4326).",
-      "required": ["type"],
-      "properties": {
-        "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-        "coordinates": { "type": "array", "description": "For a Point: [longitude, latitude]." },
-        "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-        "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-      },
-      "additionalProperties": true
-    },
-    "Address": {
-      "type": "object",
-      "description": "schema.org PostalAddress per beckn Address/2.0.",
-      "additionalProperties": false,
-      "properties": {
-        "streetAddress": { "type": "string" },
-        "extendedAddress": { "type": "string" },
-        "addressLocality": { "type": "string" },
-        "addressRegion": { "type": "string" },
-        "postalCode": { "type": "string" },
-        "addressCountry": { "type": "string", "description": "ISO 3166-1 alpha-2 or country name." }
-      }
-    },
-    "Location": {
-      "type": "object",
-      "description": "Physical location per beckn Location/2.0. geo (required) is a GeoJSONGeometry; address (optional) is a postal address. Coordinates are [longitude, latitude] per RFC 7946.",
-      "required": ["geo"],
-      "additionalProperties": true,
-      "properties": {
-        "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-        "address": { "$ref": "#/$defs/Address" }
-      }
-    },
     "EnergyResourceCommonAttributes": {
       "$anchor": "EnergyResourceCommonAttributes",
       "type": "object",
@@ -52,7 +17,7 @@
         "maxImportKw": { "type": "number", "minimum": 0, "description": "Maximum power drawn from the grid (absorbs / charges), kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption)." },
         "telemetryProvider": { "type": "string", "description": "Vendor API / data source identifier for telemetry." },
         "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time the asset was commissioned." },
-        "location": { "$ref": "#/$defs/Location", "description": "Physical location of this asset." }
+        "location": { "$ref": "https://schema.beckn.io/Location/2.0/schema.json#/$defs/Location", "description": "Physical location of this asset." }
       }
     },
     "EnergyResourceCommon": {

--- a/specification/schema/EnergyResourceEVCharger/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/context.jsonld
@@ -8,26 +8,17 @@
       "@id": "erDeg:EnergyResourceEVCharger",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make":              { "@id": "erDeg:make",              "@type": "xsd:string"   },
-            "model":             { "@id": "erDeg:model",             "@type": "xsd:string"   },
-            "ratedPowerKw":      { "@id": "erDeg:ratedPowerKw",      "@type": "xsd:decimal"  },
-            "maxImportKw":       { "@id": "erDeg:maxImportKw",       "@type": "xsd:decimal"  },
-            "maxExportKw":       { "@id": "erDeg:maxExportKw",       "@type": "xsd:decimal"  },
-            "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string"   },
-            "commissioningDate": { "@id": "deg:commissioningDate",   "@type": "xsd:dateTime" },
-            "location":          { "@id": "erDeg:location",          "@type": "@id"          },
-            "connectorType":     { "@id": "erDeg:connectorType",     "@type": "xsd:string"   },
-            "controlProtocol":   { "@id": "erDeg:controlProtocol",   "@type": "xsd:string"   },
-            "v2xProtocol":       { "@id": "erDeg:v2xProtocol",       "@type": "xsd:string"   }
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
+            "connectorType":   { "@id": "erDeg:connectorType",   "@type": "xsd:string" },
+            "controlProtocol": { "@id": "erDeg:controlProtocol", "@type": "xsd:string" },
+            "v2xProtocol":     { "@id": "erDeg:v2xProtocol",     "@type": "xsd:string" }
           }
         },
-        "subResources":    { "@id": "erDeg:subResources",    "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceEVCharger/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/vocab.jsonld
@@ -15,71 +15,8 @@
       "@id": "erDeg:EnergyResourceEVCharger",
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — EV Charger",
-      "rdfs:comment": "An EV charging station (EVSE) energy resource. A flexible load at the grid connection point — NOT a storage resource. EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+)."
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type discriminator",
-      "rdfs:comment": "Asset-class discriminator. For EnergyResourceEVCharger: EV_CHARGER or EV_V2G.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceEVCharger" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. Kept for backward compatibility. Prefer maxImportKw for EV chargers.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:maxImportKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max import power (kW)",
-      "rdfs:comment": "Maximum charge power drawn from the grid, kW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption direction).",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:maxExportKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max export power (kW)",
-      "rdfs:comment": "Maximum V2G discharge power injected to the grid, kW. Always ≥0. Set for EV_V2G. CIM: PowerElectronicsConnection.maxP (injection direction).",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date-time when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:dateTime" }
-    },
-    {
-      "@id": "erDeg:location",
-      "@type": "rdf:Property",
-      "rdfs:label": "Location",
-      "rdfs:comment": "Physical location per beckn Location/2.0: geo (GeoJSON Point, coordinates [lon, lat]) + optional postal address.",
-      "schema:rangeIncludes": { "@id": "schema:Place" }
+      "rdfs:comment": "An EV charging station (EVSE) energy resource. A flexible load at the grid connection point — NOT a storage resource. EV_V2G is a specialisation with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" }
     },
     {
       "@id": "erDeg:connectorType",
@@ -103,20 +40,6 @@
       "rdfs:label": "V2X protocol",
       "rdfs:comment": "Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources. CHAdeMO_V2G, CCS_BPT, ISO_15118_20_AC_BPT, ISO_15118_20_DC_BPT.",
       "rdfs:domain": { "@id": "erDeg:EnergyResourceEVCharger" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources in the topology tree.",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceEVCharger" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent resources (e.g. the meter this EVSE is behind).",
       "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]

--- a/specification/schema/EnergyResourceGenerator/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceGenerator/v1.0/context.jsonld
@@ -2,29 +2,22 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "EnergyResourceGenerator": {
       "@id": "erDeg:EnergyResourceGenerator",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make": { "@id": "erDeg:make", "@type": "xsd:string" },
-            "model": { "@id": "erDeg:model", "@type": "xsd:string" },
-            "ratedPowerKw": { "@id": "erDeg:ratedPowerKw", "@type": "xsd:decimal" },
-            "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string" },
-            "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
-            "location":          { "@id": "erDeg:location",        "@type": "@id"         },
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
             "nominalPowerKw": { "@id": "erDeg:nominalPowerKw", "@type": "xsd:decimal" },
-            "efficiency": { "@id": "erDeg:efficiency", "@type": "xsd:decimal" }
+            "efficiency":     { "@id": "erDeg:efficiency",     "@type": "xsd:decimal" }
           }
         },
-        "subResources": { "@id": "erDeg:subResources", "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceGenerator/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceGenerator/v1.0/vocab.jsonld
@@ -2,10 +2,10 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "rdf":   "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":  "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "schema": "https://schema.org/"
   },
   "@graph": [
@@ -14,58 +14,8 @@
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — Generator",
       "rdfs:comment": "A generation DER energy resource (solar PV, wind, hydro, biogas, CHP, fuel cell). CIM: GeneratingUnit and subtypes (IEC 61970-301).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#GeneratingUnit" }
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type",
-      "rdfs:comment": "Asset-class discriminator. Values: SOLAR_PV, SOLAR (deprecated alias), WIND, HYDRO, BIOGAS, CHP, FUEL_CELL.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceGenerator" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. CIM: GeneratingUnit.maxOperatingP.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" },
-      "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#GeneratingUnit.maxOperatingP" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:gps",
-      "@type": "rdf:Property",
-      "rdfs:label": "GPS coordinates",
-      "rdfs:comment": "GPS coordinates of the asset as 'lat,lng' decimal string.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     },
     {
       "@id": "erDeg:nominalPowerKw",
@@ -83,20 +33,6 @@
       "rdfs:comment": "Conversion efficiency as a percentage (0–100). Most relevant for FUEL_CELL and CHP resources.",
       "rdfs:domain": { "@id": "erDeg:EnergyResourceGenerator" },
       "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources in the topology tree.",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceGenerator" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent resources (e.g. the meter this DER sits behind).",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]
 }

--- a/specification/schema/EnergyResourceInverter/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceInverter/v1.0/context.jsonld
@@ -8,31 +8,22 @@
       "@id": "erDeg:EnergyResourceInverter",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make":                    { "@id": "erDeg:make",                    "@type": "xsd:string"   },
-            "model":                   { "@id": "erDeg:model",                   "@type": "xsd:string"   },
-            "ratedPowerKw":            { "@id": "erDeg:ratedPowerKw",            "@type": "xsd:decimal"  },
-            "maxExportKw":             { "@id": "erDeg:maxExportKw",             "@type": "xsd:decimal"  },
-            "maxImportKw":             { "@id": "erDeg:maxImportKw",             "@type": "xsd:decimal"  },
-            "telemetryProvider":       { "@id": "erDeg:telemetryProvider",       "@type": "xsd:string"   },
-            "commissioningDate":       { "@id": "deg:commissioningDate",         "@type": "xsd:dateTime" },
-            "location":                { "@id": "erDeg:location",                "@type": "@id"          },
-            "ratedApparentPowerKva":   { "@id": "erDeg:ratedApparentPowerKva",   "@type": "xsd:decimal"  },
-            "maxReactivePowerKvar":    { "@id": "erDeg:maxReactivePowerKvar",    "@type": "xsd:decimal"  },
-            "minReactivePowerKvar":    { "@id": "erDeg:minReactivePowerKvar",    "@type": "xsd:decimal"  },
-            "rideThroughCategory":     { "@id": "erDeg:rideThroughCategory",     "@type": "xsd:string"   },
-            "operatingMode":           { "@id": "erDeg:operatingMode",           "@type": "xsd:string"   },
-            "voltVarEnabled":          { "@id": "erDeg:voltVarEnabled",          "@type": "xsd:boolean"  },
-            "freqDroopEnabled":        { "@id": "erDeg:freqDroopEnabled",        "@type": "xsd:boolean"  },
-            "enterServiceRampTimeSec": { "@id": "erDeg:enterServiceRampTimeSec", "@type": "xsd:decimal"  }
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
+            "ratedApparentPowerKva":   { "@id": "erDeg:ratedApparentPowerKva",   "@type": "xsd:decimal" },
+            "maxReactivePowerKvar":    { "@id": "erDeg:maxReactivePowerKvar",    "@type": "xsd:decimal" },
+            "minReactivePowerKvar":    { "@id": "erDeg:minReactivePowerKvar",    "@type": "xsd:decimal" },
+            "rideThroughCategory":     { "@id": "erDeg:rideThroughCategory",     "@type": "xsd:string"  },
+            "operatingMode":           { "@id": "erDeg:operatingMode",           "@type": "xsd:string"  },
+            "voltVarEnabled":          { "@id": "erDeg:voltVarEnabled",          "@type": "xsd:boolean" },
+            "freqDroopEnabled":        { "@id": "erDeg:freqDroopEnabled",        "@type": "xsd:boolean" },
+            "enterServiceRampTimeSec": { "@id": "erDeg:enterServiceRampTimeSec", "@type": "xsd:decimal" }
           }
         },
-        "subResources":    { "@id": "erDeg:subResources",    "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceInverter/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceInverter/v1.0/vocab.jsonld
@@ -16,71 +16,8 @@
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — Inverter",
       "rdfs:comment": "Grid-connected power-electronics converter without a dedicated fuel source. Captures reactive-power and frequency-support capabilities per IEEE 1547-2018 and SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#PowerElectronicsConnection" }
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type discriminator",
-      "rdfs:comment": "Asset-class discriminator. For EnergyResourceInverter the value is always INVERTER.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak active power in kilowatts. Kept for backward compatibility. Prefer maxExportKw.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:maxExportKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max export power (kW)",
-      "rdfs:comment": "Maximum active power injected to the grid, kW. Always ≥0. SunSpec Model 702 maxW. CIM: PowerElectronicsConnection.maxP (injection direction).",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:maxImportKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max import power (kW)",
-      "rdfs:comment": "Maximum active power absorbed from the grid, kW. Always ≥0. Set for four-quadrant inverters. CIM: PowerElectronicsConnection.maxP (absorption direction).",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date-time when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:dateTime" }
-    },
-    {
-      "@id": "erDeg:location",
-      "@type": "rdf:Property",
-      "rdfs:label": "Location",
-      "rdfs:comment": "Physical location per beckn Location/2.0: geo (GeoJSON Point, coordinates [lon, lat]) + optional postal address.",
-      "schema:rangeIncludes": { "@id": "schema:Place" }
     },
     {
       "@id": "erDeg:ratedApparentPowerKva",
@@ -146,20 +83,6 @@
       "rdfs:comment": "Ramp time in seconds from 0 to rated power after reconnection. SunSpec Model 703 ESRmpTms.",
       "rdfs:domain": { "@id": "erDeg:EnergyResourceInverter" },
       "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources in the topology tree.",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceInverter" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent resources (e.g. the meter this inverter is behind).",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]
 }

--- a/specification/schema/EnergyResourceLoad/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceLoad/v1.0/context.jsonld
@@ -2,29 +2,22 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "EnergyResourceLoad": {
       "@id": "erDeg:EnergyResourceLoad",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make": { "@id": "erDeg:make", "@type": "xsd:string" },
-            "model": { "@id": "erDeg:model", "@type": "xsd:string" },
-            "ratedPowerKw": { "@id": "erDeg:ratedPowerKw", "@type": "xsd:decimal" },
-            "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string" },
-            "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
-            "location":          { "@id": "erDeg:location",        "@type": "@id"         },
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
             "controlProtocol": { "@id": "erDeg:controlProtocol", "@type": "xsd:string" },
-            "loadCategory": { "@id": "erDeg:loadCategory", "@type": "xsd:string" }
+            "loadCategory":    { "@id": "erDeg:loadCategory",    "@type": "xsd:string" }
           }
         },
-        "subResources": { "@id": "erDeg:subResources", "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceLoad/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceLoad/v1.0/vocab.jsonld
@@ -2,10 +2,10 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "rdf":   "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":  "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "schema": "https://schema.org/"
   },
   "@graph": [
@@ -14,57 +14,8 @@
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — Load",
       "rdfs:comment": "A controllable load energy resource (smart HVAC, water heater, controllable load). CIM: EnergyConsumer / ConformLoad (IEC 61970-301).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#ConformLoad" }
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type",
-      "rdfs:comment": "Asset-class discriminator. Values: SMART_HVAC, SMART_WATER_HEATER, CONTROLLABLE_LOAD.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceLoad" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. CIM: GeneratingUnit.maxOperatingP.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:gps",
-      "@type": "rdf:Property",
-      "rdfs:label": "GPS coordinates",
-      "rdfs:comment": "GPS coordinates of the asset as 'lat,lng' decimal string.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     },
     {
       "@id": "erDeg:controlProtocol",
@@ -82,20 +33,6 @@
       "rdfs:domain": { "@id": "erDeg:EnergyResourceLoad" },
       "schema:rangeIncludes": { "@id": "xsd:string" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#EnergyConsumer" }
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources in the topology tree.",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceLoad" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent resources (e.g. the meter this load sits behind).",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]
 }

--- a/specification/schema/EnergyResourceMeter/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceMeter/v1.0/context.jsonld
@@ -8,28 +8,21 @@
       "@id": "erDeg:EnergyResourceMeter",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make":               { "@id": "erDeg:make",               "@type": "xsd:string"  },
-            "model":              { "@id": "erDeg:model",              "@type": "xsd:string"  },
-            "ratedPowerKw":       { "@id": "erDeg:ratedPowerKw",       "@type": "xsd:decimal" },
-            "telemetryProvider":  { "@id": "erDeg:telemetryProvider",  "@type": "xsd:string"  },
-            "commissioningDate":  { "@id": "deg:commissioningDate",    "@type": "xsd:dateTime" },
-            "location":           { "@id": "erDeg:location",           "@type": "@id"         },
-            "meterCapability":    { "@id": "erDeg:meterCapability",    "@type": "xsd:string"  },
-            "energyDirection":    { "@id": "erDeg:energyDirection",    "@type": "xsd:string"  },
-            "functions":          { "@id": "erDeg:meterFunctions",     "@container": "@set"   },
-            "feeder":             { "@id": "erDeg:feeder",             "@type": "xsd:string"  },
-            "bus":                { "@id": "erDeg:bus",                "@type": "xsd:string"  },
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
+            "meterCapability":         { "@id": "erDeg:meterCapability",         "@type": "xsd:string" },
+            "energyDirection":         { "@id": "erDeg:energyDirection",         "@type": "xsd:string" },
+            "functions":               { "@id": "erDeg:meterFunctions",          "@container": "@set" },
+            "feeder":                  { "@id": "erDeg:feeder",                  "@type": "xsd:string" },
+            "bus":                     { "@id": "erDeg:bus",                     "@type": "xsd:string" },
             "communicationTechnology": { "@id": "erDeg:communicationTechnology", "@type": "xsd:string" },
             "applicationProtocol":     { "@id": "erDeg:applicationProtocol",     "@type": "xsd:string" }
           }
         },
-        "subResources":    { "@id": "erDeg:subResources",    "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceMeter/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceMeter/v1.0/vocab.jsonld
@@ -16,57 +16,8 @@
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — Meter",
       "rdfs:comment": "A metering-point energy resource. Anchors DER sub-resources in the topology tree. CIM: cim:Meter extends cim:EndDevice (IEC 61968-9).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61968-9.ttl#Meter" }
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type discriminator",
-      "rdfs:comment": "Asset-class discriminator. For EnergyResourceMeter the value is always METER.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceMeter" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. CIM: GeneratingUnit.maxOperatingP.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:gps",
-      "@type": "rdf:Property",
-      "rdfs:label": "GPS location",
-      "rdfs:comment": "GeoJSON Point geometry (RFC 7946) for the asset location. Coordinates are [longitude, latitude].",
-      "schema:rangeIncludes": { "@id": "schema:GeoCoordinates" }
     },
     {
       "@id": "erDeg:meterCapability",
@@ -122,14 +73,6 @@
       "schema:rangeIncludes": { "@id": "xsd:string" }
     },
     {
-      "@id": "erDeg:meterLocation",
-      "@type": "rdf:Property",
-      "rdfs:label": "Meter location",
-      "rdfs:comment": "Physical location of the meter installation per beckn Location/2.0 (GeoJSON Point + PostalAddress).",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceMeter" },
-      "schema:rangeIncludes": { "@id": "schema:Place" }
-    },
-    {
       "@id": "erDeg:communicationTechnology",
       "@type": "rdf:Property",
       "rdfs:label": "Communication technology",
@@ -148,20 +91,6 @@
         { "@id": "https://webstore.iec.ch/en/publication/67916" },
         { "@id": "https://www.nema.org/standards/view/ANSI-C12-18" }
       ]
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources in the topology tree (DERs, storage, loads behind this meter).",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceMeter" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent resources (feeder, substation) this meter belongs to.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]
 }

--- a/specification/schema/EnergyResourceNetwork/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceNetwork/v1.0/context.jsonld
@@ -2,31 +2,24 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "EnergyResourceNetwork": {
       "@id": "erDeg:EnergyResourceNetwork",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make": { "@id": "erDeg:make", "@type": "xsd:string" },
-            "model": { "@id": "erDeg:model", "@type": "xsd:string" },
-            "ratedPowerKw": { "@id": "erDeg:ratedPowerKw", "@type": "xsd:decimal" },
-            "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string" },
-            "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
-            "location":          { "@id": "erDeg:location",        "@type": "@id"         },
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
             "nominalVoltageKv": { "@id": "erDeg:nominalVoltageKv", "@type": "xsd:decimal" },
-            "zone": { "@id": "erDeg:zone", "@type": "xsd:string" },
-            "substationId": { "@id": "erDeg:substationId", "@type": "xsd:string" },
-            "feederCode": { "@id": "erDeg:feederCode", "@type": "xsd:string" }
+            "zone":             { "@id": "erDeg:zone",             "@type": "xsd:string"  },
+            "substationId":     { "@id": "erDeg:substationId",     "@type": "xsd:string"  },
+            "feederCode":       { "@id": "erDeg:feederCode",       "@type": "xsd:string"  }
           }
         },
-        "subResources": { "@id": "erDeg:subResources", "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceNetwork/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceNetwork/v1.0/vocab.jsonld
@@ -2,10 +2,10 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "rdf":   "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":  "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "schema": "https://schema.org/"
   },
   "@graph": [
@@ -14,57 +14,8 @@
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — Network",
       "rdfs:comment": "A grid-network infrastructure energy resource (DT, busbar, feeder, microgrid). CIM: PowerTransformer, BusbarSection, Feeder, Substation (IEC 61970-301).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#EquipmentContainer" }
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type",
-      "rdfs:comment": "Asset-class discriminator. Values: DT, BUS, FEEDER, MICROGRID.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceNetwork" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. CIM: GeneratingUnit.maxOperatingP.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:gps",
-      "@type": "rdf:Property",
-      "rdfs:label": "GPS coordinates",
-      "rdfs:comment": "GPS coordinates of the asset as 'lat,lng' decimal string.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     },
     {
       "@id": "erDeg:nominalVoltageKv",
@@ -100,20 +51,6 @@
       "rdfs:domain": { "@id": "erDeg:EnergyResourceNetwork" },
       "schema:rangeIncludes": { "@id": "xsd:string" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-301.ttl#Feeder" }
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources anchored to this network element (meters, DTs, buses).",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceNetwork" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent network elements (e.g. substation or feeder this DT belongs to).",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]
 }

--- a/specification/schema/EnergyResourceStorage/v1.0/context.jsonld
+++ b/specification/schema/EnergyResourceStorage/v1.0/context.jsonld
@@ -2,32 +2,23 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "EnergyResourceStorage": {
       "@id": "erDeg:EnergyResourceStorage",
       "@context": {
         "@version": 1.1,
-        "resourceType": { "@id": "erDeg:resourceType", "@type": "xsd:string" },
         "attributes": {
-          "@id": "erDeg:attributes",
-          "@type": "@id",
+          "@id": "deg:attributes",
           "@context": {
-            "make": { "@id": "erDeg:make", "@type": "xsd:string" },
-            "model": { "@id": "erDeg:model", "@type": "xsd:string" },
-            "ratedPowerKw": { "@id": "erDeg:ratedPowerKw", "@type": "xsd:decimal" },
-            "telemetryProvider": { "@id": "erDeg:telemetryProvider", "@type": "xsd:string" },
-            "commissioningDate": { "@id": "deg:commissioningDate", "@type": "xsd:dateTime" },
-            "location":          { "@id": "erDeg:location",        "@type": "@id"         },
+            "@import": "https://schema.beckn.io/EnergyResourceCommon/v1.0/attributes-context.jsonld",
             "storageCapacityKwh": { "@id": "erDeg:storageCapacityKwh", "@type": "xsd:decimal" },
-            "storageType": { "@id": "erDeg:storageType", "@type": "xsd:string" },
-            "stateOfHealthPct": { "@id": "erDeg:stateOfHealthPct", "@type": "xsd:decimal" },
-            "maxChargeRateKw": { "@id": "erDeg:maxChargeRateKw", "@type": "xsd:decimal" },
-            "maxDischargeRateKw": { "@id": "erDeg:maxDischargeRateKw", "@type": "xsd:decimal" }
+            "storageType":        { "@id": "erDeg:storageType",        "@type": "xsd:string"  },
+            "stateOfHealthPct":   { "@id": "erDeg:stateOfHealthPct",   "@type": "xsd:decimal" }
           }
         },
-        "subResources": { "@id": "erDeg:subResources", "@container": "@list" },
-        "parentResources": { "@id": "erDeg:parentResources", "@container": "@list" }
+        "subResources":    { "@id": "deg:subResources",    "@container": "@set" },
+        "parentResources": { "@id": "deg:parentResources", "@container": "@set" }
       }
     }
   }

--- a/specification/schema/EnergyResourceStorage/v1.0/vocab.jsonld
+++ b/specification/schema/EnergyResourceStorage/v1.0/vocab.jsonld
@@ -2,10 +2,10 @@
   "@context": {
     "@version": 1.1,
     "erDeg": "https://schema.beckn.io/deg/EnergyResource/",
-    "deg": "https://schema.beckn.io/deg#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "deg":   "https://schema.beckn.io/deg#",
+    "rdf":   "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":  "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
     "schema": "https://schema.org/"
   },
   "@graph": [
@@ -14,57 +14,8 @@
       "@type": "rdfs:Class",
       "rdfs:label": "EnergyResource — Storage",
       "rdfs:comment": "A storage DER energy resource (BESS, EV charger, V2G). CIM: BatteryUnit and ElectricVehicleChargingStation (IEC 61970-302).",
+      "rdfs:subClassOf": { "@id": "deg:EnergyResourceCommon" },
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61970-302.ttl#BatteryUnit" }
-    },
-    {
-      "@id": "erDeg:resourceType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Resource type",
-      "rdfs:comment": "Asset-class discriminator. Values: BESS, BATTERY (deprecated alias), EV_CHARGER, EV_V2G.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceStorage" },
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:make",
-      "@type": "rdf:Property",
-      "rdfs:label": "Manufacturer",
-      "rdfs:comment": "Manufacturer name of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:model",
-      "@type": "rdf:Property",
-      "rdfs:label": "Model",
-      "rdfs:comment": "Model number of the energy resource.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:ratedPowerKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Rated power (kW)",
-      "rdfs:comment": "Manufacturer-rated peak power in kilowatts. CIM: GeneratingUnit.maxOperatingP.",
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:telemetryProvider",
-      "@type": "rdf:Property",
-      "rdfs:label": "Telemetry provider",
-      "rdfs:comment": "Vendor API or data source identifier for telemetry.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "deg:commissioningDate",
-      "@type": "rdf:Property",
-      "rdfs:label": "Commissioning date",
-      "rdfs:comment": "ISO 8601 date when the asset was commissioned.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
-    },
-    {
-      "@id": "erDeg:gps",
-      "@type": "rdf:Property",
-      "rdfs:label": "GPS coordinates",
-      "rdfs:comment": "GPS coordinates of the asset as 'lat,lng' decimal string.",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     },
     {
       "@id": "erDeg:storageCapacityKwh",
@@ -90,36 +41,6 @@
       "rdfs:comment": "Battery state-of-health as a percentage (0–100).",
       "rdfs:domain": { "@id": "erDeg:EnergyResourceStorage" },
       "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:maxChargeRateKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max charge rate (kW)",
-      "rdfs:comment": "Maximum charge rate in kilowatts.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceStorage" },
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:maxDischargeRateKw",
-      "@type": "rdf:Property",
-      "rdfs:label": "Max discharge rate (kW)",
-      "rdfs:comment": "Maximum discharge rate in kilowatts.",
-      "rdfs:domain": { "@id": "erDeg:EnergyResourceStorage" },
-      "schema:rangeIncludes": { "@id": "xsd:decimal" }
-    },
-    {
-      "@id": "erDeg:subResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Sub-resources",
-      "rdfs:comment": "Child resources in the topology tree.",
-      "schema:rangeIncludes": { "@id": "erDeg:EnergyResourceStorage" }
-    },
-    {
-      "@id": "erDeg:parentResources",
-      "@type": "rdf:Property",
-      "rdfs:label": "Parent resources",
-      "rdfs:comment": "ids of parent resources (e.g. the meter this DER sits behind).",
-      "schema:rangeIncludes": { "@id": "xsd:string" }
     }
   ]
 }

--- a/specification/schema/MeterServiceProfile/v1.0/attributes.yaml
+++ b/specification/schema/MeterServiceProfile/v1.0/attributes.yaml
@@ -1,0 +1,111 @@
+openapi: 3.1.1
+info:
+  title: MeterServiceProfile
+  version: 1.0.0
+  description: |
+    Tariff, regulatory load, and connection profile for a single meter
+    connection point. Links to a METER resource via meterId.
+
+    Aligns with CIM UsagePoint (IEC 61968-9): sanctionedLoadKw maps to
+    UsagePoint.ratedCurrent × voltage, tariffCategoryCode to UsagePoint.serviceCategory,
+    connectionType to UsagePoint.phaseCode, paymentMode to ESPI AmiBillingReadyKind.
+
+    Used by ElectricityCredential/v1.2 consumptionProfiles[].
+    Formerly called ConsumptionProfile — that alias is preserved for backward compatibility.
+
+    Canonical IRI: https://schema.beckn.io/MeterServiceProfile/v1.0
+
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+servers:
+  - url: https://schema.beckn.io
+    description: Canonical schema registry
+paths: {}
+components:
+  schemas:
+
+    MeterServiceProfile:
+      $id: https://schema.beckn.io/MeterServiceProfile/v1.0#/components/schemas/MeterServiceProfile
+      type: object
+      description: >
+        Tariff and regulatory load profile for one meter connection point.
+        meterId links to a METER entry in energyResources[].
+        CIM: UsagePoint (IEC 61968-9).
+      required:
+        - meterId
+        - sanctionedLoadKw
+        - tariffCategoryCode
+      x-tags:
+        - electricity
+        - credential
+        - tariff
+        - meter
+      x-jsonld:
+        "@id": deg:MeterServiceProfile
+      properties:
+        meterId:
+          type: string
+          minLength: 1
+          description: Matches the id of a METER entry in customerProfile.energyResources[].
+          x-jsonld:
+            "@id": deg:meterId
+        sanctionedLoadKw:
+          type: number
+          minimum: 0.5
+          maximum: 10000
+          description: Sanctioned/approved import load in kW. CIM: UsagePoint.ratedCurrent × voltage.
+          x-jsonld:
+            "@id": deg:sanctionedLoadKw
+        sanctionedExportLoadKw:
+          type: number
+          minimum: 0
+          description: Sanctioned/approved grid export limit in kW.
+          x-jsonld:
+            "@id": deg:sanctionedExportLoadKw
+        billingCycleDay:
+          type: integer
+          minimum: 1
+          maximum: 31
+          description: Day of month on which the billing cycle resets.
+          x-jsonld:
+            "@id": deg:billingCycleDay
+        contractMaxDemandKw:
+          type: number
+          minimum: 0
+          description: Maximum demand contracted with the utility for this connection, in kW.
+          x-jsonld:
+            "@id": deg:contractMaxDemandKw
+        tariffCategoryCode:
+          type: string
+          minLength: 1
+          description: Billing/tariff category code assigned by the utility. CIM: UsagePoint.serviceCategory.
+          x-jsonld:
+            "@id": deg:tariffCategoryCode
+        premisesType:
+          type: string
+          enum:
+            - Residential
+            - Commercial
+            - Industrial
+            - Agricultural
+          description: Type of premises at the metering point.
+          x-jsonld:
+            "@id": deg:premisesType
+        connectionType:
+          type: string
+          enum:
+            - Single-phase
+            - Three-phase
+          description: Electrical connection type. CIM: UsagePoint.phaseCode.
+          x-jsonld:
+            "@id": deg:connectionType
+        paymentMode:
+          type: string
+          enum:
+            - POSTPAID
+            - PREPAID
+          description: >
+            Billing/payment modality. POSTPAID: consume now, pay later. PREPAID: pay-before-use.
+            Administrative — placed on the profile (not the meter) because it can change via
+            firmware without hardware replacement. CIM: ESPI AmiBillingReadyKind (IEC 61968-9).
+          x-jsonld:
+            "@id": deg:paymentMode

--- a/specification/schema/MeterServiceProfile/v1.0/context.jsonld
+++ b/specification/schema/MeterServiceProfile/v1.0/context.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "deg": "https://schema.beckn.io/deg#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "MeterServiceProfile": {
+      "@id": "deg:MeterServiceProfile"
+    },
+    "meterId":                { "@id": "deg:meterId" },
+    "sanctionedLoadKw":       { "@id": "deg:sanctionedLoadKw",       "@type": "xsd:decimal" },
+    "sanctionedExportLoadKw": { "@id": "deg:sanctionedExportLoadKw", "@type": "xsd:decimal" },
+    "billingCycleDay":        { "@id": "deg:billingCycleDay",        "@type": "xsd:integer" },
+    "contractMaxDemandKw":    { "@id": "deg:contractMaxDemandKw",    "@type": "xsd:decimal" },
+    "tariffCategoryCode":     { "@id": "deg:tariffCategoryCode" },
+    "premisesType":           { "@id": "deg:premisesType" },
+    "connectionType":         { "@id": "deg:connectionType" },
+    "paymentMode":            { "@id": "deg:paymentMode" }
+  }
+}

--- a/specification/schema/MeterServiceProfile/v1.0/schema.json
+++ b/specification/schema/MeterServiceProfile/v1.0/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.beckn.io/MeterServiceProfile/v1.0",
+  "title": "MeterServiceProfile",
+  "description": "Tariff, regulatory load, and connection profile for a single meter connection point. Links to a METER resource via meterId. CIM: UsagePoint (IEC 61968-9). Formerly called ConsumptionProfile in ElectricityCredential — that alias is preserved for backward compatibility.",
+  "$defs": {
+    "MeterServiceProfile": {
+      "$anchor": "MeterServiceProfile",
+      "type": "object",
+      "description": "Tariff and regulatory load profile for one meter connection. meterId matches the id of a METER entry in energyResources[].",
+      "required": ["meterId", "sanctionedLoadKw", "tariffCategoryCode"],
+      "properties": {
+        "meterId": { "type": "string", "minLength": 1, "description": "Matches the id of a METER entry in energyResources[]." },
+        "sanctionedLoadKw": { "type": "number", "minimum": 0.5, "maximum": 10000, "description": "Sanctioned/approved import load in kW." },
+        "sanctionedExportLoadKw": { "type": "number", "minimum": 0, "description": "Sanctioned/approved grid export limit in kW." },
+        "billingCycleDay": { "type": "integer", "minimum": 1, "maximum": 31, "description": "Day of month the billing cycle resets." },
+        "contractMaxDemandKw": { "type": "number", "minimum": 0, "description": "Maximum demand contracted with the utility, kW." },
+        "tariffCategoryCode": { "type": "string", "minLength": 1, "description": "Billing/tariff category code assigned by the utility." },
+        "premisesType": { "type": "string", "enum": ["Residential", "Commercial", "Industrial", "Agricultural"] },
+        "connectionType": { "type": "string", "enum": ["Single-phase", "Three-phase"], "description": "Electrical connection type. CIM: UsagePoint.phaseCode." },
+        "paymentMode": { "type": "string", "enum": ["POSTPAID", "PREPAID"], "description": "Billing/payment modality. Administrative — placed on the profile not the meter. CIM: ESPI AmiBillingReadyKind." }
+      }
+    }
+  }
+}

--- a/specification/schema/MeterServiceProfile/v1.0/vocab.jsonld
+++ b/specification/schema/MeterServiceProfile/v1.0/vocab.jsonld
@@ -1,0 +1,91 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "deg":    "https://schema.beckn.io/deg#",
+    "rdf":    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":   "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":    "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "deg:MeterServiceProfile",
+      "@type": "rdfs:Class",
+      "rdfs:label": "MeterServiceProfile",
+      "rdfs:comment": "Tariff, regulatory load, and connection profile for a single meter connection point. CIM: UsagePoint (IEC 61968-9). Formerly ConsumptionProfile in ElectricityCredential.",
+      "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61968-9.ttl#UsagePoint" }
+    },
+    {
+      "@id": "deg:meterId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Meter ID",
+      "rdfs:comment": "References the id of the METER entry in energyResources[].",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:sanctionedLoadKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Sanctioned load (kW)",
+      "rdfs:comment": "Sanctioned/approved import load in kilowatts. CIM: UsagePoint connection limits.",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "deg:sanctionedExportLoadKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Sanctioned export load (kW)",
+      "rdfs:comment": "Sanctioned/approved grid export limit in kilowatts.",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "deg:billingCycleDay",
+      "@type": "rdf:Property",
+      "rdfs:label": "Billing cycle day",
+      "rdfs:comment": "Day of the month on which the billing cycle resets (1–31).",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:integer" }
+    },
+    {
+      "@id": "deg:contractMaxDemandKw",
+      "@type": "rdf:Property",
+      "rdfs:label": "Contract max demand (kW)",
+      "rdfs:comment": "Maximum demand contracted with the utility for this connection, in kilowatts.",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:decimal" }
+    },
+    {
+      "@id": "deg:tariffCategoryCode",
+      "@type": "rdf:Property",
+      "rdfs:label": "Tariff category code",
+      "rdfs:comment": "Billing/tariff category code assigned by the utility. CIM: UsagePoint.serviceCategory.",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:premisesType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Premises type",
+      "rdfs:comment": "Type of premises at the metering point (Residential, Commercial, Industrial, Agricultural).",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:connectionType",
+      "@type": "rdf:Property",
+      "rdfs:label": "Connection type",
+      "rdfs:comment": "Electrical connection type (Single-phase, Three-phase). CIM: UsagePoint.phaseCode.",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
+      "@id": "deg:paymentMode",
+      "@type": "rdf:Property",
+      "rdfs:label": "Payment mode",
+      "rdfs:comment": "Billing/payment modality (POSTPAID, PREPAID). Administrative attribute. CIM: ESPI AmiBillingReadyKind (IEC 61968-9).",
+      "rdfs:domain": { "@id": "deg:MeterServiceProfile" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Item 1 — JSON-LD context composition**: Created `EnergyResourceCommon/v1.0/attributes-context.jsonld` as a flat importable context for the 10 common attributes bag fields (all `deg:` IRIs). Rewrote all 7 kind `context.jsonld` files to use `@import` inside their attributes scoped context and removed duplicated common field mappings. Fixed `erDeg:attributes/subResources/parentResources` → `deg:` in all kind contexts. Trimmed all 7 kind `vocab.jsonld` files: removed common properties already defined in `EnergyResourceCommon/v1.0/vocab.jsonld`, added `rdfs:subClassOf deg:EnergyResourceCommon` to each class, removed stale `maxChargeRateKw`/`maxDischargeRateKw` from Storage.
- **Item 2 — location `$ref`**: Replaced inline `location` definition (GeoJSON/Address) in `EnergyResourceCommon/v1.0/attributes.yaml` and `schema.json` with external `$ref` to `https://schema.beckn.io/Location/2.0`. Removed inline `GeoJSONGeometry`, `Address`, `Location` `$defs` from `schema.json`.
- **Item 4 — MeterServiceProfile extraction**: Extracted `ConsumptionProfile` from `ElectricityCredential/v1.2` into a new standalone schema `MeterServiceProfile/v1.0` (aligned with CIM `UsagePoint`, IEC 61968-9). Updated `ElectricityCredential/v1.2` to reference it via external `$ref`; kept `ConsumptionProfile` as a backward-compatible alias.

## Stats

- 18 files modified, 5 files created
- Net: −790 lines (deduplication)

## Test plan

- [ ] Verify `attributes-context.jsonld` is valid JSON-LD 1.1 (flat context, no `@import` loops)
- [ ] Verify each kind `context.jsonld` uses `@import` only inside the attributes scoped context (not at top level, per JSON-LD 1.1 spec)
- [ ] Verify `EnergyResourceCommon/v1.0/schema.json` has no inline `GeoJSONGeometry`/`Address`/`Location` `$defs`
- [ ] Verify `MeterServiceProfile/v1.0/attributes.yaml` matches the former `ConsumptionProfile` fields exactly
- [ ] Verify `ElectricityCredential/v1.2` still references `ConsumptionProfile` (backward compat alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)