### PR TITLE
fix(schema): quote CIM: descriptions in MeterServiceProfile attributes.yaml

### DIFF
--- a/specification/schema/MeterServiceProfile/v1.0/attributes.yaml
+++ b/specification/schema/MeterServiceProfile/v1.0/attributes.yaml
@@ -52,7 +52,7 @@ components:
           type: number
           minimum: 0.5
           maximum: 10000
-          description: Sanctioned/approved import load in kW. CIM: UsagePoint.ratedCurrent × voltage.
+          description: "Sanctioned/approved import load in kW. CIM: UsagePoint.ratedCurrent × voltage."
           x-jsonld:
             "@id": deg:sanctionedLoadKw
         sanctionedExportLoadKw:
@@ -77,7 +77,7 @@ components:
         tariffCategoryCode:
           type: string
           minLength: 1
-          description: Billing/tariff category code assigned by the utility. CIM: UsagePoint.serviceCategory.
+          description: "Billing/tariff category code assigned by the utility. CIM: UsagePoint.serviceCategory."
           x-jsonld:
             "@id": deg:tariffCategoryCode
         premisesType:
@@ -95,7 +95,7 @@ components:
           enum:
             - Single-phase
             - Three-phase
-          description: Electrical connection type. CIM: UsagePoint.phaseCode.
+          description: "Electrical connection type. CIM: UsagePoint.phaseCode."
           x-jsonld:
             "@id": deg:connectionType
         paymentMode:


### PR DESCRIPTION
## Summary

Fixes `[yaml-parse-error] attributes.yaml parse error: bad indentation of a mapping entry (55:66)`.

**Root cause:** PR #381 appeared to fix this but the cherry-pick conflict resolution left the unquoted version on main. This PR applies the fix directly to main.

**Root cause of original bug:** YAML plain scalars cannot contain `colon + space` (`: `). Three `description` fields embedded `CIM: UsagePoint.xxx` inline — the parser treated `CIM:` as a new mapping key.

**Fix:** Quote the three affected description strings (lines 55, 80, 98).

## Test plan

- [ ] YAML parse passes on `MeterServiceProfile/v1.0/attributes.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)