### PR TITLE
fix(schema-publish): add missing v1.1 READMEs; fix YAML parse error in EnergyResourceLoad

### DIFF
--- a/specification/schema/EnergyResource/v2.1/README.md
+++ b/specification/schema/EnergyResource/v2.1/README.md
@@ -1,0 +1,177 @@
+# EnergyResource — v2.1
+
+Canonical, technology-neutral class for any asset that produces, consumes, stores, or modulates energy. Used by P2P-trading, demand-flex, and `ElectricityCredential/v1.2` (`customerProfile.energyResources[]`).
+
+Part of the [DEG Schema](../../) · [EnergyResource](../README.md)
+
+## v2.1 changes
+
+All power and capacity fields now use `QuantitativeValue {value, unit}` with short unit aliases (`W`, `kW`, `MW`, `kWh`, `MWh`, `kVA`, `MVA`, `kVAR`, `MVAR`, `V`, `kV`) mapped to QUDT IRIs via JSON-LD context.
+
+| v2.0 (scalar) | v2.1 (QuantitativeValue) | unit enum |
+|---|---|---|
+| `ratedPowerKw` | `ratedPower` | `W \| kW \| MW` |
+| `maxExportKw` | `maxExport` | `W \| kW \| MW` |
+| `maxImportKw` | `maxImport` | `W \| kW \| MW` |
+| `nominalPowerKw` | `nominalPower` | `W \| kW \| MW` |
+| `storageCapacityKwh` | `storageCapacity` | `kWh \| MWh` |
+| `ratedApparentPowerKva` | `ratedApparentPower` | `kVA \| MVA` |
+| `maxReactivePowerKvar` / `minReactivePowerKvar` | `maxReactivePower` / `minReactivePower` | `kVAR \| MVAR` |
+| `nominalVoltageKv` | `nominalVoltage` | `V \| kV` |
+
+Inherits `EnergyResourceCommon/v1.1` (was v1.0 in v2.0).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [attributes.yaml](./attributes.yaml) | OpenAPI 3.1.1 — `EnergyResource` discriminated union and all typed kinds |
+| [context.jsonld](./context.jsonld) | JSON-LD context |
+| [vocab.jsonld](./vocab.jsonld) | RDF vocabulary |
+
+## Architecture
+
+`EnergyResource` is a discriminated union (`oneOf`) of seven typed kinds. Each kind does `allOf [EnergyResourceCommon]` and refines the `attributes` bag with kind-specific fields.
+
+```
+EnergyResourceCommonAttributes   ← attributes bag base (make, model, power, location…)
+        ↑ allOf
+EnergyResourceCommon             ← envelope (id, type, subResources, parentResources, attributes)
+        ↑ allOf  (each kind)
+EnergyResourceMeter        (METER)
+EnergyResourceGenerator    (SOLAR_PV | WIND | HYDRO | BIOGAS | CHP | FUEL_CELL)
+EnergyResourceStorage      (BESS)
+EnergyResourceEVCharger    (EV_CHARGER | EV_V2G)
+EnergyResourceInverter     (INVERTER)
+EnergyResourceLoad         (SMART_HVAC | SMART_WATER_HEATER | CONTROLLABLE_LOAD)
+EnergyResourceNetwork      (DT | BUS | FEEDER | MICROGRID)
+        ↑ oneOf
+EnergyResource
+```
+
+## Typed kinds
+
+| Kind | `type` values | CIM alignment |
+|------|--------------|---------------|
+| `EnergyResourceMeter` | `METER` | `Meter` / `EndDevice` (IEC 61968-9) |
+| `EnergyResourceGenerator` | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` | `GeneratingUnit` subtypes (IEC 61970-302) |
+| `EnergyResourceStorage` | `BESS` | `BatteryUnit` (IEC 61970-302) |
+| `EnergyResourceEVCharger` | `EV_CHARGER`, `EV_V2G` | `ElectricVehicleChargingStation` (CIM17+) |
+| `EnergyResourceInverter` | `INVERTER` | `PowerElectronicsConnection` (IEC 61970-302) |
+| `EnergyResourceLoad` | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` | `EnergyConsumer` / `ConformLoad` (IEC 61970-301) |
+| `EnergyResourceNetwork` | `DT`, `BUS`, `FEEDER`, `MICROGRID` | `PowerTransformer`, `BusbarSection`, `Feeder` (IEC 61970-301) |
+
+Deprecated values still accepted: `SOLAR` → use `SOLAR_PV`; `BATTERY` → use `BESS`.
+
+## Envelope fields (EnergyResourceCommon)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Stable identifier; meter serial for METER |
+| `type` | string enum | Discriminator — see table above |
+| `subResources` | array | Child ids (string) or inline `EnergyResource` objects |
+| `parentResources` | array of strings | FK refs to parent resources |
+| `attributes` | object | `EnergyResourceCommonAttributes` + kind-specific fields |
+
+## Common attributes (EnergyResourceCommonAttributes)
+
+All live inside the `attributes` bag. No field is required at the schema level.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `make` | string | Manufacturer |
+| `model` | string | Model |
+| `ratedPower` | QuantitativeValue | Backward compat; prefer `maxExport`. `unit: W\|kW\|MW` |
+| `maxExport` | QuantitativeValue | Max power injected to grid (generation / discharge). `unit: W\|kW\|MW` |
+| `maxImport` | QuantitativeValue | Max power drawn from grid (load / charge). `unit: W\|kW\|MW` |
+| `telemetryProvider` | string | Vendor API / data source |
+| `commissioningDate` | string (date-time) | ISO 8601 |
+| `location` | object | `geo` (GeoJSON, coordinates [lon, lat]) + optional `address` |
+
+## Kind-specific attributes
+
+### EnergyResourceMeter
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `meterCapability` | enum | `Electromechanical` · `CMRI` · `AMR` · `AMI` |
+| `energyDirection` | enum | `Forward` (default) · `Reverse` · `Bidirectional` · `Net` |
+| `functions` | string[] | `ToU`, `NetMetering`, `MaxDemand`, `LoadControl`, `TamperDetection`, `PowerQuality`, `EventLogging` |
+| `feeder` | string | Feeder ID |
+| `bus` | string | Busbar ID |
+| `communicationTechnology` | enum | `PLC`, `RF_Mesh`, `GPRS`, `NB-IoT`, `LoRa`, `ZigBee`, `Other` |
+| `applicationProtocol` | enum | `DLMS_COSEM`, `ANSI_C12_18`, `IEC_61850`, `Modbus`, `Other` |
+
+### EnergyResourceGenerator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `nominalPower` | QuantitativeValue | Nominal rated output. `unit: W\|kW\|MW`. CIM: `GeneratingUnit.nominalP` |
+| `efficiency` | number 0–100 | Conversion efficiency %; relevant for FUEL_CELL, CHP |
+
+### EnergyResourceStorage
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `storageCapacity` | QuantitativeValue | Rated energy capacity. `unit: kWh\|MWh`. CIM: `BatteryUnit.ratedE` |
+| `storageType` | enum | `LithiumIon` · `LeadAcid` · `FlowBattery` · `NaS` · `NiCd` · `Flywheel` · `Other` |
+| `stateOfHealthPct` | number 0–100 | State of health as % of original capacity |
+
+### EnergyResourceEVCharger
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `connectorType` | enum | `Type1`, `Type2`, `CCS1`, `CCS2`, `CHAdeMO`, `GB_T`, `NACS`, `Other` |
+| `controlProtocol` | enum | `OCPP_1.6`, `OCPP_2.0.1`, `OCPP_2.1`, `ISO_15118_2`, `ISO_15118_20`, `Other` |
+| `v2xProtocol` | enum | `CHAdeMO_V2G`, `CCS_BPT`, `ISO_15118_20_AC_BPT`, `ISO_15118_20_DC_BPT`, `Other` — EV_V2G only |
+
+### EnergyResourceInverter
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ratedApparentPower` | QuantitativeValue | Rated apparent power. `unit: kVA\|MVA`. SunSpec 702 `maxVA` |
+| `maxReactivePower` | QuantitativeValue | Max reactive injection (leading). `unit: kVAR\|MVAR`. SunSpec 702 `maxVar` |
+| `minReactivePower` | QuantitativeValue | Max reactive absorption (lagging). `unit: kVAR\|MVAR`. Value typically negative |
+| `rideThroughCategory` | enum | `CategoryI` / `CategoryII` / `CategoryIII` (IEEE 1547-2018) |
+| `operatingMode` | enum | `GridFollowing` / `GridForming` / `Standby` |
+| `voltVarEnabled` | boolean | Volt-VAr curve active |
+| `freqDroopEnabled` | boolean | Frequency-Watt droop active |
+| `enterServiceRampTimeSec` | number ≥0 | Ramp-up time after reconnect, seconds |
+
+### EnergyResourceLoad
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `controlProtocol` | enum | `OpenADR_2.0b`, `OCPP_2.0.1`, `SunSpec_Modbus`, `EEBus`, `Modbus`, `Other` |
+| `loadCategory` | enum | `Heating`, `Cooling`, `WaterHeating`, `Lighting`, `EV`, `Industrial`, `Other` |
+
+### EnergyResourceNetwork
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `nominalVoltage` | QuantitativeValue | Nominal voltage. `unit: V\|kV`. CIM: `BaseVoltage.nominalVoltage` |
+| `zone` | string | Operating zone or region identifier |
+| `substationId` | string | Parent substation identifier |
+| `feederCode` | string | Feeder code per utility network records |
+
+## Examples
+
+**SOLAR DER behind a meter:**
+```json
+{
+  "id": "did:web:utility.com:assets:solar:DER-SOLAR-001",
+  "type": "SOLAR_PV",
+  "attributes": {"maxExport": {"value": 5, "unit": "kW"}, "make": "Waaree", "model": "WS-400M"},
+  "parentResources": ["did:web:utility.com:assets:meter:MET001"]
+}
+```
+
+**BESS (5 kW / 10 kWh):**
+```json
+{
+  "id": "did:web:utility.com:assets:bess:BESS-001",
+  "type": "BESS",
+  "attributes": {"maxExport": {"value": 5, "unit": "kW"}, "maxImport": {"value": 5, "unit": "kW"}, "storageCapacity": {"value": 10, "unit": "kWh"}},
+  "parentResources": ["did:web:utility.com:assets:meter:MET001"]
+}
+```

--- a/specification/schema/EnergyResourceCommon/v1.1/README.md
+++ b/specification/schema/EnergyResourceCommon/v1.1/README.md
@@ -1,0 +1,95 @@
+# EnergyResourceCommon v1.1
+
+Canonical base schemas shared by all typed `EnergyResource` kinds.
+
+**Canonical IRI:** `https://schema.beckn.io/EnergyResourceCommon/v1.1`
+
+---
+
+## v1.1 changes
+
+Power dimensioning fields now use `QuantitativeValue {value, unit}` instead of plain numbers with unit-suffixed names:
+
+| v1.0 (scalar) | v1.1 (QuantitativeValue) | unit enum |
+|---|---|---|
+| `ratedPowerKw` | `ratedPower` | `W \| kW \| MW` |
+| `maxExportKw` | `maxExport` | `W \| kW \| MW` |
+| `maxImportKw` | `maxImport` | `W \| kW \| MW` |
+
+Unit aliases (`W`, `kW`, `MW`, `kWh`, `MWh`, `kVA`, `MVA`, `kVAR`, `MVAR`, `V`, `kV`) are defined in the JSON-LD context and mapped to QUDT IRIs.
+
+---
+
+## Schemas
+
+### `EnergyResourceCommon`
+
+The structural envelope inherited by every kind via `allOf`. Defines:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Stable asset identifier (IES DID convention) |
+| `type` | string | Asset class discriminator — constrained to a kind-specific `enum` or `const` |
+| `subResources` | array | Downward topology — child resource ids or inline EnergyResource objects |
+| `parentResources` | array | Upward topology — ids of parent resources (string refs only) |
+| `attributes` | object | Attribute bag — inherits `EnergyResourceCommonAttributes` via `allOf` |
+
+### `EnergyResourceCommonAttributes`
+
+The attribute bag base inherited inside every kind's `<Kind>Attributes` object via `allOf`. No field is required at this level.
+
+| Field | Type | Description |
+|---|---|---|
+| `make` | string | Manufacturer (free text) |
+| `model` | string | Model (free text) |
+| `ratedPower` | QuantitativeValue | Nameplate power. Deprecated; prefer `maxExport` |
+| `maxExport` | QuantitativeValue | Max power injected to grid (discharge / generation). `unit: W\|kW\|MW` |
+| `maxImport` | QuantitativeValue | Max power drawn from grid (charge / load). `unit: W\|kW\|MW` |
+| `telemetryProvider` | string | Vendor API / data-source identifier |
+| `commissioningDate` | date-time | ISO 8601 asset commissioning date-time |
+| `location` | object | beckn Location/2.0 shape — `geo` (GeoJSON, required) + `address` (postal, optional) |
+
+---
+
+## Inheritance pattern
+
+**Kind envelope:**
+
+```yaml
+EnergyResourceMeter:
+  allOf:
+    - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+    - type: object
+      properties:
+        type:
+          const: "METER"
+        attributes:
+          $ref: "#/components/schemas/EnergyResourceMeterAttributes"
+```
+
+**Kind attributes bag:**
+
+```yaml
+EnergyResourceMeterAttributes:
+  allOf:
+    - $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+    - type: object
+      additionalProperties: true
+      properties:
+        # Kind-specific fields only — common fields inherited above
+        meterCapability: ...
+```
+
+---
+
+## Kinds that inherit this schema
+
+| Kind | Canonical IRI | Types |
+|---|---|---|
+| EnergyResourceMeter | `schema.beckn.io/EnergyResourceMeter/v1.1` | `METER` |
+| EnergyResourceGenerator | `schema.beckn.io/EnergyResourceGenerator/v1.1` | `SOLAR_PV`, `WIND`, `HYDRO`, `BIOGAS`, `CHP`, `FUEL_CELL` |
+| EnergyResourceStorage | `schema.beckn.io/EnergyResourceStorage/v1.1` | `BESS` |
+| EnergyResourceEVCharger | `schema.beckn.io/EnergyResourceEVCharger/v1.1` | `EV_CHARGER`, `EV_V2G` |
+| EnergyResourceInverter | `schema.beckn.io/EnergyResourceInverter/v1.1` | `INVERTER` |
+| EnergyResourceLoad | `schema.beckn.io/EnergyResourceLoad/v1.1` | `SMART_HVAC`, `SMART_WATER_HEATER`, `CONTROLLABLE_LOAD` |
+| EnergyResourceNetwork | `schema.beckn.io/EnergyResourceNetwork/v1.1` | `DT`, `BUS`, `FEEDER`, `MICROGRID` |

--- a/specification/schema/EnergyResourceEVCharger/v1.1/README.md
+++ b/specification/schema/EnergyResourceEVCharger/v1.1/README.md
@@ -1,0 +1,93 @@
+# EnergyResourceEVCharger v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceEVCharger/v1.1`
+**CIM:** `ElectricVehicleChargingStation` (CIM17+)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. Common power fields renamed to `QuantitativeValue`:
+`ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport` (unit: `W|kW|MW`).
+
+---
+
+## Overview
+
+`EnergyResourceEVCharger` represents EV charging stations (EVSE). It is a **flexible load** — NOT a storage resource. The EV battery is storage; the EVSE is the charge/discharge interface.
+
+`EV_V2G` is a specialisation of `EV_CHARGER` with ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. Set `maxImport` (charge) and `maxExport` (V2G discharge) in the `attributes` bag.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | Description |
+|---|---|
+| `EV_CHARGER` | Unidirectional EV charging station |
+| `EV_V2G` | Bidirectional V2G-capable EVSE (ISO 15118-20 / OCPP 2.1 BPT) |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxImport` | QuantitativeValue | Max charge rate. `unit: W\|kW\|MW` |
+| `maxExport` | QuantitativeValue | Max V2G discharge rate (EV_V2G only). `unit: W\|kW\|MW` |
+| `commissioningDate` | date-time | ISO 8601 |
+
+### EV-specific attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `connectorType` | enum | `Type1`, `Type2`, `CCS1`, `CCS2`, `CHAdeMO`, `GB_T`, `NACS`, `Other` (IEC 62196 / J3400) |
+| `controlProtocol` | enum | `OCPP_1.6`, `OCPP_2.0.1`, `OCPP_2.1`, `ISO_15118_2`, `ISO_15118_20`, `Other` |
+| `v2xProtocol` | enum | `CHAdeMO_V2G`, `CCS_BPT`, `ISO_15118_20_AC_BPT`, `ISO_15118_20_DC_BPT`, `Other` — present for EV_V2G |
+
+---
+
+## Examples
+
+**EV_CHARGER:**
+```json
+{
+  "id": "did:web:utility.com:assets:evse:EVSE-001",
+  "type": "EV_CHARGER",
+  "attributes": {
+    "maxImport": {"value": 7.4, "unit": "kW"},
+    "connectorType": "Type2",
+    "controlProtocol": "OCPP_2.0.1"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```
+
+**EV_V2G:**
+```json
+{
+  "id": "did:web:utility.com:assets:evse:EVSE-V2G-001",
+  "type": "EV_V2G",
+  "attributes": {
+    "maxImport": {"value": 7.4, "unit": "kW"},
+    "maxExport": {"value": 3.7, "unit": "kW"},
+    "connectorType": "Type2",
+    "controlProtocol": "ISO_15118_20",
+    "v2xProtocol": "ISO_15118_20_AC_BPT"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/EnergyResourceGenerator/v1.1/README.md
+++ b/specification/schema/EnergyResourceGenerator/v1.1/README.md
@@ -1,0 +1,82 @@
+# EnergyResourceGenerator v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceGenerator/v1.1`
+**CIM:** `GeneratingUnit` subtypes (IEC 61970-302)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. Common power fields renamed to `QuantitativeValue`:
+`ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport`.
+Generator-specific: `nominalPowerKw → nominalPower` (unit: `W|kW|MW`).
+
+---
+
+## Overview
+
+`EnergyResourceGenerator` covers all electrical generation technologies: solar PV, wind, hydro, biogas, CHP, and fuel cell.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class | Notes |
+|---|---|---|
+| `SOLAR_PV` | `PhotovoltaicUnit` | Preferred; `SOLAR` deprecated |
+| `WIND` | `WindGeneratingUnit` | |
+| `HYDRO` | `HydroGeneratingUnit` | |
+| `BIOGAS` | `ThermalGeneratingUnit` (by fuel) | |
+| `CHP` | `ThermalGeneratingUnit` (combined heat and power) | |
+| `FUEL_CELL` | IEC 62933-2 | |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model number |
+| `maxExport` | QuantitativeValue | Peak generation capacity. `unit: W\|kW\|MW` |
+| `telemetryProvider` | string | Telemetry vendor / API |
+| `commissioningDate` | date-time | ISO 8601 |
+| `location` | object | `geo` + optional `address` |
+
+### Generator-specific attributes
+
+| Field | Type | CIM | Description |
+|-------|------|-----|-------------|
+| `nominalPower` | QuantitativeValue | `GeneratingUnit.nominalP` | Nominal rated output. `unit: W\|kW\|MW` |
+| `efficiency` | number 0–100 | — | Conversion efficiency %; relevant for FUEL_CELL, CHP |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "id": "did:web:utility.com:assets:solar:DER-SOLAR-001",
+  "type": "SOLAR_PV",
+  "attributes": {
+    "maxExport": {"value": 5, "unit": "kW"},
+    "make": "Waaree",
+    "model": "WS-400M",
+    "commissioningDate": "2025-02-10T00:00:00+05:30"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/EnergyResourceInverter/v1.1/README.md
+++ b/specification/schema/EnergyResourceInverter/v1.1/README.md
@@ -1,0 +1,83 @@
+# EnergyResourceInverter v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceInverter/v1.1`
+**CIM:** `cim:PowerElectronicsConnection` (IEC 61970-302)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. All power fields renamed to `QuantitativeValue`:
+- Common: `ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport` (unit: `W|kW|MW`)
+- Inverter-specific: `ratedApparentPowerKva → ratedApparentPower` (unit: `kVA|MVA`), `maxReactivePowerKvar → maxReactivePower`, `minReactivePowerKvar → minReactivePower` (unit: `kVAR|MVAR`)
+
+---
+
+## Overview
+
+`EnergyResourceInverter` represents grid-connected power-electronics inverters without a dedicated fuel source. Captures reactive-power and frequency-support capabilities per **IEEE 1547-2018** and **SunSpec DER Models 702–714**. Use cases: standalone battery inverters, VPP aggregation points, grid-forming inverters.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class |
+|---|---|
+| `INVERTER` | `PowerElectronicsConnection` (IEC 61970-302) |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxExport` | QuantitativeValue | Max active power export. `unit: W\|kW\|MW` |
+| `maxImport` | QuantitativeValue | Max active power import. `unit: W\|kW\|MW` |
+
+### Inverter-specific attributes
+
+| Field | Type | Standard | Description |
+|-------|------|----------|-------------|
+| `ratedApparentPower` | QuantitativeValue | SunSpec 702 `maxVA` | Rated apparent power. `unit: kVA\|MVA` |
+| `maxReactivePower` | QuantitativeValue | SunSpec 702 `maxVar` | Max reactive injection (leading). `unit: kVAR\|MVAR` |
+| `minReactivePower` | QuantitativeValue | SunSpec 702 `maxVarNeg` | Max reactive absorption (lagging). `unit: kVAR\|MVAR`. Value typically negative |
+| `rideThroughCategory` | enum | IEEE 1547-2018 | `CategoryI` / `CategoryII` / `CategoryIII` |
+| `operatingMode` | enum | CIM `inverterMode` | `GridFollowing` / `GridForming` / `Standby` |
+| `voltVarEnabled` | boolean | IEEE 2030.5 / SunSpec 705 | Volt-VAr curve active |
+| `freqDroopEnabled` | boolean | SunSpec 711 / IEEE 1547 | Frequency-Watt droop active |
+| `enterServiceRampTimeSec` | number ≥0 | SunSpec 703 `ESRmpTms` | Ramp-up time after reconnect, seconds |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "id": "did:web:utility.com:assets:inv:INV-001",
+  "type": "INVERTER",
+  "attributes": {
+    "maxExport": {"value": 10, "unit": "kW"},
+    "maxImport": {"value": 10, "unit": "kW"},
+    "ratedApparentPower": {"value": 12, "unit": "kVA"},
+    "maxReactivePower": {"value": 6, "unit": "kVAR"},
+    "operatingMode": "GridForming",
+    "voltVarEnabled": true,
+    "freqDroopEnabled": true,
+    "rideThroughCategory": "CategoryIII"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/EnergyResourceLoad/v1.1/README.md
+++ b/specification/schema/EnergyResourceLoad/v1.1/README.md
@@ -1,0 +1,73 @@
+# EnergyResourceLoad v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceLoad/v1.1`
+**CIM:** `cim:EnergyConsumer` / `cim:ConformLoad` (IEC 61970-301)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. Common power fields renamed to `QuantitativeValue`:
+`ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport` (unit: `W|kW|MW`).
+
+---
+
+## Overview
+
+`EnergyResourceLoad` represents controllable electrical loads including smart HVAC, smart water heaters, and generic demand-response loads.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class |
+|---|---|
+| `SMART_HVAC` | `EnergyConsumer` / `ConformLoad` |
+| `SMART_WATER_HEATER` | `EnergyConsumer` / `ConformLoad` |
+| `CONTROLLABLE_LOAD` | `EnergyConsumer` / `ConformLoad` |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxImport` | QuantitativeValue | Rated load draw. `unit: W\|kW\|MW` |
+| `commissioningDate` | date-time | ISO 8601 |
+
+### Load-specific attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `controlProtocol` | enum | `OpenADR_2.0b`, `OCPP_2.0.1`, `SunSpec_Modbus`, `EEBus`, `Modbus`, `Other` |
+| `loadCategory` | enum | `Heating`, `Cooling`, `WaterHeating`, `Lighting`, `EV`, `Industrial`, `Other` |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "id": "did:web:utility.com:assets:hvac:HVAC-001",
+  "type": "SMART_HVAC",
+  "attributes": {
+    "maxImport": {"value": 3, "unit": "kW"},
+    "loadCategory": "Heating",
+    "controlProtocol": "OpenADR_2.0b"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/EnergyResourceLoad/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceLoad/v1.1/attributes.yaml
@@ -57,6 +57,6 @@ components:
             loadCategory:
               type: string
               enum: [Heating, Cooling, WaterHeating, Lighting, EV, Industrial, Other]
-              description: Functional category of this load. CIM: ConformLoad classification.
+              description: "Functional category of this load. CIM: ConformLoad classification."
               x-jsonld:
                 "@id": erDeg:loadCategory

--- a/specification/schema/EnergyResourceMeter/v1.1/README.md
+++ b/specification/schema/EnergyResourceMeter/v1.1/README.md
@@ -1,0 +1,85 @@
+# EnergyResourceMeter v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceMeter/v1.1`
+**CIM:** `cim:Meter` extends `cim:EndDevice` (IEC 61968-9)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. Common power fields renamed to `QuantitativeValue`:
+`ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport` (unit: `W|kW|MW`).
+
+---
+
+## Overview
+
+`EnergyResourceMeter` is the typed attribute schema for metering-point energy resources (`type = "METER"`). It anchors all DER sub-resources in the topology tree and carries the physical installation location, feeder/bus references, and communication technology.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class |
+|---|---|
+| `METER` | `cim:Meter` (IEC 61968-9) |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model number |
+| `ratedPower` | QuantitativeValue | Rated peak power. `unit: W\|kW\|MW` |
+| `maxExport` | QuantitativeValue | Max grid export capacity. `unit: W\|kW\|MW` |
+| `maxImport` | QuantitativeValue | Max grid import capacity. `unit: W\|kW\|MW` |
+| `telemetryProvider` | string | Telemetry vendor / API identifier |
+| `commissioningDate` | date-time | ISO 8601 |
+| `location` | object | `geo` (GeoJSONGeometry) + optional `address` |
+
+### Meter-specific attributes
+
+| Field | Type | CIM | Description |
+|-------|------|-----|-------------|
+| `meterCapability` | enum | `AmiBillingReadyKind` (IEC 61968-9) | `Electromechanical` · `CMRI` · `AMR` · `AMI` |
+| `energyDirection` | enum | `FlowDirectionKind` (ESPI NAESB REQ.21) | `Forward` (default) · `Reverse` · `Bidirectional` · `Net` |
+| `functions` | array of enum | `EndDeviceFunction[0..*]` (IEC 61968-9) | `ToU` · `NetMetering` · `MaxDemand` · `LoadControl` · `TamperDetection` · `PowerQuality` · `EventLogging` |
+| `feeder` | string | — | Feeder identifier this meter is supplied from |
+| `bus` | string | — | Busbar identifier at the connection point |
+| `communicationTechnology` | enum | — | `PLC` · `RF_Mesh` · `GPRS` · `NB-IoT` · `LoRa` · `ZigBee` · `Other` |
+| `applicationProtocol` | enum | IEC 62056 / ANSI C12 | `DLMS_COSEM` · `ANSI_C12_18` · `IEC_61850` · `Modbus` · `Other` |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "id": "did:web:bescom.karnataka.gov.in:assets:meter:MET-001",
+  "type": "METER",
+  "attributes": {
+    "meterCapability": "AMI",
+    "energyDirection": "Forward",
+    "location": {"geo": {"type": "Point", "coordinates": [77.5946, 12.9716]}},
+    "feeder": "FDR-BLR-042",
+    "communicationTechnology": "NB-IoT",
+    "applicationProtocol": "DLMS_COSEM"
+  },
+  "parentResources": ["did:web:bescom.karnataka.gov.in:assets:feeder:FDR-BLR-042"]
+}
+```

--- a/specification/schema/EnergyResourceNetwork/v1.1/README.md
+++ b/specification/schema/EnergyResourceNetwork/v1.1/README.md
@@ -1,0 +1,77 @@
+# EnergyResourceNetwork v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceNetwork/v1.1`
+**CIM:** `PowerTransformer`, `BusbarSection`, `Feeder`, `Substation` (IEC 61970-301)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. Common power fields renamed to `QuantitativeValue`:
+`ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport`.
+Network-specific: `nominalVoltageKv → nominalVoltage` (unit: `V|kV`).
+
+---
+
+## Overview
+
+`EnergyResourceNetwork` represents distribution network topology elements used for hierarchical grid modelling and feeder-level aggregation.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class | Description |
+|---|---|---|
+| `DT` | `PowerTransformer` | Distribution transformer |
+| `BUS` | `BusbarSection` | Busbar / bus section |
+| `FEEDER` | `Feeder` | Distribution feeder |
+| `MICROGRID` | `Substation` / custom | Microgrid or sub-grid island |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `make` | string | Manufacturer |
+| `model` | string | Model |
+| `commissioningDate` | date-time | ISO 8601 |
+
+### Network-specific attributes
+
+| Field | Type | CIM | Description |
+|-------|------|-----|-------------|
+| `nominalVoltage` | QuantitativeValue | `BaseVoltage.nominalVoltage` | Nominal operating voltage. `unit: V\|kV` |
+| `zone` | string | — | Operating zone or region identifier |
+| `substationId` | string | — | Parent substation identifier |
+| `feederCode` | string | — | Feeder code per utility network records |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "id": "did:web:utility.com:assets:feeder:FDR-BLR-042",
+  "type": "FEEDER",
+  "attributes": {
+    "nominalVoltage": {"value": 11, "unit": "kV"},
+    "feederCode": "FDR-042",
+    "substationId": "SS-BLR-NORTH-01"
+  }
+}
+```

--- a/specification/schema/EnergyResourceStorage/v1.1/README.md
+++ b/specification/schema/EnergyResourceStorage/v1.1/README.md
@@ -1,0 +1,75 @@
+# EnergyResourceStorage v1.1
+
+**Schema ID:** `https://schema.beckn.io/EnergyResourceStorage/v1.1`
+**CIM:** `cim:BatteryUnit` (IEC 61970-302)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+Inherits `EnergyResourceCommon/v1.1`. Common power fields renamed to `QuantitativeValue`:
+`ratedPowerKw → ratedPower`, `maxExportKw → maxExport`, `maxImportKw → maxImport`.
+Storage-specific: `storageCapacityKwh → storageCapacity` (unit: `kWh|MWh`).
+
+---
+
+## Overview
+
+`EnergyResourceStorage` represents stationary energy storage assets (BESS). `storageCapacity` (QuantitativeValue) is exclusive to this kind. EV charging stations are NOT storage; see `EnergyResourceEVCharger`.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 context |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary |
+
+---
+
+## Type Discriminator
+
+| `type` value | CIM class | Notes |
+|---|---|---|
+| `BESS` | `BatteryUnit` (IEC 61970-302) | Preferred; `BATTERY` deprecated |
+
+---
+
+## Attributes
+
+### Common attributes (inherited from EnergyResourceCommon/v1.1)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxExport` | QuantitativeValue | Max discharge rate. `unit: W\|kW\|MW` |
+| `maxImport` | QuantitativeValue | Max charge rate. `unit: W\|kW\|MW` |
+| `commissioningDate` | date-time | ISO 8601 |
+
+### Storage-specific attributes
+
+| Field | Type | CIM | Description |
+|-------|------|-----|-------------|
+| `storageCapacity` | QuantitativeValue | `BatteryUnit.ratedE` | Rated energy capacity. `unit: kWh\|MWh` |
+| `storageType` | enum | — | `LithiumIon` · `LeadAcid` · `FlowBattery` · `NaS` · `NiCd` · `Flywheel` · `Other` |
+| `stateOfHealthPct` | number 0–100 | — | State of health as % of original capacity |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "id": "did:web:utility.com:assets:bess:BESS-001",
+  "type": "BESS",
+  "attributes": {
+    "maxExport": {"value": 5, "unit": "kW"},
+    "maxImport": {"value": 5, "unit": "kW"},
+    "storageCapacity": {"value": 10, "unit": "kWh"},
+    "storageType": "LithiumIon"
+  },
+  "parentResources": ["did:web:utility.com:assets:meter:MET-001"]
+}
+```

--- a/specification/schema/MeterServiceProfile/v1.1/README.md
+++ b/specification/schema/MeterServiceProfile/v1.1/README.md
@@ -1,0 +1,80 @@
+# MeterServiceProfile v1.1
+
+**Schema ID:** `https://schema.beckn.io/MeterServiceProfile/v1.1`
+**CIM:** `cim:UsagePoint` (IEC 61968-9)
+**Status:** Current
+
+---
+
+## v1.1 changes
+
+`sanctionedLoad`, `sanctionedExportLoad`, and `contractMaxDemand` are now `QuantitativeValue {value, unit}` (unit: `W | kW | MW`) instead of plain numbers with unit-suffixed names:
+
+| v1.0 (scalar) | v1.1 (QuantitativeValue) |
+|---|---|
+| `sanctionedLoadKw` | `sanctionedLoad` |
+| `sanctionedExportLoadKw` | `sanctionedExportLoad` |
+| `contractMaxDemandKw` | `contractMaxDemand` |
+
+---
+
+## Overview
+
+`MeterServiceProfile` describes the tariff, regulatory load, and connection terms for a single electricity meter connection point. One profile per meter; linked via `meterId` to a `METER` entry in `customerProfile.energyResources[]`.
+
+Carried in `ElectricityCredential/v1.2` as `consumptionProfiles[]`.
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`attributes.yaml`](./attributes.yaml) | OpenAPI 3.1.1 schema |
+| [`schema.json`](./schema.json) | JSON Schema 2020-12 (bundled) |
+| [`context.jsonld`](./context.jsonld) | JSON-LD 1.1 term → IRI mappings |
+| [`vocab.jsonld`](./vocab.jsonld) | RDF vocabulary — class and property definitions |
+
+---
+
+## Fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `meterId` | ✅ | string | Matches `id` of a `METER` entry in `energyResources[]` |
+| `sanctionedLoad` | ✅ | QuantitativeValue | Sanctioned import load. `unit: W\|kW\|MW` |
+| `tariffCategoryCode` | ✅ | string | Utility-assigned tariff/billing category code |
+| `sanctionedExportLoad` | — | QuantitativeValue | Sanctioned grid export limit. `unit: W\|kW\|MW` |
+| `billingCycleDay` | — | integer 1–31 | Day of month the billing cycle resets |
+| `contractMaxDemand` | — | QuantitativeValue | Contracted maximum demand. `unit: W\|kW\|MW` |
+| `premisesType` | — | enum | `Residential`, `Commercial`, `Industrial`, `Agricultural` |
+| `connectionType` | — | enum | `Single-phase` or `Three-phase` |
+| `paymentMode` | — | enum | `POSTPAID` or `PREPAID` |
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "meterId": "did:web:bescom.karnataka.gov.in:assets:meter:MET-001",
+  "sanctionedLoad": {"value": 5, "unit": "kW"},
+  "tariffCategoryCode": "LT-2A"
+}
+```
+
+## Full example
+
+```json
+{
+  "meterId": "did:web:bescom.karnataka.gov.in:assets:meter:MET-001",
+  "sanctionedLoad": {"value": 5, "unit": "kW"},
+  "sanctionedExportLoad": {"value": 3, "unit": "kW"},
+  "billingCycleDay": 1,
+  "contractMaxDemand": {"value": 5, "unit": "kW"},
+  "tariffCategoryCode": "LT-2A",
+  "premisesType": "Residential",
+  "connectionType": "Single-phase",
+  "paymentMode": "POSTPAID"
+}
+```


### PR DESCRIPTION
## Summary

Fixes all errors reported by the schema publishing check.

- **10 missing READMEs added** — each v1.1 version folder now has a `README.md` documenting the v1.1 field changes (QuantitativeValue renames), attributes table, and minimal valid example
- **YAML parse error fixed** — `EnergyResourceLoad/v1.1/attributes.yaml` line 60: the `loadCategory` description contained `CIM: ConformLoad` (colon-space inside an unquoted scalar); quoted the string to satisfy strict YAML parsers

> Note: this branch is based on `feat/ec-v1.2-quantitative-value` — merge that first, then this one.

## Folders with new README

| Folder | Was missing |
|---|---|
| `EnergyResource/v2.1/` | ✅ added |
| `EnergyResourceCommon/v1.1/` | ✅ added |
| `EnergyResourceMeter/v1.1/` | ✅ added |
| `EnergyResourceGenerator/v1.1/` | ✅ added |
| `EnergyResourceStorage/v1.1/` | ✅ added |
| `EnergyResourceEVCharger/v1.1/` | ✅ added |
| `EnergyResourceInverter/v1.1/` | ✅ added |
| `EnergyResourceLoad/v1.1/` | ✅ added |
| `EnergyResourceNetwork/v1.1/` | ✅ added |
| `MeterServiceProfile/v1.1/` | ✅ added |

## Test plan

- [ ] Re-run the schema publish check — all previously failing items should pass
- [ ] Confirm `EnergyResourceLoad/v1.1/attributes.yaml` parses without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)