### PR TITLE
feat(schema): demonstrate + backport careOf across ElectricityCredential v1.0–v1.2

### DIFF
--- a/specification/schema/ElectricityCredential/v1.0/schema.json
+++ b/specification/schema/ElectricityCredential/v1.0/schema.json
@@ -274,6 +274,29 @@
                     "maxLength": 200,
                     "description": "Full name of the customer as per ID proof"
                 },
+                "careOf": {
+                    "type": "array",
+                    "description": "Optional care-of (c/o) reference person(s), used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality. Each entry pairs a name with an optional, gender-neutral relationship.",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "required": ["name"],
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200,
+                                "description": "Name of the care-of / reference person used to disambiguate the customer."
+                            },
+                            "relationship": {
+                                "type": "string",
+                                "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"],
+                                "description": "Gender-neutral relationship of the reference person to the customer."
+                            }
+                        }
+                    }
+                },
                 "installationAddress": {
                     "type": "object",
                     "description": "The physical location of the installation. Follows the beckn Location schema.",

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -115,6 +115,7 @@
             "required": ["fullName", "installationAddress", "serviceConnectionDate"],
             "properties": {
                 "fullName": { "type": "string", "minLength": 1, "maxLength": 200 },
+                "careOf": { "type": "array", "minItems": 1, "description": "Optional care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer sharing the same fullName within a locality.", "items": { "type": "object", "required": ["name"], "additionalProperties": false, "properties": { "name": { "type": "string", "minLength": 1, "maxLength": 200 }, "relationship": { "type": "string", "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"] } } } },
                 "installationAddress": { "$ref": "#/$defs/Location" },
                 "serviceConnectionDate": { "type": "string", "format": "date-time" }
             }

--- a/specification/schema/ElectricityCredential/v1.2/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example-parallel-metering.json
@@ -54,6 +54,7 @@
     },
     "customerDetails": {
       "fullName": "Arjun Mehra",
+      "careOf": [{ "name": "Lakshmi Mehra", "relationship": "parent" }],
       "installationAddress": {
         "geo": {"type": "Point", "coordinates": [77.2090, 28.6139]},
         "address": {"streetAddress": "45 Rohini Sector 9", "addressLocality": "Delhi", "addressRegion": "Delhi", "postalCode": "110085", "addressCountry": "IN"}

--- a/specification/schema/ElectricityCredential/v1.2/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example-submetering.json
@@ -64,6 +64,7 @@
     },
     "customerDetails": {
       "fullName": "Sunita Rao",
+      "careOf": [{ "name": "Prakash Rao", "relationship": "spouse" }],
       "installationAddress": {
         "geo": {"type": "Point", "coordinates": [77.5946, 12.9716]},
         "address": {"streetAddress": "12 Residency Road, Flat 101", "addressLocality": "Bengaluru", "addressRegion": "Karnataka", "postalCode": "560025", "addressCountry": "IN"}

--- a/specification/schema/ElectricityCredential/v1.2/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example.json
@@ -68,6 +68,7 @@
     },
     "customerDetails": {
       "fullName": "Jane Doe",
+      "careOf": [{ "name": "John Doe", "relationship": "parent" }],
       "installationAddress": {
         "geo": {"type": "Point", "coordinates": [-122.4194, 37.7749]},
         "address": {"streetAddress": "123 Energy Street, Unit 4", "addressLocality": "Metro City", "addressRegion": "Example State", "postalCode": "12345", "addressCountry": "US"}


### PR DESCRIPTION
## Summary

Follow-up to #401 (which added the optional `careOf` field to `CustomerDetails/v1.0`). This propagates `careOf` across all current ElectricityCredential versions — examples and inline schema copies.

`careOf` is an optional array of reference persons used to uniquely identify / disambiguate a customer who may share the same `fullName` with others in a locality. Each entry pairs a `name` with an optional, gender-neutral `relationship` (`parent | spouse | guardian | sibling | child | other`).

## How each version embeds CustomerDetails

| Version | Embedding | Change |
|---|---|---|
| **v1.2** | external `$ref` → `CustomerDetails/v1.0` | schema.json unchanged (already reflects `careOf`); examples updated |
| **v1.1** | inline copy (shape matches canonical) | `careOf` added to inline `CustomerDetails` |
| **v1.0** | inline copy (legacy address model) | `careOf` added to inline `CustomerDetails` |

## Changes

**Examples** — added `careOf` to the `customerDetails` block in the three v1.2 examples:
- `example.json` — `[{ "name": "John Doe", "relationship": "parent" }]`
- `example-parallel-metering.json` — `[{ "name": "Lakshmi Mehra", "relationship": "parent" }]` (woman parent — shows the enum is gender-neutral)
- `example-submetering.json` — `[{ "name": "Prakash Rao", "relationship": "spouse" }]`

**Schema** — backported the optional `careOf` array into the inline `CustomerDetails` in `ElectricityCredential/v1.0/schema.json` and `v1.1/schema.json`.

## Compatibility

Additive and **non-breaking** — `careOf` is optional (not in `required`) everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)