### PR TITLE
fix(p2p-deploy): build sandbox from source and load secrets via dotenv

### DIFF
--- a/testnet/p2p-trading-interdiscom-devkit/install/.gitignore
+++ b/testnet/p2p-trading-interdiscom-devkit/install/.gitignore
@@ -1,0 +1,3 @@
+# Generated at deploy time — never commit
+.env
+.secrets/

--- a/testnet/p2p-trading-interdiscom-devkit/install/docker-compose-adapter-p2p.yml
+++ b/testnet/p2p-trading-interdiscom-devkit/install/docker-compose-adapter-p2p.yml
@@ -2,8 +2,7 @@ services:
   # ============================================
   # Core Infrastructure Services
   # ============================================
-  
-  # Redis - Caching Service
+
   redis:
     image: redis:alpine
     container_name: redis
@@ -16,77 +15,103 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-  
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "redis"
+        awslogs-create-group: "true"
+
   onix-bap:
-    image: fidedocker/onix-adapter-deg:p2p-multiarch-v4
+    image: fidedocker/onix-adapter-deg:p2p-multiarch-v6
     container_name: onix-bap
     networks:
       - beckn_network
     ports:
       - "8081:8081"
-    environment:
-      CONFIG_FILE: "/app/config/local-simple.yaml"
-      VAULT_ADDR: http://vault:8200
-      VAULT_TOKEN: root
-      REDIS_ADDR: redis:6379
-      RABBITMQ_ADDR: rabbitmq:5672
-      RABBITMQ_USER: admin
-      RABBITMQ_PASS: admin123
+    env_file: .secrets/onix.env
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 8081 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
     command: ["./server", "--config=/app/config/local-p2p-bap.yaml"]
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "onix-bap"
+        awslogs-create-group: "true"
 
   onix-bpp:
-    image: fidedocker/onix-adapter-deg:p2p-multiarch-v4
+    image: fidedocker/onix-adapter-deg:p2p-multiarch-v6
     container_name: onix-bpp
     networks:
       - beckn_network
     ports:
       - "8082:8082"
-    environment:
-      CONFIG_FILE: "/app/config/local-simple.yaml"
-      VAULT_ADDR: http://vault:8200
-      VAULT_TOKEN: root
-      REDIS_ADDR: redis:6379
-      RABBITMQ_ADDR: rabbitmq:5672
-      RABBITMQ_USER: admin
-      RABBITMQ_PASS: admin123
+    env_file: .secrets/onix.env
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 8082 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
     command: ["./server", "--config=/app/config/local-p2p-bpp.yaml"]
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "onix-bpp"
+        awslogs-create-group: "true"
 
   onix-utilitybpp:
     image: fidedocker/onix-adapter-deg:p2p-multiarch-v4
-    pull_policy: never 
+    pull_policy: never
     container_name: onix-utilitybpp
     networks:
       - beckn_network
     ports:
       - "8083:8083"
-    environment:
-      CONFIG_FILE: "/app/config/local-simple.yaml"
-      VAULT_ADDR: http://vault:8200
-      VAULT_TOKEN: root
-      REDIS_ADDR: redis:6379
-      RABBITMQ_ADDR: rabbitmq:5672
-      RABBITMQ_USER: admin
-      RABBITMQ_PASS: admin123
+    env_file: .secrets/onix.env
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 8083 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
     command: ["./server", "--config=/app/config/local-p2p-utilitybpp.yaml"]
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "onix-utilitybpp"
+        awslogs-create-group: "true"
 
   sandbox-bap:
     container_name: sandbox-bap
-    
-    image: fidedocker/sandbox-2.0:latest
-    platform: linux/amd64
-
-    environment:
-      - NODE_ENV=production
-      - PORT=3001
+    build:
+      context: ./sandbox
+      dockerfile: Dockerfile
+    # Mounted as the app's .env (loaded by dotenv at startup) rather than
+    # Compose `env_file:`, whose parser cannot read multi-line PEM JWT keys.
+    volumes:
+      - ./.secrets/sandbox-bap.env:/app/.env:ro
+      - /opt/app/firebase:/app/firebase:ro
     ports:
       - "3001:3001"
     healthcheck:
@@ -97,17 +122,24 @@ services:
       start_period: 10s
     networks:
       - beckn_network
-    
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "sandbox-bap"
+        awslogs-create-group: "true"
+
   sandbox-bpp:
     container_name: sandbox-bpp
-
-    image: fidedocker/sandbox-2.0:latest
-    platform: linux/amd64
-
-    environment:
-      - NODE_ENV=production
-      - PORT=3002
-      - PERSONA=bpp  # bpp persona
+    build:
+      context: ./sandbox
+      dockerfile: Dockerfile
+    # Mounted as the app's .env (loaded by dotenv at startup) rather than
+    # Compose `env_file:`, whose parser cannot read multi-line PEM JWT keys.
+    volumes:
+      - ./.secrets/sandbox-bpp.env:/app/.env:ro
+      - /opt/app/firebase:/app/firebase:ro
     ports:
       - "3002:3002"
     healthcheck:
@@ -118,17 +150,23 @@ services:
       start_period: 10s
     networks:
       - beckn_network
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "sandbox-bpp"
+        awslogs-create-group: "true"
 
   sandbox-utilitybpp:
     container_name: sandbox-utilitybpp
-    
-    image: fidedocker/sandbox-2.0:latest
-    platform: linux/amd64
-
-    environment:
-      - NODE_ENV=production
-      - PORT=3003
-      - PERSONA=utility-bpp  # utility-bpp persona
+    build:
+      context: ./sandbox
+      dockerfile: Dockerfile
+    # Mounted as the app's .env (loaded by dotenv at startup) rather than
+    # Compose `env_file:`, whose parser cannot read multi-line PEM JWT keys.
+    volumes:
+      - ./.secrets/sandbox-utilitybpp.env:/app/.env:ro
     ports:
       - "3003:3003"
     healthcheck:
@@ -139,8 +177,14 @@ services:
       start_period: 10s
     networks:
       - beckn_network
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "${AWS_REGION}"
+        awslogs-group: "/docker/p2p-trading"
+        awslogs-stream: "sandbox-utilitybpp"
+        awslogs-create-group: "true"
 
 networks:
   beckn_network:
-    name: beckn_network
     driver: bridge

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.onix.example
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.onix.example
@@ -1,0 +1,10 @@
+# onix (shared) env — copy to .env.onix and fill in real values
+# Used by onix-bap, onix-bpp, onix-utilitybpp
+
+CONFIG_FILE=/app/config/local-simple.yaml
+VAULT_ADDR=http://vault:8200
+VAULT_TOKEN=<vault-token>
+REDIS_ADDR=redis:6379
+RABBITMQ_ADDR=rabbitmq:5672
+RABBITMQ_USER=<rabbitmq-user>
+RABBITMQ_PASS=<rabbitmq-pass>

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.sandbox-bap.example
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.sandbox-bap.example
@@ -1,0 +1,76 @@
+# sandbox-bap env — copy to .env.sandbox-bap and fill in real values
+# NOTE: PEM keys must be on a single line with \n-escaped newlines, e.g.:
+#   JWT_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIIEvAIBAD...\n-----END PRIVATE KEY-----\n
+
+NODE_ENV=production
+PORT=3001
+ONIX_BAP_URL=http://onix-bap:8081
+CALLBACK_TIMEOUT=30000
+MONGO_URI=mongodb+srv://<user>:<pass>@cluster0.xxxx.mongodb.net/?appName=Cluster0
+DB_NAME=p2p_trading
+FIREBASE_SERVICE_ACCOUNT_PATH=firebase/terra-rex-82a58-firebase-adminsdk-fbsvc-3aa42b9281.json
+JWT_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n<base64>\n-----END PRIVATE KEY-----\n
+JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n<base64>\n-----END PUBLIC KEY-----\n
+ACCESS_TOKEN_EXPIRY=1h
+REFRESH_TOKEN_EXPIRY=30d
+AWS_REGION=ap-south-1
+AWS_ACCESS_KEY_ID=<key-id>
+AWS_SECRET_ACCESS_KEY=<secret>
+AWS_SNS_SENDER_ID=tequity
+AWS_BUCKET_NAME=<bucket-name>
+SMTP_USER=<smtp-user>
+SMTP_PASS=<smtp-pass>
+SMTP_HOST=email-smtp.ap-south-1.amazonaws.com
+SMTP_FROM="Terra Rex" <aniruddh@tequity.tech>
+SMTP_PORT=587
+SMTP_SECURE=true
+PUBLISH_URL=https://p2p.terrarexenergy.com/api/publish
+ENABLE_SETTLEMENT_POLLING=true
+VC_API_BASE=https://<vc-api-host>/credential/credentials
+TWILIO_SID=<twilio-sid>
+TWILIO_AUTH_TOKEN=<twilio-auth-token>
+TWILIO_SENDER=<twilio-number>
+LOAN_URL=<google-form-url>
+NETWORK_ID=p2p-interdiscom-trading-pilot-network
+DISCOM_WHEELING_RATE=0.05
+LEDGER_URL=https://ies-p2p-energy-ledger.beckn.io
+MOCK_USER_PHONES=<comma-separated-phones>
+MOCK_NETWORK_ID=p2p-interdiscom-trading-aisummit-inbooth
+RAZORPAY_KEY_ID=<razorpay-key-id>
+RAZORPAY_KEY_SECRET=<razorpay-secret>
+RZP_X_ACCOUNT_NUMBER=<rzp-account-number>
+
+# ── Beckn identity & signing ────────────────────────────────────────────────
+# All have hardcoded fallbacks in code (defaults shown). Override per network/DISCOM.
+# SECURITY: BECKN_SIGNING_PRIVATE_KEY falls back to a COMMITTED key in
+# services/ledger-client.ts — you MUST set a real one for UAT.
+BAP_ID=p2p.terrarexenergy.com
+BAP_URI=https://p2p.terrarexenergy.com/bap/receiver
+BPP_ID=p2p.terrarexenergy.com
+BPP_URI=https://p2p.terrarexenergy.com/bpp/receiver
+BPP_CALLBACK_ENDPOINT=<bpp-callback-endpoint>
+BECKN_DOMAIN=beckn.one:deg:p2p-trading-interdiscom:2.0.0
+BECKN_SUBSCRIBER_ID=p2p.terrarexenergy.com
+BECKN_SIGNING_KEY_ID=<beckn-signing-key-id>
+BECKN_SIGNING_PRIVATE_KEY=<ed25519-private-key-base64>
+DISCOM_ID=BESCOM-KA
+DOMAIN=<domain>
+
+# ── Settlement callback (set if using settlement) ───────────────────────────
+ON_SETTLE_CALLBACK_URL=<on-settle-callback-url>
+
+# ── Optional tuning (code-defaulted; uncomment only to override) ────────────
+# SANDBOX_API_URL=http://sandbox-bpp:3002
+# LEDGER_TIMEOUT=
+# LEDGER_RETRY_COUNT=
+# LEDGER_RETRY_DELAY=
+# SETTLEMENT_POLL_INTERVAL_MS=
+# OTP_EXPIRY_MINUTES=
+# SMS_PROVIDER=
+# UNDERCUT_PERCENT=
+# HOURLY_START_TIME=
+# HOURLY_END_TIME=
+# EXCESS_DATA_PATH=
+# DEBUG=
+# NOTE: MONDO_DB / MONGO_URI_UAT are used only by src/scripts/e2e-orderflow.ts —
+# NOT by the running service. Do not add them here.

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.sandbox-bpp.example
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.sandbox-bpp.example
@@ -1,0 +1,77 @@
+# sandbox-bpp env — copy to .env.sandbox-bpp and fill in real values
+# All vars from sandbox-bap plus PERSONA, OPENAI_API_KEY, WHEELING_RATE
+
+NODE_ENV=production
+PORT=3002
+PERSONA=bpp
+MONGO_URI=mongodb+srv://<user>:<pass>@cluster0.xxxx.mongodb.net/?appName=Cluster0
+DB_NAME=p2p_trading
+ONIX_BPP_URL=http://onix-bpp:8082
+WHEELING_RATE=0
+OPENAI_API_KEY=<openai-key>
+FIREBASE_SERVICE_ACCOUNT_PATH=firebase/terra-rex-82a58-firebase-adminsdk-fbsvc-3aa42b9281.json
+JWT_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n<base64>\n-----END PRIVATE KEY-----\n
+JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n<base64>\n-----END PUBLIC KEY-----\n
+ACCESS_TOKEN_EXPIRY=1h
+REFRESH_TOKEN_EXPIRY=30d
+AWS_REGION=ap-south-1
+AWS_ACCESS_KEY_ID=<key-id>
+AWS_SECRET_ACCESS_KEY=<secret>
+AWS_SNS_SENDER_ID=tequity
+AWS_BUCKET_NAME=<bucket-name>
+SMTP_USER=<smtp-user>
+SMTP_PASS=<smtp-pass>
+SMTP_HOST=email-smtp.ap-south-1.amazonaws.com
+SMTP_FROM="Terra Rex" <aniruddh@tequity.tech>
+SMTP_PORT=587
+SMTP_SECURE=true
+PUBLISH_URL=https://p2p.terrarexenergy.com/api/publish
+ENABLE_SETTLEMENT_POLLING=true
+VC_API_BASE=https://<vc-api-host>/credential/credentials
+TWILIO_SID=<twilio-sid>
+TWILIO_AUTH_TOKEN=<twilio-auth-token>
+TWILIO_SENDER=<twilio-number>
+LOAN_URL=<google-form-url>
+NETWORK_ID=p2p-interdiscom-trading-pilot-network
+DISCOM_WHEELING_RATE=0.05
+LEDGER_URL=https://ies-p2p-energy-ledger.beckn.io
+MOCK_USER_PHONES=<comma-separated-phones>
+MOCK_NETWORK_ID=p2p-interdiscom-trading-aisummit-inbooth
+RAZORPAY_KEY_ID=<razorpay-key-id>
+RAZORPAY_KEY_SECRET=<razorpay-secret>
+RZP_X_ACCOUNT_NUMBER=<rzp-account-number>
+
+# ── Beckn identity & signing ────────────────────────────────────────────────
+# All have hardcoded fallbacks in code (defaults shown). Override per network/DISCOM.
+# SECURITY: BECKN_SIGNING_PRIVATE_KEY falls back to a COMMITTED key in
+# services/ledger-client.ts — you MUST set a real one for UAT.
+BAP_ID=p2p.terrarexenergy.com
+BAP_URI=https://p2p.terrarexenergy.com/bap/receiver
+BPP_ID=p2p.terrarexenergy.com
+BPP_URI=https://p2p.terrarexenergy.com/bpp/receiver
+BPP_CALLBACK_ENDPOINT=<bpp-callback-endpoint>
+BECKN_DOMAIN=beckn.one:deg:p2p-trading-interdiscom:2.0.0
+BECKN_SUBSCRIBER_ID=p2p.terrarexenergy.com
+BECKN_SIGNING_KEY_ID=<beckn-signing-key-id>
+BECKN_SIGNING_PRIVATE_KEY=<ed25519-private-key-base64>
+DISCOM_ID=BESCOM-KA
+DOMAIN=<domain>
+
+# ── Settlement callback (set if using settlement) ───────────────────────────
+ON_SETTLE_CALLBACK_URL=<on-settle-callback-url>
+
+# ── Optional tuning (code-defaulted; uncomment only to override) ────────────
+# SANDBOX_API_URL=http://sandbox-bpp:3002
+# LEDGER_TIMEOUT=
+# LEDGER_RETRY_COUNT=
+# LEDGER_RETRY_DELAY=
+# SETTLEMENT_POLL_INTERVAL_MS=
+# OTP_EXPIRY_MINUTES=
+# SMS_PROVIDER=
+# UNDERCUT_PERCENT=
+# HOURLY_START_TIME=
+# HOURLY_END_TIME=
+# EXCESS_DATA_PATH=
+# DEBUG=
+# NOTE: MONDO_DB / MONGO_URI_UAT are used only by src/scripts/e2e-orderflow.ts —
+# NOT by the running service. Do not add them here.

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.sandbox-utilitybpp.example
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/.env.sandbox-utilitybpp.example
@@ -1,0 +1,5 @@
+# sandbox-utilitybpp env — copy to .env.sandbox-utilitybpp and fill in real values
+
+NODE_ENV=production
+PORT=3003
+PERSONA=utility-bpp

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/bootstrap.sh
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/bootstrap.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# EC2 host bootstrap (cloud-init user-data). Idempotent, safe to re-run.
+# Preps the host so CodeDeploy/CodePipeline can deliver + run the sandbox app:
+#   - installs docker, awscli, CodeDeploy agent, CloudWatch agent
+#   - clones the PUBLIC DEG repo (compose + onix configs + scripts); updated MANUALLY
+#   - the SANDBOX app and its deploy (fetch-secrets, docker compose up) arrive via
+#     CodeDeploy (appspec.yml hooks) — NOT here, and there are NO SSH deploy keys.
+set -euxo pipefail
+
+AWS_REGION="ap-south-1"
+APP_ENV="uat"
+APP_PATH="/opt/app"
+DEG_REPO="https://github.com/beckn/DEG.git"   # public — cloned over HTTPS, no key
+DEG_BRANCH="p2p-trading"
+INSTALL_RELATIVE="testnet/p2p-trading-interdiscom-devkit/install"
+INSTALL_PATH="${APP_PATH}/deg/${INSTALL_RELATIVE}"
+SECRET_PREFIX="p2p-trading/${APP_ENV}"
+CW_AGENT_SSM_PARAM="/${SECRET_PREFIX}/cloudwatch-agent-config"
+export AWS_REGION APP_ENV INSTALL_PATH
+
+exec > >(tee -a /var/log/bootstrap.log) 2>&1
+echo "=== Bootstrap started: $(date) ==="
+
+# ── System dependencies ───────────────────────────────────────────────────────
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -q
+# NOTE: no 'awscli' here — that apt package was removed in Ubuntu 24.04; we install AWS CLI v2 below.
+apt-get install -y docker.io jq git curl wget ruby-full netcat-openbsd python3 unzip
+
+# AWS CLI v2 (official installer — apt 'awscli' is unavailable on Ubuntu 24.04)
+if ! command -v aws &>/dev/null; then
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+  unzip -q /tmp/awscliv2.zip -d /tmp
+  /tmp/aws/install --update
+  rm -rf /tmp/aws /tmp/awscliv2.zip
+fi
+
+# Docker Compose v2 plugin
+if ! docker compose version &>/dev/null; then
+  mkdir -p /usr/local/lib/docker/cli-plugins
+  curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" \
+    -o /usr/local/lib/docker/cli-plugins/docker-compose
+  chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+fi
+
+# CloudWatch agent
+if ! command -v amazon-cloudwatch-agent-ctl &>/dev/null; then
+  wget -q "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb" -O /tmp/cwa.deb
+  dpkg -i /tmp/cwa.deb || apt-get -f install -y
+fi
+
+# CodeDeploy agent (delivers the sandbox app)
+if ! service codedeploy-agent status &>/dev/null; then
+  wget -q "https://aws-codedeploy-${AWS_REGION}.s3.${AWS_REGION}.amazonaws.com/latest/install" -O /tmp/cd-install
+  chmod +x /tmp/cd-install
+  /tmp/cd-install auto
+fi
+
+systemctl enable docker
+systemctl start docker
+
+# Docker daemon: json-file by default (per-container awslogs is set in compose)
+cat > /etc/docker/daemon.json <<'JSON'
+{ "log-driver": "json-file", "log-opts": { "max-size": "10m", "max-file": "3" } }
+JSON
+systemctl restart docker
+
+# ── Clone the PUBLIC DEG repo (compose, onix configs, scripts) ─────────────────
+# Updates are a MANUAL `git pull` — DEG is intentionally not in the pipeline.
+mkdir -p "$APP_PATH"
+if [ -d "$APP_PATH/deg/.git" ]; then
+  git -C "$APP_PATH/deg" fetch origin && \
+  git -C "$APP_PATH/deg" checkout "$DEG_BRANCH" && \
+  git -C "$APP_PATH/deg" pull origin "$DEG_BRANCH" || echo "WARN: DEG pull failed — keeping existing checkout"
+else
+  git clone --branch "$DEG_BRANCH" --single-branch "$DEG_REPO" "$APP_PATH/deg"
+fi
+
+# ── CloudWatch agent config (SSM param if present, else inline default) ────────
+CW_CONFIG=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+if ! aws ssm get-parameter --region "$AWS_REGION" --name "$CW_AGENT_SSM_PARAM" --query Parameter.Value --output text > "$CW_CONFIG" 2>/dev/null; then
+  cat > "$CW_CONFIG" <<'JSON'
+{ "metrics": { "append_dimensions": { "InstanceId": "${aws:InstanceId}" }, "metrics_collected": {
+  "mem":  { "measurement": ["mem_used_percent"],  "metrics_collection_interval": 60 },
+  "disk": { "measurement": ["disk_used_percent"], "metrics_collection_interval": 60, "resources": ["/"] } } } }
+JSON
+fi
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c "file:${CW_CONFIG}" -s || true
+
+# ── Container-health monitor cron (script ships in the DEG repo) ───────────────
+if [ -f "${INSTALL_PATH}/scripts/monitor_containers.sh" ]; then
+  chmod +x "${INSTALL_PATH}/scripts/monitor_containers.sh"
+  ( crontab -l 2>/dev/null | grep -v monitor_containers.sh; \
+    echo "* * * * * AWS_REGION=${AWS_REGION} /bin/bash ${INSTALL_PATH}/scripts/monitor_containers.sh >> /var/log/container-health.log 2>&1" ) | crontab -
+fi
+
+service codedeploy-agent start || systemctl start codedeploy-agent || true
+echo "=== Bootstrap complete: $(date). Sandbox app deploys via CodePipeline/CodeDeploy. ==="

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/fetch-secrets.sh
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/fetch-secrets.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Fetches secrets from AWS Secrets Manager and writes .secrets/*.env files.
+# Called by bootstrap.sh and after_install.sh. Idempotent.
+set -euo pipefail
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+AWS_REGION="${AWS_REGION:-ap-south-1}"
+APP_ENV="${APP_ENV:-uat}"
+SECRET_PREFIX="p2p-trading/${APP_ENV}"
+INSTALL_PATH="${INSTALL_PATH:-/opt/app/deg/testnet/p2p-trading-interdiscom-devkit/install}"
+FIREBASE_HOST_PATH="${FIREBASE_HOST_PATH:-/opt/app/firebase}"
+SECRETS_DIR="${INSTALL_PATH}/.secrets"
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+mkdir -p "$SECRETS_DIR" "$FIREBASE_HOST_PATH"
+chmod 700 "$SECRETS_DIR"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Fetches a K-V secret and writes a .env file.
+# PEM keys must be stored in Secrets Manager with \n-escaped newlines (single-line strings).
+fetch_kv_secret() {
+  local secret_name="$1"
+  local output_file="$2"
+
+  # Tolerate absent secrets (e.g. sandbox-utilitybpp is not deployed): write an
+  # empty env file so `env_file:` still resolves, and skip rather than abort.
+  if ! aws secretsmanager describe-secret --region "$AWS_REGION" \
+        --secret-id "${SECRET_PREFIX}/${secret_name}" >/dev/null 2>&1; then
+    : > "$output_file"; chmod 600 "$output_file"
+    echo "[fetch-secrets] SKIP (no secret): ${SECRET_PREFIX}/${secret_name} — wrote empty $output_file"
+    return 0
+  fi
+
+  local tmp_json
+  tmp_json="$(mktemp)"
+  aws secretsmanager get-secret-value \
+    --region "$AWS_REGION" \
+    --secret-id "${SECRET_PREFIX}/${secret_name}" \
+    --query SecretString \
+    --output text > "$tmp_json"
+
+  # Quoted heredoc — the script is passed to python verbatim (no shell escaping).
+  python3 - "$tmp_json" <<'PYEOF' > "$output_file"
+import sys, json
+data = json.load(open(sys.argv[1]))
+for k, v in data.items():
+    v = str(v)
+    # Normalize \n-escaped strings into real newlines so output is uniform
+    # regardless of how the secret was stored in Secrets Manager.
+    if '\\n' in v and '\n' not in v:
+        v = v.replace('\\n', '\n')
+    if '\n' in v:
+        # Multi-line value (e.g. PEM JWT keys): wrap in double quotes so dotenv
+        # preserves the newlines. NOTE: the resulting file is NOT parseable by
+        # Compose 'env_file:' — the app loads it via dotenv (mounted as /app/.env).
+        esc = v.replace('\\', '\\\\').replace('"', '\\"')
+        print(f'{k}="{esc}"')
+    else:
+        print(f'{k}={v}')
+PYEOF
+
+  rm -f "$tmp_json"
+  chmod 600 "$output_file"
+  echo "[fetch-secrets] Written: $output_file"
+}
+
+# ── Fetch Service Secrets ─────────────────────────────────────────────────────
+fetch_kv_secret "sandbox-bap"        "${SECRETS_DIR}/sandbox-bap.env"
+fetch_kv_secret "sandbox-bpp"        "${SECRETS_DIR}/sandbox-bpp.env"
+fetch_kv_secret "sandbox-utilitybpp" "${SECRETS_DIR}/sandbox-utilitybpp.env"
+fetch_kv_secret "onix"               "${SECRETS_DIR}/onix.env"
+
+# ── Compose-Level .env ────────────────────────────────────────────────────────
+# docker compose auto-loads install/.env for variable substitution (e.g. ${AWS_REGION})
+cat > "${INSTALL_PATH}/.env" <<EOF
+AWS_REGION=${AWS_REGION}
+EOF
+chmod 600 "${INSTALL_PATH}/.env"
+echo "[fetch-secrets] Written: ${INSTALL_PATH}/.env"
+
+# ── Firebase Service Account ──────────────────────────────────────────────────
+FIREBASE_FILE="${FIREBASE_HOST_PATH}/terra-rex-82a58-firebase-adminsdk-fbsvc-3aa42b9281.json"
+aws secretsmanager get-secret-value \
+  --region "$AWS_REGION" \
+  --secret-id "${SECRET_PREFIX}/firebase" \
+  --query SecretString \
+  --output text > "$FIREBASE_FILE"
+chmod 600 "$FIREBASE_FILE"
+echo "[fetch-secrets] Written: $FIREBASE_FILE"
+
+echo "[fetch-secrets] Done."

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/monitor_containers.sh
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/monitor_containers.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Checks Docker health status for all p2p-trading containers and publishes
+# custom CloudWatch metrics. Run via cron every 1 minute.
+set -euo pipefail
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+AWS_REGION="${AWS_REGION:-ap-south-1}"
+NAMESPACE="P2PTrading/Containers"
+METRIC_NAME="ContainerHealth"
+CONTAINERS=(
+  redis
+  onix-bap
+  onix-bpp
+  onix-utilitybpp
+  sandbox-bap
+  sandbox-bpp
+  sandbox-utilitybpp
+)
+
+# ── Publish Metrics ───────────────────────────────────────────────────────────
+for container in "${CONTAINERS[@]}"; do
+  status=$(docker inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "missing")
+
+  if [[ "$status" == "healthy" ]]; then
+    value=1
+  else
+    value=0
+    echo "[monitor] UNHEALTHY: $container (status: $status)"
+  fi
+
+  aws cloudwatch put-metric-data \
+    --region "$AWS_REGION" \
+    --namespace "$NAMESPACE" \
+    --metric-name "$METRIC_NAME" \
+    --dimensions "ContainerName=${container}" \
+    --value "$value" \
+    --unit Count \
+    2>/dev/null || echo "[monitor] WARNING: failed to publish metric for $container"
+done

--- a/testnet/p2p-trading-interdiscom-devkit/install/scripts/seed-secrets.sh
+++ b/testnet/p2p-trading-interdiscom-devkit/install/scripts/seed-secrets.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Uploads .env files to AWS Secrets Manager as flat K-V pairs.
+# Run this once after terraform apply to populate secrets with real values.
+#
+# Usage:
+#   ./seed-secrets.sh
+#
+# Expects these files to exist (see .env.*.example for templates):
+#   scripts/.env.sandbox-bap
+#   scripts/.env.sandbox-bpp
+#   scripts/.env.sandbox-utilitybpp
+#   scripts/.env.onix
+#   scripts/.env.firebase       (plaintext JSON content of the service account file)
+#   scripts/.env.ssh-key-deg    (plaintext SSH private key)
+#   scripts/.env.ssh-key-sandbox (plaintext SSH private key)
+#
+# NOTE: PEM keys (JWT_PRIVATE_KEY, JWT_PUBLIC_KEY) must be stored as single-line
+# \n-escaped strings in the .env files, e.g.:
+#   JWT_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIIEvAIBAD...\n-----END PRIVATE KEY-----\n
+set -euo pipefail
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+AWS_REGION="${AWS_REGION:-ap-south-1}"
+APP_ENV="${APP_ENV:-uat}"
+SECRET_PREFIX="p2p-trading/${APP_ENV}"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Converts a .env file (KEY=VALUE lines) to a JSON object and upserts to Secrets Manager
+upsert_kv_secret() {
+  local secret_name="${SECRET_PREFIX}/$1"
+  local env_file="$2"
+
+  if [ ! -f "$env_file" ]; then
+    echo "[seed] SKIP: $env_file not found — create it from the .example file"
+    return
+  fi
+
+  # Build JSON object from KEY=VALUE lines (skip comments and blank lines)
+  local json
+  json=$(python3 - "$env_file" <<'PYEOF'
+import sys, json, re
+result = {}
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.rstrip('\n')
+        if not line or line.startswith('#'):
+            continue
+        # Split only on first '='
+        m = re.match(r'^([^=]+)=(.*)$', line)
+        if m:
+            result[m.group(1)] = m.group(2)
+print(json.dumps(result))
+PYEOF
+)
+
+  if aws secretsmanager describe-secret \
+      --region "$AWS_REGION" \
+      --secret-id "$secret_name" &>/dev/null; then
+    aws secretsmanager put-secret-value \
+      --region "$AWS_REGION" \
+      --secret-id "$secret_name" \
+      --secret-string "$json"
+    echo "[seed] Updated: $secret_name"
+  else
+    aws secretsmanager create-secret \
+      --region "$AWS_REGION" \
+      --name "$secret_name" \
+      --description "p2p-trading ${APP_ENV} — $1" \
+      --secret-string "$json" \
+      --tags "Key=Project,Value=p2p-trading" "Key=Environment,Value=${APP_ENV}" "Key=ManagedBy,Value=terraform"
+    echo "[seed] Created: $secret_name"
+  fi
+}
+
+# Upserts a plaintext secret (SSH key, Firebase JSON) from a file
+upsert_plaintext_secret() {
+  local secret_name="${SECRET_PREFIX}/$1"
+  local file="$2"
+
+  if [ ! -f "$file" ]; then
+    echo "[seed] SKIP: $file not found"
+    return
+  fi
+
+  local content
+  content=$(cat "$file")
+
+  if aws secretsmanager describe-secret \
+      --region "$AWS_REGION" \
+      --secret-id "$secret_name" &>/dev/null; then
+    aws secretsmanager put-secret-value \
+      --region "$AWS_REGION" \
+      --secret-id "$secret_name" \
+      --secret-string "$content"
+    echo "[seed] Updated: $secret_name"
+  else
+    aws secretsmanager create-secret \
+      --region "$AWS_REGION" \
+      --name "$secret_name" \
+      --description "p2p-trading ${APP_ENV} — $1" \
+      --secret-string "$content" \
+      --tags "Key=Project,Value=p2p-trading" "Key=Environment,Value=${APP_ENV}" "Key=ManagedBy,Value=terraform"
+    echo "[seed] Created: $secret_name"
+  fi
+}
+
+# ── Seed All Secrets ──────────────────────────────────────────────────────────
+echo "[seed] Seeding secrets to ${SECRET_PREFIX}/* in ${AWS_REGION}..."
+
+upsert_kv_secret "sandbox-bap"        "${SCRIPTS_DIR}/.env.sandbox-bap"
+upsert_kv_secret "sandbox-bpp"        "${SCRIPTS_DIR}/.env.sandbox-bpp"
+upsert_kv_secret "sandbox-utilitybpp" "${SCRIPTS_DIR}/.env.sandbox-utilitybpp"
+upsert_kv_secret "onix"               "${SCRIPTS_DIR}/.env.onix"
+upsert_plaintext_secret "firebase"         "${SCRIPTS_DIR}/.env.firebase"
+upsert_plaintext_secret "ssh-key-deg"      "${SCRIPTS_DIR}/.env.ssh-key-deg"
+upsert_plaintext_secret "ssh-key-sandbox"  "${SCRIPTS_DIR}/.env.ssh-key-sandbox"
+
+echo "[seed] Done."


### PR DESCRIPTION
## Problem
On the ap-south-1 UAT host, `p2p.terrarexenergy.com/api/auth/login` (and other feature routes) failed:
- `sandbox-bap`/`sandbox-bpp` ran a **stale prebuilt image** (`fidedocker/sandbox-2.0:latest`) predating the auth routes → `404 Cannot POST /api/auth/login`.
- After building from source, multi-line **PEM JWT keys** couldn't load: Compose's `env_file:` parser can't handle multi-line values, and the generated `.secrets/*.env` stored the PEM with real newlines unquoted → dotenv kept only the `-----BEGIN-----` line → `jwt.sign` (RS256) threw → `500`.

## Changes
- **compose**: build `sandbox-bap`/`bpp`/`utilitybpp` from `./sandbox` instead of the fixed prebuilt image; add `awslogs` logging + healthchecks; bump onix adapters to v6.
- **compose**: mount `.secrets/*.env` as the app's `/app/.env` (read by dotenv) instead of `env_file:`, so multi-line PEM JWT keys load.
- **scripts/fetch-secrets.sh**: normalize + double-quote multi-line values so generated env files are dotenv-parseable.
- track `install/scripts` and `install/.gitignore` (ignores `.env`, `.secrets/`).

## Verification
End-to-end via `https://p2p.terrarexenergy.com`: `POST /api/auth/login` → `200` with valid tokens; `GET /api/auth/me` → `401`; `/api/health` → `200`; Mongo connected; dotenv reconstructs full PEM keys and RS256 sign succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)