### PR TITLE
feat(schema): extract CustomerDetails; simplify EnergyResource wrapper

### DIFF
--- a/specification/schema/CustomerDetails/README.md
+++ b/specification/schema/CustomerDetails/README.md
@@ -1,0 +1,34 @@
+# CustomerDetails
+
+PII identity and address details for a utility service customer.
+
+**Canonical IRI:** `https://schema.beckn.io/CustomerDetails/v1.0`  
+**CIM:** `cim:Customer` (IEC 61968-1)
+
+---
+
+## Versions
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| [v1.0](./v1.0/) | Current | Extracted from `ElectricityCredential/v1.2` `customerDetails`. Reusable across any utility credential carrying customer PII. |
+
+---
+
+## Purpose
+
+`CustomerDetails` carries the personally-identifiable information (PII) for a utility customer. It is intentionally kept separate from `CustomerProfile` (which is non-PII) so that credentials can be issued with or without the PII section depending on the data-sharing context.
+
+Three concerns:
+
+- **Identity** — `fullName` (as per ID proof)
+- **Location** — `installationAddress` (GeoJSON + PostalAddress via beckn Location/2.0)
+- **Tenure** — `serviceConnectionDate` (when the connection was activated)
+
+> `fullName` appears **only** here — never in `customerProfile` or any `energyResources` entry.
+
+## Usage
+
+Carried as `credentialSubject.customerDetails` in `ElectricityCredential/v1.2`. May be reused by any utility credential (gas, water) that needs to carry customer PII.
+
+See [v1.0/README.md](./v1.0/README.md) for the full field table and example.

--- a/specification/schema/CustomerDetails/v1.0/README.md
+++ b/specification/schema/CustomerDetails/v1.0/README.md
@@ -1,0 +1,68 @@
+# CustomerDetails v1.0
+
+**Schema ID:** `https://schema.beckn.io/CustomerDetails/v1.0`  
+**CIM:** `cim:Customer` (IEC 61968-1)  
+**Status:** Current
+
+---
+
+## Overview
+
+`CustomerDetails` carries the PII identity and address details for a utility service customer. It is separated from the non-PII `CustomerProfile` to allow credential issuers to control PII disclosure independently.
+
+Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a standalone reusable schema.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`schema.json`](./schema.json) | JSON Schema 2020-12 (bundled) |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 term → IRI mappings |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary — class and property definitions |
+
+---
+
+## Fields
+
+| Field | Required | Type | CIM | Description |
+|-------|----------|------|-----|-------------|
+| `fullName` | ✅ | string | `Customer.name` | Full name as per ID proof |
+| `installationAddress` | ✅ | Location/2.0 | `ServiceLocation` | GeoJSON Point + PostalAddress |
+| `serviceConnectionDate` | ✅ | date-time | activation date | ISO 8601 with timezone offset |
+
+---
+
+## CIM alignment
+
+| Field | CIM class / attribute | IEC standard |
+|---|---|---|
+| `CustomerDetails` | `cim:Customer` | IEC 61968-1 |
+| `installationAddress` | `cim:ServiceLocation` | IEC 61968-1 |
+| `serviceConnectionDate` | service connection activation date | IEC 61968-1 |
+
+---
+
+## Example
+
+```json
+{
+  "fullName": "Ravi Kumar",
+  "installationAddress": {
+    "geo": {
+      "type": "Point",
+      "coordinates": [77.5946, 12.9716]
+    },
+    "address": {
+      "streetAddress": "12 MG Road",
+      "addressLocality": "Bengaluru",
+      "addressRegion": "Karnataka",
+      "postalCode": "560001",
+      "addressCountry": "IN"
+    }
+  },
+  "serviceConnectionDate": "2019-03-15T10:00:00+05:30"
+}
+```

--- a/specification/schema/CustomerDetails/v1.0/attributes.yaml
+++ b/specification/schema/CustomerDetails/v1.0/attributes.yaml
@@ -1,0 +1,76 @@
+openapi: 3.1.1
+info:
+  title: CustomerDetails
+  version: 1.0.0
+  description: |
+    PII identity and address details for a utility service customer.
+
+    Contains the personally-identifiable information that is kept separate
+    from the non-PII CustomerProfile. fullName appears ONLY here — never
+    in customerProfile or any resource entry.
+
+    CIM alignment (IEC 61968-1):
+      CustomerDetails → cim:Customer
+      fullName        → cim:Customer.name
+      serviceConnectionDate → cim:ServiceLocation.firstAddressDetail (activation date)
+      installationAddress   → cim:ServiceLocation
+
+    Canonical IRI: https://schema.beckn.io/CustomerDetails/v1.0
+
+    Used by ElectricityCredential/v1.2 credentialSubject.customerDetails.
+    May be reused by any utility credential that carries customer PII.
+
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+servers:
+  - url: https://schema.beckn.io
+    description: Canonical schema registry
+paths: {}
+components:
+  schemas:
+
+    CustomerDetails:
+      $id: https://schema.beckn.io/CustomerDetails/v1.0#/components/schemas/CustomerDetails
+      type: object
+      description: >
+        PII identity and address details for a utility customer.
+        fullName appears ONLY here — never in customerProfile or resource entries.
+        CIM: cim:Customer (IEC 61968-1).
+      required:
+        - fullName
+        - installationAddress
+        - serviceConnectionDate
+      x-tags:
+        - customer
+        - pii
+        - credential
+        - electricity
+        - deg
+      x-jsonld:
+        "@id": deg:CustomerDetails
+      properties:
+
+        fullName:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Full name of the customer as per ID proof.
+          x-jsonld:
+            "@id": schema:name
+
+        installationAddress:
+          $ref: "https://schema.beckn.io/Location/2.0/attributes.yaml#/components/schemas/Location"
+          description: >
+            Physical location of the metered installation. geo (GeoJSON Point,
+            coordinates [longitude, latitude]) is required; address
+            (schema.org PostalAddress fields) is optional.
+          x-jsonld:
+            "@id": deg:installationAddress
+
+        serviceConnectionDate:
+          type: string
+          format: date-time
+          description: >
+            Date and time the service connection was activated, with timezone
+            offset (ISO 8601). CIM: ServiceLocation activation date.
+          x-jsonld:
+            "@id": deg:serviceConnectionDate

--- a/specification/schema/CustomerDetails/v1.0/context.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/context.jsonld
@@ -1,0 +1,43 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "deg":    "https://schema.beckn.io/deg#",
+    "xsd":    "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/",
+    "beckn":  "https://schema.beckn.io/",
+
+    "CustomerDetails": { "@id": "deg:CustomerDetails" },
+
+    "fullName":             { "@id": "schema:name",                  "@type": "xsd:string"   },
+    "serviceConnectionDate":{ "@id": "deg:serviceConnectionDate",    "@type": "xsd:dateTime" },
+
+    "installationAddress": {
+      "@id": "beckn:Location",
+      "@type": "@id",
+      "@context": {
+        "geo": {
+          "@id": "beckn:geo",
+          "@type": "@id",
+          "@context": {
+            "type":        { "@id": "beckn:geoType",     "@type": "xsd:string" },
+            "coordinates": { "@id": "beckn:coordinates", "@container": "@list" },
+            "bbox":        { "@id": "beckn:bbox",        "@container": "@list" },
+            "geometries":  { "@id": "beckn:geometries",  "@container": "@list" }
+          }
+        },
+        "address": {
+          "@id": "beckn:address",
+          "@type": "@id",
+          "@context": {
+            "streetAddress":   { "@id": "beckn:streetAddress",   "@type": "xsd:string" },
+            "extendedAddress": { "@id": "beckn:extendedAddress", "@type": "xsd:string" },
+            "addressLocality": { "@id": "beckn:addressLocality", "@type": "xsd:string" },
+            "addressRegion":   { "@id": "beckn:addressRegion",   "@type": "xsd:string" },
+            "addressCountry":  { "@id": "beckn:addressCountry",  "@type": "xsd:string" },
+            "postalCode":      { "@id": "beckn:postalCode",      "@type": "xsd:string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/schema/CustomerDetails/v1.0/schema.json
+++ b/specification/schema/CustomerDetails/v1.0/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.beckn.io/CustomerDetails/v1.0",
+  "title": "CustomerDetails v1.0",
+  "description": "PII identity and address details for a utility service customer. fullName appears ONLY here. CIM: cim:Customer (IEC 61968-1).",
+  "$defs": {
+    "CustomerDetails": {
+      "$anchor": "CustomerDetails",
+      "type": "object",
+      "required": ["fullName", "installationAddress", "serviceConnectionDate"],
+      "properties": {
+        "fullName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Full name of the customer as per ID proof."
+        },
+        "installationAddress": {
+          "$ref": "https://schema.beckn.io/Location/2.0/schema.json#/$defs/Location",
+          "description": "Physical location of the metered installation. geo (GeoJSON Point) required; address (PostalAddress) optional."
+        },
+        "serviceConnectionDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time the service connection was activated (ISO 8601 with timezone offset)."
+        }
+      }
+    }
+  }
+}

--- a/specification/schema/CustomerDetails/v1.0/vocab.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/vocab.jsonld
@@ -1,0 +1,35 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "deg":    "https://schema.beckn.io/deg#",
+    "rdf":    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":   "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd":    "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "deg:CustomerDetails",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Customer Details",
+      "rdfs:comment": "PII identity and address details for a utility service customer. CIM: cim:Customer (IEC 61968-1).",
+      "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61968-1.ttl#Customer" }
+    },
+    {
+      "@id": "deg:serviceConnectionDate",
+      "@type": "rdf:Property",
+      "rdfs:label": "Service connection date",
+      "rdfs:comment": "Date and time the utility service connection was activated. ISO 8601 with timezone offset.",
+      "rdfs:domain": { "@id": "deg:CustomerDetails" },
+      "schema:rangeIncludes": { "@id": "xsd:dateTime" }
+    },
+    {
+      "@id": "deg:installationAddress",
+      "@type": "rdf:Property",
+      "rdfs:label": "Installation address",
+      "rdfs:comment": "Physical location of the metered installation. CIM: cim:ServiceLocation (IEC 61968-1).",
+      "rdfs:domain": { "@id": "deg:CustomerDetails" },
+      "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61968-1.ttl#ServiceLocation" }
+    }
+  ]
+}

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -72,64 +72,12 @@ components:
               x-jsonld:
                 "@id": deg:customerProfile
             customerDetails:
+              $ref: "https://schema.beckn.io/CustomerDetails/v1.0#/components/schemas/CustomerDetails"
               description: >
-                Customer personal and address information. Kept inline because
-                installationAddress here follows the rich beckn Location shape,
-                broader than the address shape in UtilityCustomerCredential.
+                PII section — fullName, installationAddress (beckn Location/2.0),
+                serviceConnectionDate. Defined in CustomerDetails/v1.0.
               x-jsonld:
                 "@id": deg:customerDetails
-              type: object
-              required:
-                - fullName
-                - installationAddress
-                - serviceConnectionDate
-              properties:
-                fullName:
-                  type: string
-                  description: Full name of the customer as per ID proof.
-                installationAddress:
-                  type: object
-                  description: Physical location of the installation. Follows the beckn Location schema.
-                  required:
-                    - address
-                    - area_code
-                    - country
-                  properties:
-                    address:
-                      type: string
-                    city:
-                      type: object
-                      properties:
-                        name: { type: string }
-                        code: { type: string }
-                    district:
-                      type: string
-                    state:
-                      type: object
-                      properties:
-                        name: { type: string }
-                        code: { type: string }
-                    country:
-                      type: object
-                      required: [code]
-                      properties:
-                        name: { type: string }
-                        code:
-                          type: string
-                          pattern: "^[A-Z]{2}$"
-                          description: ISO 3166-1 alpha-2 country code.
-                    area_code:
-                      type: string
-                    gps:
-                      type: string
-                      description: "GPS coordinates as 'lat,lng' string."
-                    openLocationCode:
-                      type: string
-                      description: Open Location Code (OLC) for the installation.
-                serviceConnectionDate:
-                  type: string
-                  format: date-time
-                  description: Date and time the electricity connection was activated (with timezone offset).
             consumptionProfiles:
               description: >
                 Connection and consumption characteristics for load management

--- a/specification/schema/ElectricityCredential/v1.1/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.1/attributes.yaml
@@ -232,31 +232,8 @@ components:
             "@id": deg:billingCycleDay
 
     CustomerDetails:
-      type: object
+      $ref: "https://schema.beckn.io/CustomerDetails/v1.0#/components/schemas/CustomerDetails"
       description: >
-        PII section. fullName appears ONLY here — never in customerProfile
-        or any resource entry.
-      required:
-        - fullName
-        - installationAddress
-        - serviceConnectionDate
-      x-jsonld:
-        "@id": deg:customerDetails
-      properties:
-        fullName:
-          type: string
-          description: Full name of the customer as per ID proof.
-        installationAddress:
-          type: object
-          description: "Physical location per beckn Location/v2.0. geo (GeoJSONGeometry) is required; address (beckn Address/v2.0) is optional."
-          required:
-            - geo
-          properties:
-            geo:
-              $ref: 'https://schema.beckn.io/GeoJSONGeometry/v2.0/attributes.yaml#/components/schemas/GeoJSONGeometry'
-            address:
-              $ref: 'https://schema.beckn.io/Address/v2.0/attributes.yaml#/components/schemas/Address'
-        serviceConnectionDate:
-          type: string
-          format: date-time
-          description: Date and time the connection was activated (with timezone offset).
+        PII section — fullName, installationAddress, serviceConnectionDate.
+        fullName appears ONLY here — never in customerProfile or resource entries.
+        Defined in CustomerDetails/v1.0.

--- a/specification/schema/ElectricityCredential/v1.1/context.jsonld
+++ b/specification/schema/ElectricityCredential/v1.1/context.jsonld
@@ -87,39 +87,9 @@
             "@id": "deg:customerDetails",
             "@type": "@id",
             "@context": {
-                "@version": 1.1,
-                "@protected": true,
-                "fullName": { "@id": "schema:name", "@type": "xsd:string" },
-                "serviceConnectionDate": { "@id": "deg:serviceConnectionDate", "@type": "xsd:dateTime" },
-                "installationAddress": {
-                    "@id": "beckn:Location",
-                    "@type": "@id",
-                    "@context": {
-                        "beckn": "https://schema.beckn.io/",
-                        "geo": {
-                            "@id": "beckn:geo",
-                            "@type": "@id",
-                            "@context": {
-                                "type":        { "@id": "beckn:geoType",     "@type": "xsd:string" },
-                                "coordinates": { "@id": "beckn:coordinates", "@container": "@list" },
-                                "bbox":        { "@id": "beckn:bbox",        "@container": "@list" },
-                                "geometries":  { "@id": "beckn:geometries",  "@container": "@list" }
-                            }
-                        },
-                        "address": {
-                            "@id": "beckn:address",
-                            "@type": "@id",
-                            "@context": {
-                                "streetAddress":   { "@id": "beckn:streetAddress",   "@type": "xsd:string" },
-                                "extendedAddress": { "@id": "beckn:extendedAddress", "@type": "xsd:string" },
-                                "addressLocality": { "@id": "beckn:addressLocality", "@type": "xsd:string" },
-                                "addressRegion":   { "@id": "beckn:addressRegion",   "@type": "xsd:string" },
-                                "addressCountry":  { "@id": "beckn:addressCountry",  "@type": "xsd:string" },
-                                "postalCode":      { "@id": "beckn:postalCode",      "@type": "xsd:string" }
-                            }
-                        }
-                    }
-                }
+                "@import": "https://schema.beckn.io/CustomerDetails/v1.0/context.jsonld",
+                "@protected": true
+            }
             }
         },
         "credentialStatus": {

--- a/specification/schema/ElectricityCredential/v1.2/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.2/attributes.yaml
@@ -108,7 +108,7 @@ components:
           minItems: 1
           description: >
             All physical energy assets for this account. Each entry is
-            discriminated by 'type' into one of five composable kinds.
+            discriminated by 'type' into one of seven composable kinds.
           x-jsonld:
             "@id": deg:energyResources
           items:
@@ -154,30 +154,11 @@ components:
         Alias for MeterServiceProfile/v1.0 — kept for backward compatibility.
 
     CustomerDetails:
-      type: object
+      $ref: "https://schema.beckn.io/CustomerDetails/v1.0#/components/schemas/CustomerDetails"
       description: >
-        PII section. fullName appears ONLY here — never in customerProfile
-        or any resource entry.
-      required:
-        - fullName
-        - installationAddress
-        - serviceConnectionDate
-      x-jsonld:
-        "@id": deg:customerDetails
-      properties:
-        fullName:
-          type: string
-          description: Full name of the customer as per ID proof.
-        installationAddress:
-          $ref: "https://schema.beckn.io/Location/2.0/attributes.yaml#/components/schemas/Location"
-          description: >
-            Physical location of the installation. Follows the beckn Location/2.0 schema:
-            geo (required, GeoJSON Point — coordinates [longitude, latitude]) and
-            address (optional, schema.org PostalAddress fields).
-        serviceConnectionDate:
-          type: string
-          format: date-time
-          description: Date and time the connection was activated (with timezone offset).
+        PII section — fullName, installationAddress, serviceConnectionDate.
+        fullName appears ONLY here — never in customerProfile or resource entries.
+        Defined in CustomerDetails/v1.0.
 
     # ──────────────────────────────────────────────────────────────────────
     # EnergyResource composable hierarchy — kinds are external schemas
@@ -208,50 +189,8 @@ components:
       $ref: "https://schema.beckn.io/EnergyResourceNetwork/v1.0#/components/schemas/EnergyResourceNetwork"
 
     EnergyResource:
-      type: object
+      $ref: "https://schema.beckn.io/EnergyResource/v2.0#/components/schemas/EnergyResource"
       description: >
-        Composable energy resource, discriminated by 'type' into one of seven
-        kinds. id and type are required. Topology is expressed via
-        subResources[] (children) and parentResources[] (parents, e.g. the
-        meter a DER sits behind).
-
-        maxExportKw (≥0) and maxImportKw (≥0) replace ratedPowerKw in
-        EnergyResourceCommonAttributes. Both are non-negative directional
-        fields: maxExportKw = max power injected to grid; maxImportKw = max
-        power drawn from grid.
-
-        EV_CHARGER and EV_V2G are their own kind (EnergyResourceEVCharger),
-        not grouped with storage. INVERTER is a new kind for grid-connected
-        power-electronics converters.
-      required:
-        - id
-        - type
-      properties:
-        id:
-          type: string
-          minLength: 1
-          description: >
-            Stable identifier. For METER: meter serial number.
-            For DERs: any stable scheme.
-          x-jsonld:
-            "@id": "@id"
-        subResources:
-          type: array
-          description: Child resource ids or inline EnergyResource objects.
-          items:
-            oneOf:
-              - type: string
-              - $ref: "#/components/schemas/EnergyResource"
-        parentResources:
-          type: array
-          description: Parent resource ids — e.g. the meter a DER sits behind.
-          items:
-            type: string
-      oneOf:
-        - $ref: "#/components/schemas/EnergyResourceMeter"
-        - $ref: "#/components/schemas/EnergyResourceGenerator"
-        - $ref: "#/components/schemas/EnergyResourceStorage"
-        - $ref: "#/components/schemas/EnergyResourceEVCharger"
-        - $ref: "#/components/schemas/EnergyResourceInverter"
-        - $ref: "#/components/schemas/EnergyResourceLoad"
-        - $ref: "#/components/schemas/EnergyResourceNetwork"
+        Discriminated union of all seven typed EnergyResource kinds, each
+        inheriting id, type, subResources, parentResources, and attributes
+        from EnergyResourceCommon/v1.0. Defined in EnergyResource/v2.0.

--- a/specification/schema/ElectricityCredential/v1.2/context.jsonld
+++ b/specification/schema/ElectricityCredential/v1.2/context.jsonld
@@ -52,39 +52,8 @@
             "@id": "deg:customerDetails",
             "@type": "@id",
             "@context": {
-                "@version": 1.1,
-                "@protected": true,
-                "fullName": { "@id": "schema:name", "@type": "xsd:string" },
-                "serviceConnectionDate": { "@id": "deg:serviceConnectionDate", "@type": "xsd:dateTime" },
-                "installationAddress": {
-                    "@id": "beckn:Location",
-                    "@type": "@id",
-                    "@context": {
-                        "beckn": "https://schema.beckn.io/",
-                        "geo": {
-                            "@id": "beckn:geo",
-                            "@type": "@id",
-                            "@context": {
-                                "type":        { "@id": "beckn:geoType",     "@type": "xsd:string" },
-                                "coordinates": { "@id": "beckn:coordinates", "@container": "@list" },
-                                "bbox":        { "@id": "beckn:bbox",        "@container": "@list" },
-                                "geometries":  { "@id": "beckn:geometries",  "@container": "@list" }
-                            }
-                        },
-                        "address": {
-                            "@id": "beckn:address",
-                            "@type": "@id",
-                            "@context": {
-                                "streetAddress":   { "@id": "beckn:streetAddress",   "@type": "xsd:string" },
-                                "extendedAddress": { "@id": "beckn:extendedAddress", "@type": "xsd:string" },
-                                "addressLocality": { "@id": "beckn:addressLocality", "@type": "xsd:string" },
-                                "addressRegion":   { "@id": "beckn:addressRegion",   "@type": "xsd:string" },
-                                "addressCountry":  { "@id": "beckn:addressCountry",  "@type": "xsd:string" },
-                                "postalCode":      { "@id": "beckn:postalCode",      "@type": "xsd:string" }
-                            }
-                        }
-                    }
-                }
+                "@import": "https://schema.beckn.io/CustomerDetails/v1.0/context.jsonld",
+                "@protected": true
             }
         },
         "credentialStatus": {

--- a/specification/schema/ElectricityCredential/v1.2/schema.json
+++ b/specification/schema/ElectricityCredential/v1.2/schema.json
@@ -98,14 +98,8 @@
             "description": "Alias for MeterServiceProfile/v1.0. Kept for backward compatibility."
         },
         "CustomerDetails": {
-            "type": "object",
-            "description": "PII — fullName is only here.",
-            "required": ["fullName", "installationAddress", "serviceConnectionDate"],
-            "properties": {
-                "fullName": { "type": "string", "minLength": 1, "maxLength": 200 },
-                "installationAddress": { "$ref": "#/$defs/Location" },
-                "serviceConnectionDate": { "type": "string", "format": "date-time" }
-            }
+            "$ref": "https://schema.beckn.io/CustomerDetails/v1.0#CustomerDetails",
+            "description": "PII — fullName, installationAddress, serviceConnectionDate. Defined in CustomerDetails/v1.0."
         },
         "EnergyResourceCommonAttributes": {
             "type": "object",


### PR DESCRIPTION
## Summary

### 1 — New standalone schema: `CustomerDetails/v1.0`

Extracted from the inline `customerDetails` block in `ElectricityCredential` and published as a reusable schema at `https://schema.beckn.io/CustomerDetails/v1.0`.

**Why `CustomerDetails` (not `EnergyCustomerDetails`):**
- `fullName`, `installationAddress`, `serviceConnectionDate` are not energy-specific — they describe any utility customer (gas, water, electricity)
- Same naming pattern as `MeterServiceProfile` (not `EnergyMeterServiceProfile`)
- CIM maps it to `cim:Customer` (IEC 61968-1), which is also domain-neutral
- Can be reused by any future utility credential carrying customer PII

**Files:** `CustomerDetails/{README.md, v1.0/{attributes.yaml, schema.json, context.jsonld, vocab.jsonld, README.md}}`

### 2 — ElectricityCredential: CustomerDetails → `$ref`

| File | Change |
|------|--------|
| `v1.2/attributes.yaml` | inline CustomerDetails → `$ref CustomerDetails/v1.0` |
| `v1.2/context.jsonld` | 30-line inline customerDetails scope → `@import CustomerDetails/v1.0/context.jsonld` |
| `v1.2/schema.json` | inline CustomerDetails → `$ref CustomerDetails/v1.0` |
| `v1.1/attributes.yaml` | inline CustomerDetails → `$ref CustomerDetails/v1.0` |
| `v1.1/context.jsonld` | 30-line inline scope → `@import CustomerDetails/v1.0/context.jsonld` |
| `v1.0/attributes.yaml` | inline object (old beckn location shape) → `$ref CustomerDetails/v1.0` |

> **v1.0 note:** The original v1.0 `installationAddress` used the old beckn location shape (address string, city object, etc.). This has been updated to the modern Location/2.0 (GeoJSON + PostalAddress). v1.0 is a legacy version not expected to be used for new implementations.

### 3 — EnergyResource wrapper removed from `ElectricityCredential/v1.2`

The local `EnergyResource` definition in `v1.2/attributes.yaml` was **redundant**:
- `id`, `type`, `subResources`, `parentResources` are already on every kind via `EnergyResourceCommon/v1.0` (confirmed — `EnergyResourceCommon` already has `subResources: oneOf [string, EnergyResource/v2.0]`)
- The `oneOf` of 7 kinds is already the definition of `EnergyResource/v2.0`

Replaced the 48-line local definition with a `$ref` alias to `EnergyResource/v2.0`. Also fixed "five" → "seven" in `CustomerProfile.energyResources` description.

## Best practices applied

- New schema follows the same structure as `MeterServiceProfile/v1.0`: `attributes.yaml` + `schema.json` + `context.jsonld` (importable, flat) + `vocab.jsonld` + READMEs
- Context deduplication via `@import` — same pattern used for `consumptionProfiles` in PR #384
- External `$ref` for schema composition — same pattern used for `ConsumptionProfile` → `MeterServiceProfile/v1.0`

## Test plan

- [ ] JSON-LD expand an `ElectricityCredential` payload — verify `fullName` resolves to `schema:name`, `serviceConnectionDate` to `deg:serviceConnectionDate`
- [ ] Validate a `credentialSubject.customerDetails` payload against `CustomerDetails/v1.0/schema.json`
- [ ] Confirm `EnergyResource/v2.0` expansion includes `id`, `type`, `subResources`, `parentResources` on all 7 kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)