### PR TITLE
feat(schema): typed QuantitativeValue + x-standard + self-contained bundler (ElectricityCredential v1.2)

### DIFF
--- a/specification/schema/CustomerDetails/v1.0/attributes.yaml
+++ b/specification/schema/CustomerDetails/v1.0/attributes.yaml
@@ -54,6 +54,7 @@ components:
           minLength: 1
           maxLength: 200
           description: Full name of the customer as per ID proof.
+          x-standard: "CIM (IEC 61968-1 Customer.name)"
           x-jsonld:
             "@id": schema:name
 
@@ -97,6 +98,7 @@ components:
             Physical location of the metered installation. geo (GeoJSON Point,
             coordinates [longitude, latitude]) is required; address
             (schema.org PostalAddress fields) is optional.
+          x-standard: "GeoJSON RFC 7946; schema.org PostalAddress; CIM (IEC 61968-1 ServiceLocation)"
           x-jsonld:
             "@id": deg:installationAddress
 
@@ -105,6 +107,7 @@ components:
           format: date-time
           description: >
             Date and time the service connection was activated, with timezone
-            offset (ISO 8601). CIM: ServiceLocation activation date.
+            offset (ISO 8601).
+          x-standard: "CIM (IEC 61968-1 ServiceLocation activation date)"
           x-jsonld:
             "@id": deg:serviceConnectionDate

--- a/specification/schema/ElectricityCredential/v1.2/schema.json
+++ b/specification/schema/ElectricityCredential/v1.2/schema.json
@@ -4,12 +4,23 @@
     "title": "ElectricityCredential v1.2",
     "description": "Bundled (self-contained) JSON Schema for ElectricityCredential v1.2. All power and capacity fields use QuantitativeValue {value, unit} with short unit aliases (W, kW, MW, kWh, MWh, kVA, MVA, kVAR, MVAR, V, kV) mapped to QUDT IRIs via JSON-LD context. Renamed from v1.1: ratedPowerKw→ratedPower, maxExportKw→maxExport, maxImportKw→maxImport, nominalPowerKw→nominalPower, storageCapacityKwh→storageCapacity, ratedApparentPowerKva→ratedApparentPower, maxReactivePowerKvar→maxReactivePower, minReactivePowerKvar→minReactivePower, nominalVoltageKv→nominalVoltage, sanctionedLoadKw→sanctionedLoad, contractMaxDemandKw→contractMaxDemand. Subschemas: EnergyResource/v2.1, EnergyResourceCommon/v1.1, MeterServiceProfile/v1.1.",
     "type": "object",
-    "required": ["@context", "id", "type", "issuer", "validFrom", "credentialSubject"],
+    "required": [
+        "@context",
+        "id",
+        "type",
+        "issuer",
+        "validFrom",
+        "credentialSubject"
+    ],
     "properties": {
         "@context": {
             "type": "array",
-            "items": { "type": "string" },
-            "contains": { "const": "https://www.w3.org/ns/credentials/v2" },
+            "items": {
+                "type": "string"
+            },
+            "contains": {
+                "const": "https://www.w3.org/ns/credentials/v2"
+            },
             "minItems": 2
         },
         "id": {
@@ -19,461 +30,1241 @@
         },
         "type": {
             "type": "array",
-            "items": { "type": "string" },
-            "contains": { "const": "ElectricityCredential" },
+            "items": {
+                "type": "string"
+            },
+            "contains": {
+                "const": "ElectricityCredential"
+            },
             "minItems": 2
         },
         "issuer": {
             "type": "object",
-            "required": ["id", "name"],
+            "required": [
+                "id",
+                "name"
+            ],
             "properties": {
-                "id": { "type": "string", "format": "uri" },
-                "name": { "type": "string", "minLength": 1 },
-                "idRef": { "$ref": "#/$defs/IdRef" }
+                "id": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "idRef": {
+                    "$ref": "#/$defs/IdRef"
+                }
             }
         },
-        "validFrom": { "type": "string", "format": "date-time" },
-        "validUntil": { "type": "string", "format": "date-time" },
+        "validFrom": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "validUntil": {
+            "type": "string",
+            "format": "date-time"
+        },
         "credentialStatus": {
             "type": "object",
-            "required": ["id", "type", "statusPurpose", "statusListCredential"],
+            "required": [
+                "id",
+                "type",
+                "statusPurpose",
+                "statusListCredential"
+            ],
             "properties": {
-                "id": { "type": "string", "format": "uri" },
-                "type": { "type": "string", "const": "dediregistry" },
-                "statusPurpose": { "type": "string", "enum": ["revocation", "suspension"] },
-                "statusListCredential": { "type": "string", "format": "uri" }
+                "id": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "dediregistry"
+                },
+                "statusPurpose": {
+                    "type": "string",
+                    "enum": [
+                        "revocation",
+                        "suspension"
+                    ]
+                },
+                "statusListCredential": {
+                    "type": "string",
+                    "format": "uri"
+                }
             }
         },
         "credentialSubject": {
             "type": "object",
-            "required": ["customerProfile"],
+            "required": [
+                "customerProfile"
+            ],
             "properties": {
-                "id": { "type": "string", "format": "uri" },
-                "customerProfile": { "$ref": "#/$defs/CustomerProfile" },
-                "customerDetails": { "$ref": "#/$defs/CustomerDetails" }
+                "id": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "customerProfile": {
+                    "$ref": "#/$defs/CustomerProfile"
+                },
+                "customerDetails": {
+                    "$ref": "#/$defs/CustomerDetails"
+                }
             }
         },
         "proof": {
             "type": "object",
-            "required": ["type", "created", "verificationMethod", "proofPurpose", "proofValue"],
+            "required": [
+                "type",
+                "created",
+                "verificationMethod",
+                "proofPurpose",
+                "proofValue"
+            ],
             "properties": {
-                "type": { "type": "string" },
-                "created": { "type": "string", "format": "date-time" },
-                "verificationMethod": { "type": "string", "format": "uri" },
-                "proofPurpose": { "type": "string", "enum": ["assertionMethod", "authentication"] },
-                "proofValue": { "type": "string", "minLength": 1 }
+                "type": {
+                    "type": "string"
+                },
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "verificationMethod": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "proofPurpose": {
+                    "type": "string",
+                    "enum": [
+                        "assertionMethod",
+                        "authentication"
+                    ]
+                },
+                "proofValue": {
+                    "type": "string",
+                    "minLength": 1
+                }
             }
         }
     },
     "$defs": {
-        "QVPower": {
-            "$anchor": "QVPower",
+        "CustomerDetails": {
             "type": "object",
-            "description": "Active power quantity. unit: W | kW | MW — mapped to QUDT IRIs via JSON-LD context.",
-            "required": ["value", "unit"],
-            "additionalProperties": false,
+            "description": "PII section — fullName, installationAddress, serviceConnectionDate. fullName appears ONLY here — never in customerProfile or resource entries. Defined in CustomerDetails/v1.0.\n",
+            "required": [
+                "fullName",
+                "installationAddress",
+                "serviceConnectionDate"
+            ],
             "properties": {
-                "value": { "type": "number" },
-                "unit":  { "type": "string", "enum": ["W", "kW", "MW"] }
+                "fullName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "Full name of the customer as per ID proof.",
+                    "x-standard": "CIM (IEC 61968-1 Customer.name)"
+                },
+                "careOf": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality (e.g. a village). Each entry pairs a name with an optional, gender-neutral relationship.\n",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200,
+                                "description": "Name of the care-of / reference person used to disambiguate the customer.\n"
+                            },
+                            "relationship": {
+                                "type": "string",
+                                "enum": [
+                                    "parent",
+                                    "spouse",
+                                    "guardian",
+                                    "sibling",
+                                    "child",
+                                    "other"
+                                ],
+                                "description": "Gender-neutral relationship of the reference person to the customer.\n"
+                            }
+                        }
+                    }
+                },
+                "installationAddress": {
+                    "$ref": "#/$defs/Location",
+                    "description": "Physical location of the metered installation. geo (GeoJSON Point, coordinates [longitude, latitude]) is required; address (schema.org PostalAddress fields) is optional.\n",
+                    "x-standard": "GeoJSON RFC 7946; schema.org PostalAddress; CIM (IEC 61968-1 ServiceLocation)"
+                },
+                "serviceConnectionDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Date and time the service connection was activated, with timezone offset (ISO 8601).\n",
+                    "x-standard": "CIM (IEC 61968-1 ServiceLocation activation date)"
+                }
             }
         },
-        "QVEnergy": {
-            "$anchor": "QVEnergy",
+        "Location": {
+            "description": "A place represented by GeoJSON geometry and optional address.\nSource: main/schema/core/v2/attributes.yaml#Location",
             "type": "object",
-            "description": "Stored-energy quantity. unit: kWh | MWh.",
-            "required": ["value", "unit"],
+            "required": [
+                "geo"
+            ],
             "additionalProperties": false,
             "properties": {
-                "value": { "type": "number", "minimum": 0 },
-                "unit":  { "type": "string", "enum": ["kWh", "MWh"] }
+                "geo": {
+                    "$ref": "#/$defs/GeoJSONGeometry"
+                },
+                "address": {
+                    "$ref": "#/$defs/Address"
+                }
             }
         },
-        "QVApparentPower": {
-            "$anchor": "QVApparentPower",
+        "GeoJSONGeometry": {
+            "description": "**GeoJSON geometry** per RFC 7946. Coordinates are in **EPSG:4326 (WGS-84)** and MUST follow **[longitude, latitude, (altitude?)]** order. Supported types: - Point, LineString, Polygon - MultiPoint, MultiLineString, MultiPolygon - GeometryCollection (uses `geometries` instead of `coordinates`) Notes: - For rectangles, use a Polygon with a single linear ring where the first  and last positions are identical. - Circles are **not native** to GeoJSON. For circular searches, use  `SpatialConstraint` with `op: s_dwithin` and a Point + `distanceMeters`,  or approximate the circle as a Polygon. - Optional `bbox` is `[west, south, east, north]` in degrees.",
+            "title": "GeoJSONGeometry",
             "type": "object",
-            "description": "Apparent power quantity. unit: kVA | MVA.",
-            "required": ["value", "unit"],
-            "additionalProperties": false,
             "properties": {
-                "value": { "type": "number", "minimum": 0 },
-                "unit":  { "type": "string", "enum": ["kVA", "MVA"] }
-            }
+                "bbox": {
+                    "description": "Optional bounding box `[west, south, east, north]` in degrees.",
+                    "type": "array",
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "coordinates": {
+                    "description": "Coordinates per RFC 7946 for all types **except** GeometryCollection. Order is **[lon, lat, (alt)]**. For Polygons, this is an array of linear rings; each ring is an array of positions.",
+                    "type": "array",
+                    "items": {}
+                },
+                "geometries": {
+                    "description": "Member geometries when `type` is **GeometryCollection**.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/GeoJSONGeometry"
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "Point",
+                        "LineString",
+                        "Polygon",
+                        "MultiPoint",
+                        "MultiLineString",
+                        "MultiPolygon",
+                        "GeometryCollection"
+                    ]
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "additionalProperties": true
         },
-        "QVReactivePower": {
-            "$anchor": "QVReactivePower",
+        "Address": {
+            "description": "**Postal address** aligned with schema.org `PostalAddress`. Use for human-readable addresses. Geometry lives in `Location.geo` as GeoJSON.",
+            "title": "Address",
             "type": "object",
-            "description": "Reactive power quantity. unit: kVAR | MVAR. Value may be negative for absorption.",
-            "required": ["value", "unit"],
-            "additionalProperties": false,
             "properties": {
-                "value": { "type": "number" },
-                "unit":  { "type": "string", "enum": ["kVAR", "MVAR"] }
-            }
-        },
-        "QVVoltage": {
-            "$anchor": "QVVoltage",
-            "type": "object",
-            "description": "Voltage quantity. unit: V | kV.",
-            "required": ["value", "unit"],
-            "additionalProperties": false,
-            "properties": {
-                "value": { "type": "number", "minimum": 0 },
-                "unit":  { "type": "string", "enum": ["V", "kV"] }
-            }
-        },
-        "IdRef": {
-            "type": "object",
-            "required": ["issuedBy", "subjectId"],
-            "properties": {
-                "issuedBy": { "type": "string", "format": "uri" },
-                "subjectId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+:[A-Za-z0-9X_-]+$" }
-            }
+                "addressCountry": {
+                    "description": "Country name or ISO-3166-1 alpha-2 code.",
+                    "type": "string"
+                },
+                "addressLocality": {
+                    "description": "City/locality.",
+                    "type": "string"
+                },
+                "addressRegion": {
+                    "description": "State/region/province.",
+                    "type": "string"
+                },
+                "extendedAddress": {
+                    "description": "Address extension (apt/suite/floor, C/O).",
+                    "type": "string"
+                },
+                "postalCode": {
+                    "description": "Postal/ZIP code.",
+                    "type": "string"
+                },
+                "streetAddress": {
+                    "description": "Street address (building name/number and street).",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
         },
         "CustomerProfile": {
             "type": "object",
-            "description": "Non-PII customer identity, physical assets, and tariff profiles.",
-            "required": ["customerNumber", "energyResources"],
+            "description": "Non-PII customer identity and asset list. Supports arbitrary topologies: a single customerNumber may span multiple METER entries (different premises, sub-meters, parallel meters) each with child DERs.\n",
+            "required": [
+                "customerNumber",
+                "energyResources"
+            ],
             "properties": {
-                "customerNumber": { "type": "string", "minLength": 1 },
-                "idRef": { "$ref": "#/$defs/IdRef" },
+                "customerNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Utility customer account (CA) number."
+                },
+                "idRef": {
+                    "$ref": "#/$defs/IdRef"
+                },
                 "energyResources": {
                     "type": "array",
                     "minItems": 1,
-                    "items": { "$ref": "#/$defs/EnergyResource" }
+                    "description": "All physical energy assets for this account. Each entry is discriminated by 'type' into one of seven composable kinds.\n",
+                    "items": {
+                        "$ref": "#/$defs/EnergyResource"
+                    }
                 },
                 "consumptionProfiles": {
                     "type": "array",
                     "minItems": 1,
-                    "items": { "$ref": "#/$defs/ConsumptionProfile" }
+                    "description": "Tariff and load characteristics per meter connection. Each entry links to a METER via meterId.\n",
+                    "items": {
+                        "$ref": "#/$defs/ConsumptionProfile"
+                    }
                 }
             }
         },
-        "ConsumptionProfile": {
-            "$ref": "https://schema.beckn.io/MeterServiceProfile/v1.1#MeterServiceProfile",
-            "description": "Tariff and regulatory load profile per meter connection. Uses MeterServiceProfile/v1.1 (sanctionedLoad, contractMaxDemand as QVPower)."
+        "IdRef": {
+            "title": "IdRef",
+            "type": "object",
+            "description": "External identity reference for the customer. Defined in IdRef/v1.0.",
+            "required": [
+                "issuedBy",
+                "subjectId"
+            ],
+            "properties": {
+                "issuedBy": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "DID or URI of the issuing authority."
+                },
+                "subjectId": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9._-]+:[A-Za-z0-9X_-]+$",
+                    "description": "Subject identifier in authority-domain:id-value format."
+                }
+            }
         },
-        "CustomerDetails": {
-            "$ref": "https://schema.beckn.io/CustomerDetails/v1.0#CustomerDetails",
-            "description": "PII — fullName, installationAddress, serviceConnectionDate. Defined in CustomerDetails/v1.0."
+        "EnergyResource": {
+            "description": "Discriminated union of all seven typed EnergyResource kinds, each inheriting id, type, subResources, parentResources, and attributes from EnergyResourceCommon/v1.1. All power/capacity fields use QuantitativeValue. Defined in EnergyResource/v2.1.\n",
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceMeter"
+                },
+                {
+                    "$ref": "#/$defs/EnergyResourceGenerator"
+                },
+                {
+                    "$ref": "#/$defs/EnergyResourceStorage"
+                },
+                {
+                    "$ref": "#/$defs/EnergyResourceEVCharger"
+                },
+                {
+                    "$ref": "#/$defs/EnergyResourceInverter"
+                },
+                {
+                    "$ref": "#/$defs/EnergyResourceLoad"
+                },
+                {
+                    "$ref": "#/$defs/EnergyResourceNetwork"
+                }
+            ]
+        },
+        "EnergyResourceMeter": {
+            "description": "A metering-point energy resource. Anchors all DER sub-resources behind it in the topology tree. CIM: cim:Meter (IEC 61968-9).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "METER",
+                            "description": "Asset-class discriminator. Must be \"METER\". CIM cim:Meter (IEC 61968-9)."
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceMeterAttributes"
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceCommon": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Structural envelope inherited by every typed EnergyResource kind via allOf. Defines top-level fields common to all kinds: id, type, topology (subResources, parentResources), and the attributes bag.\n",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Stable identifier for this resource. For METER resources the meter serial number is conventional.\n"
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Asset class discriminator. Constrained to a kind-specific enum or const in each typed kind schema.\n"
+                },
+                "subResources": {
+                    "type": "array",
+                    "description": "Topology — child resources. Each item is EITHER a bare id string OR an inline EnergyResource object.\n",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "$ref": "#/$defs/EnergyResource"
+                            }
+                        ]
+                    }
+                },
+                "parentResources": {
+                    "type": "array",
+                    "description": "Upward topology — ids of parent resources.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attributes": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Attribute bag. Inherits EnergyResourceCommonAttributes via allOf plus kind-specific fields.\n",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                        }
+                    ]
+                }
+            }
         },
         "EnergyResourceCommonAttributes": {
             "type": "object",
-            "description": "Base attributes shared by all EnergyResource kinds. ratedPower, maxExport, maxImport are QVPower {value, unit: W|kW|MW}.",
             "additionalProperties": true,
+            "description": "Dimensioning and provenance fields shared by all resource kinds. Inherited inside each kind's attributes bag via allOf. No field is required at this level.\n",
             "properties": {
-                "make":  { "type": "string", "description": "Manufacturer name." },
-                "model": { "type": "string", "description": "Model number or name." },
-                "ratedPower": {
-                    "description": "Manufacturer-rated power. unit: W | kW | MW. CIM: GeneratingUnit.maxOperatingP / EndDeviceInfo.ratedPower.",
-                    "$ref": "#/$defs/QVPower"
+                "make": {
+                    "type": "string",
+                    "description": "Manufacturer (free text)."
                 },
-                "maxImport": {
-                    "description": "Maximum power drawn from the grid (absorbs/charges). unit: W | kW | MW. Always ≥0. CIM: PowerElectronicsConnection.maxP (absorption direction).",
-                    "$ref": "#/$defs/QVPower"
+                "model": {
+                    "type": "string",
+                    "description": "Model (free text)."
+                },
+                "ratedPower": {
+                    "$ref": "#/$defs/QVPower",
+                    "description": "Manufacturer-rated peak power (nameplate value in principal direction). Kept for backward compatibility — prefer maxExport.\n",
+                    "x-standard": "CIM (IEC 61968-9 EndDeviceInfo.ratedPower; IEC 61970 GeneratingUnit.maxOperatingP)"
                 },
                 "maxExport": {
-                    "description": "Maximum power injected to the grid (generates/discharges). unit: W | kW | MW. Always ≥0. CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP (injection direction).",
-                    "$ref": "#/$defs/QVPower"
+                    "$ref": "#/$defs/QVPower",
+                    "description": "Maximum power this resource injects to the grid (generates/discharges). Always ≥0. For bidirectional resources (BESS, V2G) this is the max discharge rate. Supersedes ratedPower.\n",
+                    "x-standard": "CIM (IEC 61970 GeneratingUnit.maxOperatingP; IEC 61970-302 PowerElectronicsConnection.maxP, injection)"
                 },
-                "telemetryProvider": { "type": "string", "description": "Vendor API or data-source identifier for telemetry." },
-                "commissioningDate": { "type": "string", "format": "date-time", "description": "ISO 8601 date-time the asset was commissioned." },
-                "location": { "$ref": "#/$defs/Location" }
+                "maxImport": {
+                    "$ref": "#/$defs/QVPower",
+                    "description": "Maximum power this resource draws from the grid (absorbs/charges). Always ≥0. For bidirectional resources (BESS, V2G) this is the max charge rate.\n",
+                    "x-standard": "CIM (IEC 61970-302 PowerElectronicsConnection.maxP, absorption)"
+                },
+                "telemetryProvider": {
+                    "type": "string",
+                    "description": "Vendor API / data source identifier for telemetry."
+                },
+                "commissioningDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "ISO 8601 date-time the asset was commissioned."
+                },
+                "location": {
+                    "$ref": "#/$defs/Location",
+                    "description": "Physical location of this asset."
+                },
+                "serialNumber": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Manufacturer-assigned device serial number from the equipment nameplate. Distinct from id (which is the network-issued DID).\n",
+                    "x-standard": "CIM (IEC 61968-9 EndDeviceInfo.serialNumber)"
+                },
+                "inspection": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Commissioning / safety inspection record for the asset. Captured by the distribution licensee at energisation and on re-certification events.\n",
+                    "x-standard": "IEEE 1547-2018 Cl. 11 (commissioning); CEA Connectivity Regs 2013 (amended 2018)",
+                    "properties": {
+                        "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "ISO 8601 date the inspection was performed."
+                        },
+                        "result": {
+                            "type": "string",
+                            "enum": [
+                                "pass",
+                                "fail",
+                                "conditional"
+                            ],
+                            "description": "Inspection outcome. 'conditional' indicates pass subject to remedial action.\n"
+                        },
+                        "inspectorId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Identifier of the inspector or inspecting body, as recorded by the licensee.\n"
+                        }
+                    }
+                },
+                "aggregator": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Third-party flexibility / demand-response enrolment for this asset. Present when an aggregator is authorised to dispatch or observe the resource. Controllability flag is asset-level; the asset may still be observable even when controllable is false.\n",
+                    "x-standard": "IEEE 2030.5; IEC 61850-7-420 (DER control roles)",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Aggregator identity — typically a did:web for the aggregator's domain.\n"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Human-readable aggregator name (free text)."
+                        },
+                        "controllable": {
+                            "type": "boolean",
+                            "description": "True if the aggregator is authorised to issue dispatch / curtailment instructions. False = observation-only.\n"
+                        },
+                        "enrolledOn": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "ISO 8601 date the asset was enrolled with the aggregator."
+                        }
+                    }
+                }
+            }
+        },
+        "QVPower": {
+            "type": "object",
+            "description": "Active-power quantity {value, unit}. unit is a QUDT power alias (W, kW, MW) expanded to a QUDT IRI via the JSON-LD context.\n",
+            "required": [
+                "value",
+                "unit"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": [
+                        "W",
+                        "kW",
+                        "MW"
+                    ]
+                }
             }
         },
         "EnergyResourceMeterAttributes": {
-            "description": "Attributes for metering devices (type: METER). CIM: Meter extends EndDevice (IEC 61968-9).",
+            "description": "Attributes for METER resources. Common power fields (ratedPower, maxExport, maxImport, make, model, telemetryProvider, commissioningDate, location) inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "meterCapability": {
                             "type": "string",
-                            "enum": ["Electromechanical", "CMRI", "AMR", "AMI"],
-                            "description": "Communication/automation generation. CIM: AmiBillingReadyKind (IEC 61968-9)."
+                            "enum": [
+                                "Electromechanical",
+                                "CMRI",
+                                "AMR",
+                                "AMI"
+                            ],
+                            "description": "Communication/automation generation. Electromechanical: induction-disc. CMRI: manual optical-port (India legacy). AMR: one-way automated read. AMI: two-way smart meter.\n",
+                            "x-standard": "CIM (IEC 61968-9 AmiBillingReadyKind)"
                         },
                         "energyDirection": {
                             "type": "string",
-                            "enum": ["Forward", "Reverse", "Bidirectional", "Net"],
+                            "enum": [
+                                "Forward",
+                                "Reverse",
+                                "Bidirectional",
+                                "Net"
+                            ],
                             "default": "Forward",
-                            "description": "Energy flow direction. CIM: FlowDirectionKind (ESPI NAESB REQ.21)."
+                            "description": "Energy flow direction metered at this point.",
+                            "x-standard": "CIM (FlowDirectionKind); ESPI NAESB REQ.21"
                         },
                         "functions": {
                             "type": "array",
                             "uniqueItems": true,
-                            "description": "Active meter capabilities per IEC 61968-9 EndDeviceFunction.",
-                            "items": { "type": "string", "enum": ["ToU", "NetMetering", "MaxDemand", "LoadControl", "TamperDetection", "PowerQuality", "EventLogging"] }
+                            "description": "Active meter capabilities.",
+                            "x-standard": "CIM (IEC 61968-9 EndDeviceFunction)",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "ToU",
+                                    "NetMetering",
+                                    "MaxDemand",
+                                    "LoadControl",
+                                    "TamperDetection",
+                                    "PowerQuality",
+                                    "EventLogging"
+                                ]
+                            }
                         },
-                        "feeder": { "type": "string", "description": "Feeder identifier this meter is supplied from." },
-                        "bus": { "type": "string", "description": "Busbar identifier." },
+                        "feeder": {
+                            "type": "string",
+                            "description": "Feeder identifier this meter is supplied from."
+                        },
+                        "bus": {
+                            "type": "string",
+                            "description": "Busbar identifier at the meter's connection point."
+                        },
                         "communicationTechnology": {
                             "type": "string",
-                            "enum": ["PLC", "RF_Mesh", "GPRS", "NB-IoT", "LoRa", "ZigBee", "Other"]
+                            "enum": [
+                                "PLC",
+                                "RF_Mesh",
+                                "GPRS",
+                                "NB-IoT",
+                                "LoRa",
+                                "ZigBee",
+                                "Other"
+                            ],
+                            "description": "Last-mile physical-layer communication technology."
                         },
                         "applicationProtocol": {
                             "type": "string",
-                            "enum": ["DLMS_COSEM", "ANSI_C12_18", "IEC_61850", "Modbus", "Other"]
+                            "enum": [
+                                "DLMS_COSEM",
+                                "ANSI_C12_18",
+                                "IEC_61850",
+                                "Modbus",
+                                "Other"
+                            ],
+                            "description": "Application-layer protocol for meter data. DLMS_COSEM: IEC 62056, mandatory for India AMI per BIS IS 16444. ANSI_C12_18: North American. Orthogonal to communicationTechnology (physical layer).\n"
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceGenerator": {
+            "description": "A generation DER energy resource (SOLAR_PV, WIND, HYDRO, BIOGAS, CHP, FUEL_CELL). CIM: GeneratingUnit subtypes (IEC 61970-301).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "SOLAR_PV",
+                                "SOLAR",
+                                "WIND",
+                                "HYDRO",
+                                "BIOGAS",
+                                "CHP",
+                                "FUEL_CELL"
+                            ],
+                            "description": "Asset-class discriminator. SOLAR is deprecated — use SOLAR_PV.\n"
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceGeneratorAttributes"
                         }
                     }
                 }
             ]
         },
         "EnergyResourceGeneratorAttributes": {
-            "description": "Attributes for generation assets. CIM: GeneratingUnit subtypes (IEC 61970-302).",
+            "description": "Attributes for generation DER resources. Common fields inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "nominalPower": {
-                            "description": "Nominal (nameplate) power output. unit: W | kW | MW. CIM: GeneratingUnit.nominalP.",
-                            "$ref": "#/$defs/QVPower"
+                            "$ref": "#/$defs/QVPower",
+                            "description": "Nominal (nameplate) power output. Use when distinct from maxExport (peak).\n",
+                            "x-standard": "CIM (IEC 61970 GeneratingUnit.nominalP)"
                         },
                         "efficiency": {
                             "type": "number",
                             "minimum": 0,
                             "maximum": 100,
-                            "description": "Conversion efficiency in percent. Relevant for FUEL_CELL and CHP."
+                            "description": "Conversion efficiency as a percentage (0–100). Most relevant for FUEL_CELL and CHP resources.\n"
+                        },
+                        "dcArrayCapacity": {
+                            "$ref": "#/$defs/QVPower",
+                            "description": "DC-side nameplate capacity of a photovoltaic array at Standard Test Conditions (industry term: \"kWp\"). For PV systems this is typically larger than the AC-side maxExport because of inverter clipping and DC-to-AC ratios. Relevant for SOLAR_PV resources. The unit is the standard QUDT power alias kW — the STC/peak semantic is documented here, not encoded in the unit string.\n",
+                            "x-standard": "IS 16221 (PV module qualification); IEC 61727 (PV grid interface)"
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceStorage": {
+            "description": "A stationary battery energy storage resource (BESS). CIM: BatteryUnit (IEC 61970-302).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "BESS",
+                                "BATTERY"
+                            ],
+                            "description": "Asset-class discriminator. BATTERY is deprecated — use BESS. CIM: BatteryUnit (IEC 61970-302).\n"
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceStorageAttributes"
                         }
                     }
                 }
             ]
         },
         "EnergyResourceStorageAttributes": {
-            "description": "Attributes for stationary energy storage assets (BESS). CIM: BatteryUnit (IEC 61970-302).",
+            "description": "Attributes for BESS resources. Common fields (make, model, ratedPower, maxExport, maxImport, telemetryProvider, commissioningDate, location) are inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "storageCapacity": {
-                            "description": "Rated stored-energy capacity. unit: kWh | MWh. CIM: BatteryUnit.ratedE.",
-                            "$ref": "#/$defs/QVEnergy"
+                            "$ref": "#/$defs/QVEnergy",
+                            "description": "Rated stored-energy capacity. Replaces storageCapacityKwh from v1.0.\n",
+                            "x-standard": "CIM (IEC 61970-302 BatteryUnit.ratedE)"
                         },
                         "storageType": {
                             "type": "string",
-                            "enum": ["LithiumIon", "LeadAcid", "FlowBattery", "NaS", "NiCd", "Flywheel", "Other"]
+                            "enum": [
+                                "LithiumIon",
+                                "LeadAcid",
+                                "FlowBattery",
+                                "NaS",
+                                "NiCd",
+                                "Flywheel",
+                                "Other"
+                            ],
+                            "description": "Battery storage technology type."
                         },
                         "stateOfHealthPct": {
                             "type": "number",
                             "minimum": 0,
                             "maximum": 100,
-                            "description": "Battery state of health as percentage of original capacity."
+                            "description": "Battery state-of-health as a percentage (0–100)."
+                        },
+                        "roundTripEfficiencyPct": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "description": "AC-to-AC round-trip efficiency as a percentage (0–100): the fraction of energy returned to the grid relative to energy drawn during a full charge/discharge cycle. Distinct from stateOfHealthPct (cumulative life indicator) and from inverter conversion efficiency.\n",
+                            "x-standard": "IEC 62933-2-1 (performance test method)"
+                        }
+                    }
+                }
+            ]
+        },
+        "QVEnergy": {
+            "type": "object",
+            "description": "Energy quantity {value, unit}. unit is a QUDT energy alias (kWh, MWh) expanded to a QUDT IRI via the JSON-LD context.\n",
+            "required": [
+                "value",
+                "unit"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": [
+                        "kWh",
+                        "MWh"
+                    ]
+                }
+            }
+        },
+        "EnergyResourceEVCharger": {
+            "description": "An EV charging station (EVSE) energy resource. EV_V2G adds bidirectional Vehicle-to-Grid capability per ISO 15118-20 / OCPP 2.1 BPT. CIM: ElectricVehicleChargingStation (CIM17+).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "EV_CHARGER",
+                                "EV_V2G"
+                            ],
+                            "description": "Asset-class discriminator. EV_CHARGER: EVSE hardware. EV_V2G: Vehicle-to-Grid capable EVSE with ISO 15118-20 / OCPP 2.1 BPT.\n"
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceEVChargerAttributes"
                         }
                     }
                 }
             ]
         },
         "EnergyResourceEVChargerAttributes": {
-            "description": "Attributes for EV charging stations. EV_CHARGER is a flexible load at the grid connection point. EV_V2G adds ISO 15118-20 / OCPP 2.1 BPT bidirectional capability. CIM: ElectricVehicleChargingStation (CIM17+).",
+            "description": "Attributes for EV_CHARGER and EV_V2G resources. Common fields (make, model, ratedPower, maxExport, maxImport, telemetryProvider, commissioningDate, location) are inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "connectorType": {
                             "type": "string",
-                            "enum": ["Type1", "Type2", "CCS1", "CCS2", "CHAdeMO", "GB_T", "NACS", "Other"]
+                            "enum": [
+                                "Type1",
+                                "Type2",
+                                "CCS1",
+                                "CCS2",
+                                "CHAdeMO",
+                                "GB_T",
+                                "NACS",
+                                "Other"
+                            ],
+                            "description": "Physical connector standard. Type1: IEC 62196-2 Type 1 (J1772). Type2: IEC 62196-2 Type 2 (Mennekes). CCS1/CCS2: Combined Charging System DC fast charge. CHAdeMO: CHAdeMO DC fast charge. GB_T: GB/T 20234. NACS: SAE J3400.\n"
                         },
                         "controlProtocol": {
                             "type": "string",
-                            "enum": ["OCPP_1.6", "OCPP_2.0.1", "OCPP_2.1", "ISO_15118_2", "ISO_15118_20", "Other"]
+                            "enum": [
+                                "OCPP_1.6",
+                                "OCPP_2.0.1",
+                                "OCPP_2.1",
+                                "ISO_15118_2",
+                                "ISO_15118_20",
+                                "Other"
+                            ],
+                            "description": "EVSE control and smart-charging protocol."
                         },
                         "v2xProtocol": {
                             "type": "string",
-                            "enum": ["CHAdeMO_V2G", "CCS_BPT", "ISO_15118_20_AC_BPT", "ISO_15118_20_DC_BPT", "Other"]
+                            "enum": [
+                                "CHAdeMO_V2G",
+                                "CCS_BPT",
+                                "ISO_15118_20_AC_BPT",
+                                "ISO_15118_20_DC_BPT",
+                                "Other"
+                            ],
+                            "description": "Vehicle-to-Grid / V2X protocol. Present only for EV_V2G resources."
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceInverter": {
+            "description": "A grid-connected power-electronics inverter energy resource. Captures IEEE 1547-2018 ride-through categories, operating mode, and reactive / frequency-support capabilities. CIM: PowerElectronicsConnection (IEC 61970-302).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "INVERTER",
+                            "description": "Asset-class discriminator. Must be \"INVERTER\". CIM: PowerElectronicsConnection (IEC 61970-302).\n"
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceInverterAttributes"
                         }
                     }
                 }
             ]
         },
         "EnergyResourceInverterAttributes": {
-            "description": "Attributes for grid-connected power-electronics inverters (type: INVERTER). IEEE 1547-2018 / SunSpec DER Models 702-714. CIM: PowerElectronicsConnection (IEC 61970-302).",
+            "description": "Attributes for INVERTER resources. Common fields (make, model, ratedPower, maxExport, maxImport, telemetryProvider, commissioningDate, location) are inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "ratedApparentPower": {
-                            "description": "Rated apparent power. unit: kVA | MVA. SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS.",
-                            "$ref": "#/$defs/QVApparentPower"
+                            "$ref": "#/$defs/QVApparentPower",
+                            "description": "Rated apparent power. Replaces ratedApparentPowerKva from v1.0.\n",
+                            "x-standard": "SunSpec DER Model 702 (maxVA); CIM (IEC 61970-302 PowerElectronicsConnection.ratedS)"
                         },
                         "maxReactivePower": {
-                            "description": "Max reactive power injection (leading / over-excited). unit: kVAR | MVAR. Always ≥0. SunSpec Model 702 maxVar. CIM: PowerElectronicsConnection.maxQ.",
-                            "$ref": "#/$defs/QVReactivePower"
+                            "$ref": "#/$defs/QVReactivePower",
+                            "description": "Maximum reactive power injection (leading / over-excited). Replaces maxReactivePowerKvar from v1.0.\n",
+                            "x-standard": "SunSpec DER Model 702 (maxVar); CIM (IEC 61970-302 PowerElectronicsConnection.maxQ)"
                         },
                         "minReactivePower": {
-                            "description": "Max reactive power absorption (lagging / under-excited). unit: kVAR | MVAR. Value typically negative. SunSpec Model 702 maxVarNeg. CIM: PowerElectronicsConnection.minQ.",
-                            "$ref": "#/$defs/QVReactivePower"
+                            "$ref": "#/$defs/QVReactivePower",
+                            "description": "Maximum reactive power absorption (lagging / under-excited). Value is typically negative. Replaces minReactivePowerKvar from v1.0.\n",
+                            "x-standard": "SunSpec DER Model 702 (maxVarNeg); CIM (IEC 61970-302 PowerElectronicsConnection.minQ)"
                         },
                         "rideThroughCategory": {
                             "type": "string",
-                            "enum": ["CategoryI", "CategoryII", "CategoryIII"],
-                            "description": "IEEE 1547-2018 abnormal operating performance category."
+                            "enum": [
+                                "CategoryI",
+                                "CategoryII",
+                                "CategoryIII"
+                            ],
+                            "description": "Abnormal operating performance category. CategoryI: basic. CategoryII: enhanced for distribution-connected DER. CategoryIII: advanced for large/transmission-connected DER.\n",
+                            "x-standard": "IEEE 1547-2018 (ride-through category)"
                         },
                         "operatingMode": {
                             "type": "string",
-                            "enum": ["GridFollowing", "GridForming", "Standby"]
+                            "enum": [
+                                "GridFollowing",
+                                "GridForming",
+                                "Standby"
+                            ],
+                            "description": "Inverter grid-interaction mode. GridFollowing: PLL-based sync. GridForming: own V/f reference (microgrid islanding, black-start). Standby: energised but not injecting.\n",
+                            "x-standard": "CIM (IEC 61970-302 PowerElectronicsConnection.inverterMode)"
                         },
-                        "voltVarEnabled": { "type": "boolean" },
-                        "freqDroopEnabled": { "type": "boolean" },
-                        "enterServiceRampTimeSec": { "type": "number", "minimum": 0 }
+                        "voltVarEnabled": {
+                            "type": "boolean",
+                            "description": "Volt-VAr curve active.",
+                            "x-standard": "IEEE 2030.5 (opModVoltVar); SunSpec DER Model 705"
+                        },
+                        "freqDroopEnabled": {
+                            "type": "boolean",
+                            "description": "Frequency-Watt droop active.",
+                            "x-standard": "IEEE 1547-2018; SunSpec DER Model 711"
+                        },
+                        "enterServiceRampTimeSec": {
+                            "type": "number",
+                            "minimum": 0,
+                            "description": "Seconds to ramp from 0 to rated power after reconnection.",
+                            "x-standard": "SunSpec DER Model 703 (ESRmpTms)"
+                        }
+                    }
+                }
+            ]
+        },
+        "QVApparentPower": {
+            "type": "object",
+            "description": "Apparent-power quantity {value, unit}. unit is a QUDT apparent-power alias (kVA, MVA) expanded to a QUDT IRI via the JSON-LD context.\n",
+            "required": [
+                "value",
+                "unit"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": [
+                        "kVA",
+                        "MVA"
+                    ]
+                }
+            }
+        },
+        "QVReactivePower": {
+            "type": "object",
+            "description": "Reactive-power quantity {value, unit}. unit is a QUDT reactive-power alias (kVAR, MVAR) expanded to a QUDT IRI via the JSON-LD context. value may be negative (absorption).\n",
+            "required": [
+                "value",
+                "unit"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": [
+                        "kVAR",
+                        "MVAR"
+                    ]
+                }
+            }
+        },
+        "EnergyResourceLoad": {
+            "description": "A controllable load energy resource (smart HVAC, smart water heater, or generic controllable load). CIM: EnergyConsumer / ConformLoad (IEC 61970-301).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "SMART_HVAC",
+                                "SMART_WATER_HEATER",
+                                "CONTROLLABLE_LOAD"
+                            ],
+                            "description": "Asset-class discriminator. CIM: EnergyConsumer / ConformLoad (IEC 61970-301).\n"
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceLoadAttributes"
+                        }
                     }
                 }
             ]
         },
         "EnergyResourceLoadAttributes": {
-            "description": "Attributes for controllable electrical loads. CIM: EnergyConsumer / ConformLoad (IEC 61970-301).",
+            "description": "Attributes for controllable load resources. Common fields (make, model, ratedPower, maxExport, maxImport, telemetryProvider, commissioningDate, location) are inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "controlProtocol": {
                             "type": "string",
-                            "enum": ["OpenADR_2.0b", "OCPP_2.0.1", "SunSpec_Modbus", "EEBus", "Modbus", "Other"]
+                            "enum": [
+                                "OpenADR_2.0b",
+                                "OCPP_2.0.1",
+                                "SunSpec_Modbus",
+                                "EEBus",
+                                "Modbus",
+                                "Other"
+                            ],
+                            "description": "Demand-response / control protocol supported by this load device."
                         },
                         "loadCategory": {
                             "type": "string",
-                            "enum": ["Heating", "Cooling", "WaterHeating", "Lighting", "EV", "Industrial", "Other"]
+                            "enum": [
+                                "Heating",
+                                "Cooling",
+                                "WaterHeating",
+                                "Lighting",
+                                "EV",
+                                "Industrial",
+                                "Other"
+                            ],
+                            "description": "Functional category of this load.",
+                            "x-standard": "CIM (IEC 61970-301 ConformLoad classification)"
+                        }
+                    }
+                }
+            ]
+        },
+        "EnergyResourceNetwork": {
+            "description": "A grid-network infrastructure energy resource (distribution transformer, busbar, feeder, or microgrid). Topology containers that anchor metering points and DER resources. CIM: PowerTransformer, BusbarSection, Feeder, Substation (IEC 61970-301).\n",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/EnergyResourceCommon"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "DT",
+                                "BUS",
+                                "FEEDER",
+                                "MICROGRID"
+                            ],
+                            "description": "Asset-class discriminator. DT → PowerTransformer, BUS → BusbarSection, FEEDER → Feeder (EquipmentContainer), MICROGRID → Substation / microgrid container (IEC 61970-301).\n"
+                        },
+                        "attributes": {
+                            "$ref": "#/$defs/EnergyResourceNetworkAttributes"
                         }
                     }
                 }
             ]
         },
         "EnergyResourceNetworkAttributes": {
-            "description": "Attributes for distribution network topology elements. CIM: PowerTransformer (DT), BusbarSection (BUS), Feeder (FEEDER), Substation/custom (MICROGRID).",
+            "description": "Attributes for grid-network infrastructure resources. Common fields (make, model, ratedPower, maxExport, maxImport, telemetryProvider, commissioningDate, location) are inherited from EnergyResourceCommon/v1.1 via allOf.\n",
             "allOf": [
-                { "$ref": "#/$defs/EnergyResourceCommonAttributes" },
+                {
+                    "$ref": "#/$defs/EnergyResourceCommonAttributes"
+                },
                 {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "nominalVoltage": {
-                            "description": "Nominal operating voltage. unit: V | kV. CIM: BaseVoltage.nominalVoltage.",
-                            "$ref": "#/$defs/QVVoltage"
+                            "$ref": "#/$defs/QVVoltage",
+                            "description": "Nominal operating voltage. Replaces nominalVoltageKv from v1.0.\n",
+                            "x-standard": "CIM (IEC 61970-301 BaseVoltage.nominalVoltage)"
                         },
-                        "zone": { "type": "string" },
-                        "substationId": { "type": "string" },
-                        "feederCode": { "type": "string" }
+                        "zone": {
+                            "type": "string",
+                            "description": "Operating zone or region identifier used by the utility."
+                        },
+                        "substationId": {
+                            "type": "string",
+                            "description": "Parent substation identifier per utility records."
+                        },
+                        "feederCode": {
+                            "type": "string",
+                            "description": "Feeder code per utility records. Relevant for FEEDER and DT resources."
+                        }
                     }
                 }
             ]
         },
-        "EnergyResourceMeter": {
+        "QVVoltage": {
             "type": "object",
-            "description": "Metering device. CIM: Meter extends EndDevice (IEC 61968-9).",
-            "properties": {
-                "type": { "type": "string", "const": "METER" },
-                "attributes": { "$ref": "#/$defs/EnergyResourceMeterAttributes" }
-            }
-        },
-        "EnergyResourceGenerator": {
-            "type": "object",
-            "description": "Electrical generation asset. SOLAR is deprecated — use SOLAR_PV. CIM: GeneratingUnit subtypes (IEC 61970-302).",
-            "properties": {
-                "type": { "type": "string", "enum": ["SOLAR_PV", "SOLAR", "WIND", "HYDRO", "BIOGAS", "CHP", "FUEL_CELL"] },
-                "attributes": { "$ref": "#/$defs/EnergyResourceGeneratorAttributes" }
-            }
-        },
-        "EnergyResourceStorage": {
-            "type": "object",
-            "description": "Stationary energy storage asset. BATTERY is deprecated — use BESS. CIM: BatteryUnit (IEC 61970-302).",
-            "properties": {
-                "type": { "type": "string", "enum": ["BESS", "BATTERY"] },
-                "attributes": { "$ref": "#/$defs/EnergyResourceStorageAttributes" }
-            }
-        },
-        "EnergyResourceEVCharger": {
-            "type": "object",
-            "description": "EV charging station (EVSE). A flexible load — NOT a storage resource. CIM: ElectricVehicleChargingStation (CIM17+).",
-            "properties": {
-                "type": { "type": "string", "enum": ["EV_CHARGER", "EV_V2G"] },
-                "attributes": { "$ref": "#/$defs/EnergyResourceEVChargerAttributes" }
-            }
-        },
-        "EnergyResourceInverter": {
-            "type": "object",
-            "description": "Grid-connected power-electronics inverter. CIM: PowerElectronicsConnection (IEC 61970-302).",
-            "properties": {
-                "type": { "type": "string", "const": "INVERTER" },
-                "attributes": { "$ref": "#/$defs/EnergyResourceInverterAttributes" }
-            }
-        },
-        "EnergyResourceLoad": {
-            "type": "object",
-            "description": "Controllable electrical load. CIM: EnergyConsumer / ConformLoad (IEC 61970-301).",
-            "properties": {
-                "type": { "type": "string", "enum": ["SMART_HVAC", "SMART_WATER_HEATER", "CONTROLLABLE_LOAD"] },
-                "attributes": { "$ref": "#/$defs/EnergyResourceLoadAttributes" }
-            }
-        },
-        "EnergyResourceNetwork": {
-            "type": "object",
-            "description": "Distribution network topology element. CIM: DT=PowerTransformer, BUS=BusbarSection, FEEDER=Feeder, MICROGRID=Substation/custom (IEC 61970-301).",
-            "properties": {
-                "type": { "type": "string", "enum": ["DT", "BUS", "FEEDER", "MICROGRID"] },
-                "attributes": { "$ref": "#/$defs/EnergyResourceNetworkAttributes" }
-            }
-        },
-        "EnergyResource": {
-            "type": "object",
-            "description": "Composable energy resource, discriminated by 'type' into one of seven kinds. id and type are required.",
-            "required": ["id", "type"],
-            "properties": {
-                "id": { "type": "string", "minLength": 1 },
-                "subResources": {
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            { "type": "string" },
-                            { "$ref": "#/$defs/EnergyResource" }
-                        ]
-                    }
-                },
-                "parentResources": {
-                    "type": "array",
-                    "items": { "type": "string" }
-                }
-            },
-            "oneOf": [
-                { "$ref": "#/$defs/EnergyResourceMeter" },
-                { "$ref": "#/$defs/EnergyResourceGenerator" },
-                { "$ref": "#/$defs/EnergyResourceStorage" },
-                { "$ref": "#/$defs/EnergyResourceEVCharger" },
-                { "$ref": "#/$defs/EnergyResourceInverter" },
-                { "$ref": "#/$defs/EnergyResourceLoad" },
-                { "$ref": "#/$defs/EnergyResourceNetwork" }
-            ]
-        },
-        "Location": {
-            "type": "object",
-            "required": ["geo"],
-            "properties": {
-                "geo": { "$ref": "#/$defs/GeoJSONGeometry" },
-                "address": { "$ref": "#/$defs/Address" }
-            }
-        },
-        "GeoJSONGeometry": {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-                "type": { "type": "string", "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"] },
-                "coordinates": { "type": "array" },
-                "geometries": { "type": "array", "items": { "$ref": "#/$defs/GeoJSONGeometry" } },
-                "bbox": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "type": "number" } }
-            },
-            "additionalProperties": true
-        },
-        "Address": {
-            "type": "object",
+            "description": "Voltage quantity {value, unit}. unit is a QUDT voltage alias (V, kV) expanded to a QUDT IRI via the JSON-LD context.\n",
+            "required": [
+                "value",
+                "unit"
+            ],
             "additionalProperties": false,
             "properties": {
-                "streetAddress":    { "type": "string" },
-                "extendedAddress":  { "type": "string" },
-                "addressLocality":  { "type": "string" },
-                "addressRegion":    { "type": "string" },
-                "postalCode":       { "type": "string" },
-                "addressCountry":   { "type": "string" }
+                "value": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": [
+                        "V",
+                        "kV"
+                    ]
+                }
+            }
+        },
+        "ConsumptionProfile": {
+            "type": "object",
+            "description": "Tariff and regulatory load profile for one meter connection. meterId links to a METER entry in customerProfile.energyResources[]. Uses MeterServiceProfile/v1.1 (sanctionedLoad, contractMaxDemand as QuantitativeValue).\n",
+            "required": [
+                "meterId",
+                "sanctionedLoad",
+                "tariffCategoryCode"
+            ],
+            "properties": {
+                "meterId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Matches the id of a METER entry in customerProfile.energyResources[]."
+                },
+                "sanctionedLoad": {
+                    "$ref": "#/$defs/QVPower",
+                    "description": "Sanctioned/approved import load.",
+                    "x-standard": "CIM (IEC 61968-9 UsagePoint)"
+                },
+                "sanctionedExportLoad": {
+                    "$ref": "#/$defs/QVPower",
+                    "description": "Sanctioned/approved grid export limit."
+                },
+                "billingCycleDay": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31,
+                    "description": "Day of month on which the billing cycle resets."
+                },
+                "contractMaxDemand": {
+                    "$ref": "#/$defs/QVPower",
+                    "description": "Maximum demand contracted with the utility for this connection."
+                },
+                "tariffCategoryCode": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Billing/tariff category code assigned by the utility.",
+                    "x-standard": "CIM (IEC 61968-9 UsagePoint.serviceCategory)"
+                },
+                "premisesType": {
+                    "type": "string",
+                    "enum": [
+                        "Residential",
+                        "Commercial",
+                        "Industrial",
+                        "Agricultural"
+                    ],
+                    "description": "Type of premises at the metering point."
+                },
+                "connectionType": {
+                    "type": "string",
+                    "enum": [
+                        "Single-phase",
+                        "Three-phase"
+                    ],
+                    "description": "Electrical connection type.",
+                    "x-standard": "CIM (IEC 61968-9 UsagePoint.phaseCode)"
+                },
+                "paymentMode": {
+                    "type": "string",
+                    "enum": [
+                        "POSTPAID",
+                        "PREPAID"
+                    ],
+                    "description": "Billing/payment modality. POSTPAID: consume now, pay later. PREPAID: pay-before-use.\n",
+                    "x-standard": "CIM (IEC 61968-9 AmiBillingReadyKind, ESPI)"
+                },
+                "serviceStatus": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "suspended",
+                        "closed"
+                    ],
+                    "description": "Lifecycle state of the service connection (the UsagePoint), not of the meter device itself. 'active' = currently energised and billable; 'suspended' = temporarily disconnected (non-payment, inspection, fault) with the contract still on record; 'closed' = permanently terminated. Distinct from the meter device's operational state.\n",
+                    "x-standard": "CIM (IEC 61968-9 UsagePoint.status)"
+                }
             }
         }
     }

--- a/specification/schema/EnergyResourceCommon/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceCommon/v1.1/attributes.yaml
@@ -57,6 +57,85 @@ components:
             kVA, MVA (apparent power); kVAR, MVAR (reactive power);
             V, kV (voltage). Mapped to QUDT IRIs via JSON-LD context.
 
+    QVPower:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVPower
+      type: object
+      description: >
+        Active-power quantity {value, unit}. unit is a QUDT power alias
+        (W, kW, MW) expanded to a QUDT IRI via the JSON-LD context.
+      required: [value, unit]
+      additionalProperties: false
+      properties:
+        value:
+          type: number
+        unit:
+          type: string
+          enum: [W, kW, MW]
+
+    QVEnergy:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVEnergy
+      type: object
+      description: >
+        Energy quantity {value, unit}. unit is a QUDT energy alias
+        (kWh, MWh) expanded to a QUDT IRI via the JSON-LD context.
+      required: [value, unit]
+      additionalProperties: false
+      properties:
+        value:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          enum: [kWh, MWh]
+
+    QVApparentPower:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVApparentPower
+      type: object
+      description: >
+        Apparent-power quantity {value, unit}. unit is a QUDT apparent-power
+        alias (kVA, MVA) expanded to a QUDT IRI via the JSON-LD context.
+      required: [value, unit]
+      additionalProperties: false
+      properties:
+        value:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          enum: [kVA, MVA]
+
+    QVReactivePower:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVReactivePower
+      type: object
+      description: >
+        Reactive-power quantity {value, unit}. unit is a QUDT reactive-power
+        alias (kVAR, MVAR) expanded to a QUDT IRI via the JSON-LD context.
+        value may be negative (absorption).
+      required: [value, unit]
+      additionalProperties: false
+      properties:
+        value:
+          type: number
+        unit:
+          type: string
+          enum: [kVAR, MVAR]
+
+    QVVoltage:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVVoltage
+      type: object
+      description: >
+        Voltage quantity {value, unit}. unit is a QUDT voltage alias
+        (V, kV) expanded to a QUDT IRI via the JSON-LD context.
+      required: [value, unit]
+      additionalProperties: false
+      properties:
+        value:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          enum: [V, kV]
+
     EnergyResourceCommonAttributes:
       $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes
       type: object
@@ -82,32 +161,31 @@ components:
             "@id": deg:model
 
         ratedPower:
-          $ref: "#/components/schemas/QuantitativeValue"
+          $ref: "#/components/schemas/QVPower"
           description: >
             Manufacturer-rated peak power (nameplate value in principal direction).
-            Typical unit: kW. Kept for backward compatibility — prefer maxExport.
-            CIM: GeneratingUnit.maxOperatingP / EndDeviceInfo.ratedPower.
+            Kept for backward compatibility — prefer maxExport.
+          x-standard: "CIM (IEC 61968-9 EndDeviceInfo.ratedPower; IEC 61970 GeneratingUnit.maxOperatingP)"
           x-jsonld:
             "@id": deg:ratedPower
 
         maxExport:
-          $ref: "#/components/schemas/QuantitativeValue"
+          $ref: "#/components/schemas/QVPower"
           description: >
             Maximum power this resource injects to the grid (generates/discharges).
-            Typical unit: kW. Always ≥0. For bidirectional resources (BESS, V2G)
-            this is the max discharge rate. Supersedes ratedPower.
-            CIM: GeneratingUnit.maxOperatingP / PowerElectronicsConnection.maxP
-            (injection direction).
+            Always ≥0. For bidirectional resources (BESS, V2G) this is the max
+            discharge rate. Supersedes ratedPower.
+          x-standard: "CIM (IEC 61970 GeneratingUnit.maxOperatingP; IEC 61970-302 PowerElectronicsConnection.maxP, injection)"
           x-jsonld:
             "@id": deg:maxExport
 
         maxImport:
-          $ref: "#/components/schemas/QuantitativeValue"
+          $ref: "#/components/schemas/QVPower"
           description: >
             Maximum power this resource draws from the grid (absorbs/charges).
-            Typical unit: kW. Always ≥0. For bidirectional resources (BESS, V2G)
-            this is the max charge rate.
-            CIM: PowerElectronicsConnection.maxP (absorption direction).
+            Always ≥0. For bidirectional resources (BESS, V2G) this is the max
+            charge rate.
+          x-standard: "CIM (IEC 61970-302 PowerElectronicsConnection.maxP, absorption)"
           x-jsonld:
             "@id": deg:maxImport
 
@@ -136,7 +214,7 @@ components:
           description: >
             Manufacturer-assigned device serial number from the equipment
             nameplate. Distinct from id (which is the network-issued DID).
-            CIM: cim:EndDeviceInfo.serialNumber (IEC 61968-9).
+          x-standard: "CIM (IEC 61968-9 EndDeviceInfo.serialNumber)"
           x-jsonld:
             "@id": deg:serialNumber
 
@@ -146,10 +224,8 @@ components:
           description: >
             Commissioning / safety inspection record for the asset. Captured
             by the distribution licensee at energisation and on
-            re-certification events. Aligned to IEEE 1547-2018
-            commissioning evaluations (Cl. 11) and CEA (Technical Standards
-            for Connectivity of Distributed Generation Resources)
-            Regulations, 2013 (amended 2018).
+            re-certification events.
+          x-standard: "IEEE 1547-2018 Cl. 11 (commissioning); CEA Connectivity Regs 2013 (amended 2018)"
           properties:
             date:
               type: string
@@ -178,7 +254,7 @@ components:
             asset. Present when an aggregator is authorised to dispatch or
             observe the resource. Controllability flag is asset-level; the
             asset may still be observable even when controllable is false.
-            Aligned to IEEE 2030.5 and IEC 61850-7-420 DER control roles.
+          x-standard: "IEEE 2030.5; IEC 61850-7-420 (DER control roles)"
           properties:
             id:
               type: string

--- a/specification/schema/EnergyResourceGenerator/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceGenerator/v1.1/attributes.yaml
@@ -54,15 +54,11 @@ components:
           properties:
 
             nominalPower:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVPower"
               description: >
-                Nominal (nameplate) power output. Typical unit: KiloW.
-                CIM: GeneratingUnit.nominalP. Use when distinct from maxExport (peak).
-              properties:
-                value: { type: number, minimum: 0 }
-                unit:  { type: string }
+                Nominal (nameplate) power output. Use when distinct from
+                maxExport (peak).
+              x-standard: "CIM (IEC 61970 GeneratingUnit.nominalP)"
               x-jsonld:
                 "@id": erDeg:nominalPower
 
@@ -77,21 +73,14 @@ components:
                 "@id": erDeg:efficiency
 
             dcArrayCapacity:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVPower"
               description: >
                 DC-side nameplate capacity of a photovoltaic array at Standard
                 Test Conditions (industry term: "kWp"). For PV systems this is
                 typically larger than the AC-side maxExport because of inverter
                 clipping and DC-to-AC ratios. Relevant for SOLAR_PV resources.
-                Encoded as QuantitativeValue; the unit is the standard QUDT
-                power alias kW — the STC/peak semantic is documented here,
-                not encoded in the unit string.
-                Standards: IS 16221 (PV module qualification); IEC 61727
-                (PV grid interface).
-              properties:
-                value: { type: number, minimum: 0 }
-                unit:  { type: string }
+                The unit is the standard QUDT power alias kW — the STC/peak
+                semantic is documented here, not encoded in the unit string.
+              x-standard: "IS 16221 (PV module qualification); IEC 61727 (PV grid interface)"
               x-jsonld:
                 "@id": erDeg:dcArrayCapacity

--- a/specification/schema/EnergyResourceInverter/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceInverter/v1.1/attributes.yaml
@@ -53,46 +53,28 @@ components:
           properties:
 
             ratedApparentPower:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVApparentPower"
               description: >
-                Rated apparent power. Typical unit: KiloV-A.
-                SunSpec Model 702 maxVA. CIM: PowerElectronicsConnection.ratedS.
-                Replaces ratedApparentPowerKva from v1.0.
-              properties:
-                value: { type: number, minimum: 0 }
-                unit:  { type: string }
+                Rated apparent power. Replaces ratedApparentPowerKva from v1.0.
+              x-standard: "SunSpec DER Model 702 (maxVA); CIM (IEC 61970-302 PowerElectronicsConnection.ratedS)"
               x-jsonld:
                 "@id": erDeg:ratedApparentPower
 
             maxReactivePower:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVReactivePower"
               description: >
                 Maximum reactive power injection (leading / over-excited).
-                Typical unit: KiloV-A_Reactive.
-                SunSpec Model 702 maxVar. CIM: PowerElectronicsConnection.maxQ.
                 Replaces maxReactivePowerKvar from v1.0.
-              properties:
-                value: { type: number, minimum: 0 }
-                unit:  { type: string }
+              x-standard: "SunSpec DER Model 702 (maxVar); CIM (IEC 61970-302 PowerElectronicsConnection.maxQ)"
               x-jsonld:
                 "@id": erDeg:maxReactivePower
 
             minReactivePower:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVReactivePower"
               description: >
                 Maximum reactive power absorption (lagging / under-excited).
-                Typical unit: KiloV-A_Reactive. Value is typically negative.
-                SunSpec Model 702 maxVarNeg. CIM: PowerElectronicsConnection.minQ.
-                Replaces minReactivePowerKvar from v1.0.
-              properties:
-                value: { type: number }
-                unit:  { type: string }
+                Value is typically negative. Replaces minReactivePowerKvar from v1.0.
+              x-standard: "SunSpec DER Model 702 (maxVarNeg); CIM (IEC 61970-302 PowerElectronicsConnection.minQ)"
               x-jsonld:
                 "@id": erDeg:minReactivePower
 
@@ -100,9 +82,10 @@ components:
               type: string
               enum: [CategoryI, CategoryII, CategoryIII]
               description: >
-                IEEE 1547-2018 abnormal operating performance category.
-                CategoryI: basic. CategoryII: enhanced for distribution-connected DER.
+                Abnormal operating performance category. CategoryI: basic.
+                CategoryII: enhanced for distribution-connected DER.
                 CategoryIII: advanced for large/transmission-connected DER.
+              x-standard: "IEEE 1547-2018 (ride-through category)"
               x-jsonld:
                 "@id": erDeg:rideThroughCategory
 
@@ -113,29 +96,28 @@ components:
                 Inverter grid-interaction mode. GridFollowing: PLL-based sync.
                 GridForming: own V/f reference (microgrid islanding, black-start).
                 Standby: energised but not injecting.
-                CIM: PowerElectronicsConnection.inverterMode.
+              x-standard: "CIM (IEC 61970-302 PowerElectronicsConnection.inverterMode)"
               x-jsonld:
                 "@id": erDeg:operatingMode
 
             voltVarEnabled:
               type: boolean
-              description: >
-                Volt-VAr curve active. IEEE 2030.5 opModVoltVar / SunSpec Model 705.
+              description: Volt-VAr curve active.
+              x-standard: "IEEE 2030.5 (opModVoltVar); SunSpec DER Model 705"
               x-jsonld:
                 "@id": erDeg:voltVarEnabled
 
             freqDroopEnabled:
               type: boolean
-              description: >
-                Frequency-Watt droop active. SunSpec Model 711 / IEEE 1547-2018.
+              description: Frequency-Watt droop active.
+              x-standard: "IEEE 1547-2018; SunSpec DER Model 711"
               x-jsonld:
                 "@id": erDeg:freqDroopEnabled
 
             enterServiceRampTimeSec:
               type: number
               minimum: 0
-              description: >
-                Seconds to ramp from 0 to rated power after reconnection.
-                SunSpec Model 703 ESRmpTms.
+              description: Seconds to ramp from 0 to rated power after reconnection.
+              x-standard: "SunSpec DER Model 703 (ESRmpTms)"
               x-jsonld:
                 "@id": erDeg:enterServiceRampTimeSec

--- a/specification/schema/EnergyResourceLoad/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceLoad/v1.1/attributes.yaml
@@ -57,6 +57,7 @@ components:
             loadCategory:
               type: string
               enum: [Heating, Cooling, WaterHeating, Lighting, EV, Industrial, Other]
-              description: "Functional category of this load. CIM: ConformLoad classification."
+              description: Functional category of this load.
+              x-standard: "CIM (IEC 61970-301 ConformLoad classification)"
               x-jsonld:
                 "@id": erDeg:loadCategory

--- a/specification/schema/EnergyResourceMeter/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceMeter/v1.1/attributes.yaml
@@ -52,7 +52,8 @@ components:
               description: >
                 Communication/automation generation. Electromechanical: induction-disc.
                 CMRI: manual optical-port (India legacy). AMR: one-way automated read.
-                AMI: two-way smart meter. CIM: AmiBillingReadyKind (IEC 61968-9).
+                AMI: two-way smart meter.
+              x-standard: "CIM (IEC 61968-9 AmiBillingReadyKind)"
               x-jsonld:
                 "@id": erDeg:meterCapability
 
@@ -60,16 +61,16 @@ components:
               type: string
               enum: [Forward, Reverse, Bidirectional, Net]
               default: Forward
-              description: >
-                Energy flow direction metered at this point. CIM: FlowDirectionKind
-                (ESPI NAESB REQ.21).
+              description: Energy flow direction metered at this point.
+              x-standard: "CIM (FlowDirectionKind); ESPI NAESB REQ.21"
               x-jsonld:
                 "@id": erDeg:energyDirection
 
             functions:
               type: array
               uniqueItems: true
-              description: Active meter capabilities per IEC 61968-9 EndDeviceFunction[0..*].
+              description: Active meter capabilities.
+              x-standard: "CIM (IEC 61968-9 EndDeviceFunction)"
               items:
                 type: string
                 enum: [ToU, NetMetering, MaxDemand, LoadControl, TamperDetection, PowerQuality, EventLogging]

--- a/specification/schema/EnergyResourceNetwork/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceNetwork/v1.1/attributes.yaml
@@ -52,16 +52,10 @@ components:
           properties:
 
             nominalVoltage:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVVoltage"
               description: >
-                Nominal operating voltage. Typical unit: KiloV.
-                CIM: BaseVoltage.nominalVoltage.
-                Replaces nominalVoltageKv from v1.0.
-              properties:
-                value: { type: number, minimum: 0 }
-                unit:  { type: string }
+                Nominal operating voltage. Replaces nominalVoltageKv from v1.0.
+              x-standard: "CIM (IEC 61970-301 BaseVoltage.nominalVoltage)"
               x-jsonld:
                 "@id": erDeg:nominalVoltage
 

--- a/specification/schema/EnergyResourceStorage/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceStorage/v1.1/attributes.yaml
@@ -57,15 +57,10 @@ components:
           properties:
 
             storageCapacity:
-              type: object
-              required: [value, unit]
-              additionalProperties: false
+              $ref: "https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVEnergy"
               description: >
-                Rated stored-energy capacity. Typical unit: KiloW-HR.
-                CIM: BatteryUnit.ratedE. Replaces storageCapacityKwh from v1.0.
-              properties:
-                value: { type: number, minimum: 0 }
-                unit:  { type: string }
+                Rated stored-energy capacity. Replaces storageCapacityKwh from v1.0.
+              x-standard: "CIM (IEC 61970-302 BatteryUnit.ratedE)"
               x-jsonld:
                 "@id": erDeg:storageCapacity
 
@@ -91,8 +86,9 @@ components:
               description: >
                 AC-to-AC round-trip efficiency as a percentage (0–100): the
                 fraction of energy returned to the grid relative to energy
-                drawn during a full charge/discharge cycle. Measured per IEC
-                62933-2-1. Distinct from stateOfHealthPct (cumulative life
-                indicator) and from inverter conversion efficiency.
+                drawn during a full charge/discharge cycle. Distinct from
+                stateOfHealthPct (cumulative life indicator) and from inverter
+                conversion efficiency.
+              x-standard: "IEC 62933-2-1 (performance test method)"
               x-jsonld:
                 "@id": erDeg:roundTripEfficiencyPct

--- a/specification/schema/MeterServiceProfile/v1.1/attributes.yaml
+++ b/specification/schema/MeterServiceProfile/v1.1/attributes.yaml
@@ -29,26 +29,20 @@ paths: {}
 components:
   schemas:
 
-    QuantitativeValue:
-      $id: https://schema.beckn.io/MeterServiceProfile/v1.1#/components/schemas/QuantitativeValue
+    QVPower:
+      $id: https://schema.beckn.io/EnergyResourceCommon/v1.1#/components/schemas/QVPower
       type: object
       description: >
-        A dimensioned quantity. value is the numeric magnitude; unit is a QUDT
-        unit code (e.g. KiloW, KiloW-HR, KiloV-A, KiloV-A_Reactive, KiloV).
-        The JSON-LD context maps this to qudt:QuantitativeValue with
-        qudt:value and qudt:unit, expanding the unit string to a full QUDT
-        unit IRI (http://qudt.org/vocab/unit/<unit>).
+        Active-power quantity {value, unit}. unit is a QUDT power alias
+        (W, kW, MW) expanded to a QUDT IRI via the JSON-LD context.
       required: [value, unit]
       additionalProperties: false
       properties:
         value:
           type: number
-          description: Numeric magnitude.
         unit:
           type: string
-          description: >
-            QUDT unit code. Common values for this schema:
-            KiloW (kilowatt), KiloW-HR (kilowatt-hour).
+          enum: [W, kW, MW]
 
     MeterServiceProfile:
       $id: https://schema.beckn.io/MeterServiceProfile/v1.1#/components/schemas/MeterServiceProfile
@@ -76,13 +70,14 @@ components:
           x-jsonld:
             "@id": deg:meterId
         sanctionedLoad:
-          $ref: "#/components/schemas/QuantitativeValue"
-          description: "Sanctioned/approved import load. Typical unit: KiloW. CIM: UsagePoint.ratedCurrent × voltage."
+          $ref: "#/components/schemas/QVPower"
+          description: "Sanctioned/approved import load."
+          x-standard: "CIM (IEC 61968-9 UsagePoint)"
           x-jsonld:
             "@id": deg:sanctionedLoad
         sanctionedExportLoad:
-          $ref: "#/components/schemas/QuantitativeValue"
-          description: "Sanctioned/approved grid export limit. Typical unit: KiloW."
+          $ref: "#/components/schemas/QVPower"
+          description: "Sanctioned/approved grid export limit."
           x-jsonld:
             "@id": deg:sanctionedExportLoad
         billingCycleDay:
@@ -93,14 +88,15 @@ components:
           x-jsonld:
             "@id": deg:billingCycleDay
         contractMaxDemand:
-          $ref: "#/components/schemas/QuantitativeValue"
-          description: "Maximum demand contracted with the utility for this connection. Typical unit: KiloW."
+          $ref: "#/components/schemas/QVPower"
+          description: "Maximum demand contracted with the utility for this connection."
           x-jsonld:
             "@id": deg:contractMaxDemand
         tariffCategoryCode:
           type: string
           minLength: 1
-          description: "Billing/tariff category code assigned by the utility. CIM: UsagePoint.serviceCategory."
+          description: "Billing/tariff category code assigned by the utility."
+          x-standard: "CIM (IEC 61968-9 UsagePoint.serviceCategory)"
           x-jsonld:
             "@id": deg:tariffCategoryCode
         premisesType:
@@ -118,7 +114,8 @@ components:
           enum:
             - Single-phase
             - Three-phase
-          description: "Electrical connection type. CIM: UsagePoint.phaseCode."
+          description: "Electrical connection type."
+          x-standard: "CIM (IEC 61968-9 UsagePoint.phaseCode)"
           x-jsonld:
             "@id": deg:connectionType
         paymentMode:
@@ -128,7 +125,8 @@ components:
             - PREPAID
           description: >
             Billing/payment modality. POSTPAID: consume now, pay later.
-            PREPAID: pay-before-use. CIM: ESPI AmiBillingReadyKind (IEC 61968-9).
+            PREPAID: pay-before-use.
+          x-standard: "CIM (IEC 61968-9 AmiBillingReadyKind, ESPI)"
           x-jsonld:
             "@id": deg:paymentMode
 
@@ -144,6 +142,7 @@ components:
             billable; 'suspended' = temporarily disconnected (non-payment,
             inspection, fault) with the contract still on record; 'closed' =
             permanently terminated. Distinct from the meter device's
-            operational state. CIM: cim:UsagePoint.status (IEC 61968-9).
+            operational state.
+          x-standard: "CIM (IEC 61968-9 UsagePoint.status)"
           x-jsonld:
             "@id": deg:serviceStatus

--- a/specification/scripts/bundle_schema.py
+++ b/specification/scripts/bundle_schema.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Bundle a credential's attributes.yaml into a self-contained schema.json.
+
+The canonical source of truth is the per-schema ``attributes.yaml`` files (this
+repo) plus the reserved Beckn core schemas published at schema.beckn.io
+(Location, GeoJSONGeometry, Address, …). Those leaf schemas reference each other
+by ``https://schema.beckn.io/<Schema>/<ver>#/components/schemas/<Name>`` URLs.
+
+This tool resolves that whole reference graph into one flat ``$defs`` map and
+rewrites every ``$ref`` to ``#/$defs/<Name>`` so the result validates with no
+network access. Resolution is **local-first**: a ref is read from
+``specification/schema/<Schema>/<ver>/attributes.yaml`` when that file exists
+(so unpublished local edits win), otherwise it is fetched live from
+schema.beckn.io and cached for the run.
+
+The curated W3C-VC **root envelope** (``@context``, ``id`` pattern, ``issuer``,
+``validFrom``/``validUntil``, ``proof`` …) is NOT mechanically derivable from the
+OpenAPI sources — it encodes VC Data Model 2.0 authoring choices. So the root
+(everything except ``$defs``) is preserved from the existing schema.json; only
+the ``$defs`` graph is regenerated. Run with --check to fail on drift (CI).
+
+Each bundled component keeps ``description``, ``x-standard`` and all validation
+keywords; authoring/JSON-LD cruft (``x-jsonld``, ``x-tags``, ``$id``, ``x-iri``,
+``example``, ``servers``) is stripped.
+
+Usage:
+  python3 specification/scripts/bundle_schema.py specification/schema/ElectricityCredential/v1.2
+  python3 specification/scripts/bundle_schema.py --all
+  python3 specification/scripts/bundle_schema.py specification/schema/ElectricityCredential/v1.2 --check
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import glob
+import json
+import os
+import sys
+import urllib.request
+
+import yaml
+
+BECKN = "https://schema.beckn.io/"
+STRIP_KEYS = {"x-jsonld", "x-tags", "$id", "x-iri", "x-id", "example", "servers", "$schema"}
+SCHEMA_ROOT = os.path.dirname(os.path.abspath(__file__)).replace(
+    os.path.join("specification", "scripts"), os.path.join("specification", "schema")
+)
+
+_file_cache: dict[str, dict] = {}
+
+
+def load_yaml_file(path: str) -> dict:
+    if path not in _file_cache:
+        with open(path, encoding="utf-8") as f:
+            _file_cache[path] = yaml.safe_load(f)
+    return _file_cache[path]
+
+
+def fetch_remote(url: str) -> dict:
+    if url not in _file_cache:
+        with urllib.request.urlopen(url, timeout=20) as r:  # noqa: S310 (trusted registry)
+            _file_cache[url] = yaml.safe_load(r.read().decode("utf-8"))
+    return _file_cache[url]
+
+
+def schema_doc_for(schema: str, ver: str) -> dict:
+    """Return the OpenAPI doc for <schema>/<ver>, local file first, else fetched."""
+    local = os.path.join(SCHEMA_ROOT, schema, ver, "attributes.yaml")
+    if os.path.exists(local):
+        return load_yaml_file(local)
+    return fetch_remote(f"{BECKN}{schema}/{ver}/attributes.yaml")
+
+
+def parse_ref(ref: str, ctx: tuple[str, str] | None):
+    """Resolve a $ref to (component_name, (schema, ver)).
+
+    ctx is the (schema, ver) the ref appears in, used for internal/anchor refs.
+    Handles:
+      #/components/schemas/X, #X (anchor)                 -> internal to ctx
+      https://schema.beckn.io/<S>/<v>[/attributes.yaml]#/components/schemas/X
+      https://schema.beckn.io/<S>/<v>#X                   -> anchor in <S>/<v>
+      https://schema.beckn.io/<S>/<v>                     -> whole-schema (name = S)
+    """
+    if ref.startswith("#"):
+        frag = ref[1:]
+        name = frag.split("/")[-1]
+        return name, ctx
+    assert ref.startswith(BECKN), f"unexpected ref: {ref}"
+    path, _, frag = ref[len(BECKN):].partition("#")
+    parts = [p for p in path.split("/") if p and p != "attributes.yaml"]
+    schema, ver = parts[0], parts[1]
+    if frag:
+        name = frag.lstrip("/").split("/")[-1]
+    else:
+        name = schema  # whole-schema ref -> the same-named component
+    return name, (schema, ver)
+
+
+def get_component(name: str, ctx: tuple[str, str]) -> tuple[dict, tuple[str, str]]:
+    """Fetch components.schemas[name] from ctx's doc. If it is a thin alias
+    ({$ref, description} with no validation), follow the alias, carrying the
+    local description down. Returns (node, ctx_of_returned_node)."""
+    doc = schema_doc_for(*ctx)
+    node = doc["components"]["schemas"][name]
+    extra = {k: v for k, v in node.items() if k not in ("$ref", "description")}
+    if "$ref" in node and not extra:
+        tname, tctx = parse_ref(node["$ref"], ctx)
+        target, tctx = get_component(tname, tctx)
+        target = copy.deepcopy(target)
+        if node.get("description"):
+            target["description"] = node["description"]  # local alias desc wins
+        return target, tctx
+    return node, ctx
+
+
+class Bundler:
+    def __init__(self):
+        self.defs: dict[str, dict] = {}
+        self.ctx_of: dict[str, tuple[str, str]] = {}
+
+    def rewrite(self, node, ctx):
+        """Deep-clean a node: strip cruft, rewrite $refs to #/$defs/, enqueue targets."""
+        if isinstance(node, dict):
+            if "$ref" in node:
+                name, tctx = parse_ref(node["$ref"], ctx)
+                self.want(name, tctx)
+                out = {"$ref": f"#/$defs/{name}"}
+                for k, v in node.items():
+                    if k != "$ref" and k not in STRIP_KEYS:
+                        out[k] = self.rewrite(v, ctx)
+                return out
+            return {k: self.rewrite(v, ctx) for k, v in node.items() if k not in STRIP_KEYS}
+        if isinstance(node, list):
+            return [self.rewrite(v, ctx) for v in node]
+        return node
+
+    def want(self, name: str, ctx: tuple[str, str]):
+        if name in self.defs:
+            return
+        self.defs[name] = {}  # reserve (breaks ref cycles)
+        node, real_ctx = get_component(name, ctx)
+        self.defs[name] = self.rewrite(node, real_ctx)
+
+    def build(self, root_doc_refs, ctx):
+        for name in root_doc_refs:
+            self.want(name, ctx)
+
+
+def defs_referenced_in(obj, acc):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == "$ref" and isinstance(v, str) and v.startswith("#/$defs/"):
+                acc.add(v.split("/")[-1])
+            else:
+                defs_referenced_in(v, acc)
+    elif isinstance(obj, list):
+        for v in obj:
+            defs_referenced_in(v, acc)
+
+
+def bundle(version_dir: str) -> dict:
+    norm = os.path.normpath(version_dir)
+    ver = os.path.basename(norm)
+    schema = os.path.basename(os.path.dirname(norm))
+    existing_path = os.path.join(version_dir, "schema.json")
+    with open(existing_path, encoding="utf-8") as f:
+        existing = json.load(f)
+
+    # Preserve the curated root; regenerate $defs from the leaf graph.
+    root = {k: v for k, v in existing.items() if k != "$defs"}
+    seeds: set[str] = set()
+    defs_referenced_in(root, seeds)
+
+    b = Bundler()
+    b.build(sorted(seeds), (schema, ver))
+
+    out = dict(root)
+    out["$defs"] = {k: b.defs[k] for k in b.defs}
+    return out
+
+
+def process(version_dir: str, check: bool) -> bool:
+    out = bundle(version_dir)
+    path = os.path.join(version_dir, "schema.json")
+    new = json.dumps(out, indent=4, ensure_ascii=False) + "\n"
+    with open(path, encoding="utf-8") as f:
+        cur = f.read()
+    if new == cur:
+        print(f"unchanged: {path}")
+        return True
+    if check:
+        print(f"STALE: {path} (run without --check to regenerate)")
+        return False
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new)
+    print(f"bundled:   {path}  ({len(out['$defs'])} \\$defs)")
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("dirs", nargs="*", help="schema version dir(s)")
+    ap.add_argument("--all", action="store_true", help="every schema version dir with a schema.json")
+    ap.add_argument("--check", action="store_true", help="fail if any bundle is stale (no writes)")
+    args = ap.parse_args()
+    if args.all:
+        args.dirs = sorted(os.path.dirname(p) for p in glob.glob(os.path.join(SCHEMA_ROOT, "*", "*", "schema.json")))
+    if not args.dirs:
+        ap.error("pass one or more version dirs, or --all")
+    ok = all(process(d, args.check) for d in args.dirs)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Makes the canonical **leaf schemas the single source of truth** for ElectricityCredential v1.2 and adds a bundler so `schema.json` regenerates from them — fixing a hand-maintained bundle that had drifted from the leaves in both directions.

### What changed
- **Typed QuantitativeValue models** (`QVPower`, `QVEnergy`, `QVApparentPower`, `QVReactivePower`, `QVVoltage`) defined in `EnergyResourceCommon/v1.1`; power/energy/voltage fields across the common base, the 7 kinds, and `MeterServiceProfile/v1.1` now reference them. **Unit enums are unchanged** from the published bundle.
- **`x-standard` annotations** (31 fields) carrying CIM / IEEE / IEC / SunSpec references, moved out of prose descriptions into a dedicated field.
- **`specification/scripts/bundle_schema.py`** — regenerates a credential's self-contained `$defs` from the leaf sources (local-first; fetches reserved Beckn schemas — Location/GeoJSONGeometry/Address — from schema.beckn.io) and preserves the curated VC root envelope.
- **Regenerated `ElectricityCredential/v1.2/schema.json`** — now self-contained; restores `serialNumber`, `inspection`, `aggregator`, `dcArrayCapacity`, `roundTripEfficiencyPct`, `serviceStatus` (dropped by the old bundle) and inlines `ConsumptionProfile`/`CustomerDetails` (previously unresolved external `$ref`s).

### Conformance
Metadata + additive-optional fields only. All three v1.2 examples remain **100% compliant**; typed-QV unit enums are byte-identical to the prior bundle. The only newly-enforced validation is the canonical leaf schemas' own constraints that the broken bundle had been silently skipping.

### Publishing
The updated leaf schemas need publishing to schema.beckn.io for downstream consumers to resolve the new typed-QV refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)