### PR TITLE
fix(context): consolidate deg: namespace to canonical IRI

### DIFF
--- a/specification/schema/EnergyCredential/v2.0/context.jsonld
+++ b/specification/schema/EnergyCredential/v2.0/context.jsonld
@@ -7,7 +7,7 @@
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "beckn": "https://schema.beckn.io/core/v2.0/",
-    "deg": "https://schema.beckn.io/deg/EnergyCredential/v2.0/",
+    "deg": "https://schema.beckn.io/deg#",
     "EnergyCredential": "deg:EnergyCredential",
     "issuer": "schema:issuer",
     "issuanceDate": "schema:dateCreated",

--- a/specification/schema/EnergyResource/v2.0/context.jsonld
+++ b/specification/schema/EnergyResource/v2.0/context.jsonld
@@ -6,7 +6,7 @@
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "beckn": "https://schema.beckn.io/core/v2.0/",
-    "deg": "https://schema.beckn.io/deg/EnergyResource/v2.0/",
+    "deg": "https://schema.beckn.io/deg#",
 
     "EnergyResource": "deg:EnergyResource",
 


### PR DESCRIPTION
## Summary

- `EnergyResource/v2.0/context.jsonld`: `deg:` was `https://schema.beckn.io/deg/EnergyResource/v2.0/` → `https://schema.beckn.io/deg#`
- `EnergyCredential/v2.0/context.jsonld`: `deg:` was `https://schema.beckn.io/deg/EnergyCredential/v2.0/` → `https://schema.beckn.io/deg#`

Both files used version-pinned prefixes, meaning `deg:make` in `EnergyResource/v2.0` and `deg:make` in `EnergyResourceCommon/v1.0` resolved to **different IRIs** in the linked-data graph. This fix makes all context files agree on the single canonical namespace.

## Why now

This is **PR A** of the context deduplication plan: it is a prerequisite for PR C, which will compose `ElectricityCredential/v1.2/context.jsonld` using `@import` from `EnergyResource/v2.0/context.jsonld`. The `@import` constraint requires the imported file to not use a version-pinned namespace that would conflict with the importing context.

## Test plan

- [ ] Verify `deg:make` resolves to `https://schema.beckn.io/deg#make` in both files
- [ ] Confirm no other `deg:` usages in these files point to the old versioned IRIs
- [ ] JSON-LD expansion of a sample EnergyResource payload produces correct IRIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)