### PR TITLE
feat(schema): add optional careOf field to CustomerDetails v1.0

### DIFF
--- a/specification/schema/CustomerDetails/README.md
+++ b/specification/schema/CustomerDetails/README.md
@@ -21,7 +21,7 @@ PII identity and address details for a utility service customer.
 
 Three concerns:
 
-- **Identity** — `fullName` (as per ID proof), optional `careOf` (head of household, for disambiguation)
+- **Identity** — `fullName` (as per ID proof), optional `careOf` (reference person(s) with optional gender-neutral relationship, used to uniquely identify / disambiguate the customer)
 - **Location** — `installationAddress` (GeoJSON + PostalAddress via beckn Location/2.0)
 - **Tenure** — `serviceConnectionDate` (when the connection was activated)
 

--- a/specification/schema/CustomerDetails/README.md
+++ b/specification/schema/CustomerDetails/README.md
@@ -21,7 +21,7 @@ PII identity and address details for a utility service customer.
 
 Three concerns:
 
-- **Identity** — `fullName` (as per ID proof)
+- **Identity** — `fullName` (as per ID proof), optional `careOf` (head of household, for disambiguation)
 - **Location** — `installationAddress` (GeoJSON + PostalAddress via beckn Location/2.0)
 - **Tenure** — `serviceConnectionDate` (when the connection was activated)
 

--- a/specification/schema/CustomerDetails/v1.0/README.md
+++ b/specification/schema/CustomerDetails/v1.0/README.md
@@ -30,7 +30,7 @@ Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a
 | Field | Required | Type | CIM | Description |
 |-------|----------|------|-----|-------------|
 | `fullName` | ✅ | string | `Customer.name` | Full name as per ID proof |
-| `careOf` | ➖ | string | — | Care-of (c/o) name, typically the head of household; disambiguates customers sharing the same `fullName` within a locality |
+| `careOf` | ➖ | array of `{ name, relationship? }` | — | Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same `fullName` with others in a locality. `relationship` is optional, gender-neutral: `parent` \| `spouse` \| `guardian` \| `sibling` \| `child` \| `other` |
 | `installationAddress` | ✅ | Location/2.0 | `ServiceLocation` | GeoJSON Point + PostalAddress |
 | `serviceConnectionDate` | ✅ | date-time | activation date | ISO 8601 with timezone offset |
 
@@ -51,7 +51,9 @@ Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a
 ```json
 {
   "fullName": "Ravi Kumar",
-  "careOf": "Suresh Kumar",
+  "careOf": [
+    { "name": "Suresh Kumar", "relationship": "parent" }
+  ],
   "installationAddress": {
     "geo": {
       "type": "Point",

--- a/specification/schema/CustomerDetails/v1.0/README.md
+++ b/specification/schema/CustomerDetails/v1.0/README.md
@@ -30,6 +30,7 @@ Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a
 | Field | Required | Type | CIM | Description |
 |-------|----------|------|-----|-------------|
 | `fullName` | ✅ | string | `Customer.name` | Full name as per ID proof |
+| `careOf` | ➖ | string | — | Care-of (c/o) name, typically the head of household; disambiguates customers sharing the same `fullName` within a locality |
 | `installationAddress` | ✅ | Location/2.0 | `ServiceLocation` | GeoJSON Point + PostalAddress |
 | `serviceConnectionDate` | ✅ | date-time | activation date | ISO 8601 with timezone offset |
 
@@ -50,6 +51,7 @@ Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a
 ```json
 {
   "fullName": "Ravi Kumar",
+  "careOf": "Suresh Kumar",
   "installationAddress": {
     "geo": {
       "type": "Point",

--- a/specification/schema/CustomerDetails/v1.0/attributes.yaml
+++ b/specification/schema/CustomerDetails/v1.0/attributes.yaml
@@ -57,6 +57,17 @@ components:
           x-jsonld:
             "@id": schema:name
 
+        careOf:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: >
+            Care-of (c/o) name, typically the head of household. Helps
+            disambiguate customers who share the same fullName within a
+            locality (e.g. a village).
+          x-jsonld:
+            "@id": deg:careOf
+
         installationAddress:
           $ref: "https://schema.beckn.io/Location/2.0/attributes.yaml#/components/schemas/Location"
           description: >

--- a/specification/schema/CustomerDetails/v1.0/attributes.yaml
+++ b/specification/schema/CustomerDetails/v1.0/attributes.yaml
@@ -58,15 +58,38 @@ components:
             "@id": schema:name
 
         careOf:
-          type: string
-          minLength: 1
-          maxLength: 200
+          type: array
+          minItems: 1
           description: >
-            Care-of (c/o) name, typically the head of household. Helps
-            disambiguate customers who share the same fullName within a
-            locality (e.g. a village).
+            Care-of (c/o) reference person(s) used to uniquely identify /
+            disambiguate a customer who may share the same fullName with others
+            in a locality (e.g. a village). Each entry pairs a name with an
+            optional, gender-neutral relationship.
           x-jsonld:
             "@id": deg:careOf
+          items:
+            type: object
+            required:
+              - name
+            additionalProperties: false
+            properties:
+              name:
+                type: string
+                minLength: 1
+                maxLength: 200
+                description: >
+                  Name of the care-of / reference person used to disambiguate
+                  the customer.
+                x-jsonld:
+                  "@id": schema:name
+              relationship:
+                type: string
+                enum: [parent, spouse, guardian, sibling, child, other]
+                description: >
+                  Gender-neutral relationship of the reference person to the
+                  customer.
+                x-jsonld:
+                  "@id": deg:relationship
 
         installationAddress:
           $ref: "https://schema.beckn.io/Location/2.0/attributes.yaml#/components/schemas/Location"

--- a/specification/schema/CustomerDetails/v1.0/context.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/context.jsonld
@@ -9,8 +9,16 @@
     "CustomerDetails": { "@id": "deg:CustomerDetails" },
 
     "fullName":             { "@id": "schema:name",                  "@type": "xsd:string"   },
-    "careOf":               { "@id": "deg:careOf",                   "@type": "xsd:string"   },
     "serviceConnectionDate":{ "@id": "deg:serviceConnectionDate",    "@type": "xsd:dateTime" },
+
+    "careOf": {
+      "@id": "deg:careOf",
+      "@container": "@set",
+      "@context": {
+        "name":         { "@id": "schema:name",      "@type": "xsd:string" },
+        "relationship": { "@id": "deg:relationship", "@type": "xsd:string" }
+      }
+    },
 
     "installationAddress": {
       "@id": "beckn:Location",

--- a/specification/schema/CustomerDetails/v1.0/context.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/context.jsonld
@@ -9,6 +9,7 @@
     "CustomerDetails": { "@id": "deg:CustomerDetails" },
 
     "fullName":             { "@id": "schema:name",                  "@type": "xsd:string"   },
+    "careOf":               { "@id": "deg:careOf",                   "@type": "xsd:string"   },
     "serviceConnectionDate":{ "@id": "deg:serviceConnectionDate",    "@type": "xsd:dateTime" },
 
     "installationAddress": {

--- a/specification/schema/CustomerDetails/v1.0/schema.json
+++ b/specification/schema/CustomerDetails/v1.0/schema.json
@@ -15,6 +15,12 @@
           "maxLength": 200,
           "description": "Full name of the customer as per ID proof."
         },
+        "careOf": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Care-of (c/o) name, typically the head of household. Helps disambiguate customers who share the same fullName within a locality."
+        },
         "installationAddress": {
           "$ref": "https://schema.beckn.io/Location/2.0/schema.json#/$defs/Location",
           "description": "Physical location of the metered installation. geo (GeoJSON Point) required; address (PostalAddress) optional."

--- a/specification/schema/CustomerDetails/v1.0/schema.json
+++ b/specification/schema/CustomerDetails/v1.0/schema.json
@@ -16,10 +16,27 @@
           "description": "Full name of the customer as per ID proof."
         },
         "careOf": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 200,
-          "description": "Care-of (c/o) name, typically the head of household. Helps disambiguate customers who share the same fullName within a locality."
+          "type": "array",
+          "description": "Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality. Each entry pairs a name with an optional, gender-neutral relationship.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Name of the care-of / reference person used to disambiguate the customer."
+              },
+              "relationship": {
+                "type": "string",
+                "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"],
+                "description": "Gender-neutral relationship of the reference person to the customer."
+              }
+            }
+          }
         },
         "installationAddress": {
           "$ref": "https://schema.beckn.io/Location/2.0/schema.json#/$defs/Location",

--- a/specification/schema/CustomerDetails/v1.0/vocab.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/vocab.jsonld
@@ -16,6 +16,14 @@
       "rdfs:seeAlso": { "@id": "https://ontology.tno.nl/IEC_CIM/iec61968-1.ttl#Customer" }
     },
     {
+      "@id": "deg:careOf",
+      "@type": "rdf:Property",
+      "rdfs:label": "Care of",
+      "rdfs:comment": "Care-of (c/o) name, typically the head of household. Used to disambiguate customers who share the same full name within a locality.",
+      "rdfs:domain": { "@id": "deg:CustomerDetails" },
+      "schema:rangeIncludes": { "@id": "xsd:string" }
+    },
+    {
       "@id": "deg:serviceConnectionDate",
       "@type": "rdf:Property",
       "rdfs:label": "Service connection date",

--- a/specification/schema/CustomerDetails/v1.0/vocab.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/vocab.jsonld
@@ -19,8 +19,15 @@
       "@id": "deg:careOf",
       "@type": "rdf:Property",
       "rdfs:label": "Care of",
-      "rdfs:comment": "Care-of (c/o) name, typically the head of household. Used to disambiguate customers who share the same full name within a locality.",
-      "rdfs:domain": { "@id": "deg:CustomerDetails" },
+      "rdfs:comment": "Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same full name with others in a locality. Each entry pairs a name with an optional gender-neutral relationship.",
+      "rdfs:domain": { "@id": "deg:CustomerDetails" }
+    },
+    {
+      "@id": "deg:relationship",
+      "@type": "rdf:Property",
+      "rdfs:label": "Relationship",
+      "rdfs:comment": "Gender-neutral relationship of a care-of reference person to the customer (parent, spouse, guardian, sibling, child, other).",
+      "rdfs:domain": { "@id": "deg:careOf" },
       "schema:rangeIncludes": { "@id": "xsd:string" }
     },
     {


### PR DESCRIPTION
## Summary

Adds an **optional** `careOf` (c/o — care of) field to `CustomerDetails/v1.0`, used to **uniquely identify / disambiguate** a customer who may share the same `fullName` with others in a locality (e.g. a village).

## Shape

`careOf` is an **optional array** of reference persons — each pairs a name with an optional, gender-neutral relationship:

```json
"careOf": [
  { "name": "Suresh Kumar", "relationship": "parent" }
]
```

- `name` — required within an item.
- `relationship` — optional enum: `parent | spouse | guardian | sibling | child | other` (gender-neutral by design; deliberately avoids legacy "father's/husband's name" fields).
- Array binds name ↔ relationship atomically and supports more than one reference without a schema change.

## Changes

Updated all files in `specification/schema/CustomerDetails/v1.0/`:
- `schema.json` — `careOf` array of `{ name, relationship? }`, not in `required`
- `attributes.yaml` — matching OpenAPI definition with `x-jsonld` mappings
- `context.jsonld` — `careOf` `@set` container with nested `name` / `relationship` terms
- `vocab.jsonld` — `deg:careOf` and `deg:relationship` RDF properties
- `README.md` (v1.0 + parent) — field table, example, Identity concern

## Compatibility

Additive and **non-breaking** — `careOf` is optional, so existing `ElectricityCredential` (v1.0–v1.2) consumers that `$ref` CustomerDetails are unaffected.

## Note on vocabulary

`careOf` maps to `deg:careOf` because schema.org `PostalAddress` has no care-of term. (OASIS xAL / UPU S42 model c/o as a distinct element; UIDAI/Aadhaar likewise replaced gendered father/husband fields with "C/O".)

🤖 Generated with [Claude Code](https://claude.com/claude-code)