### PR TITLE
refactor(schema): make careOf a single {name, relationship} object

### DIFF
--- a/specification/schema/CustomerDetails/README.md
+++ b/specification/schema/CustomerDetails/README.md
@@ -21,7 +21,7 @@ PII identity and address details for a utility service customer.
 
 Three concerns:
 
-- **Identity** — `fullName` (as per ID proof), optional `careOf` (reference person(s) with optional gender-neutral relationship, used to uniquely identify / disambiguate the customer)
+- **Identity** — `fullName` (as per ID proof), optional `careOf` (a reference person with optional gender-neutral relationship, used to uniquely identify / disambiguate the customer)
 - **Location** — `installationAddress` (GeoJSON + PostalAddress via beckn Location/2.0)
 - **Tenure** — `serviceConnectionDate` (when the connection was activated)
 

--- a/specification/schema/CustomerDetails/v1.0/README.md
+++ b/specification/schema/CustomerDetails/v1.0/README.md
@@ -30,7 +30,7 @@ Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a
 | Field | Required | Type | CIM | Description |
 |-------|----------|------|-----|-------------|
 | `fullName` | ✅ | string | `Customer.name` | Full name as per ID proof |
-| `careOf` | ➖ | array of `{ name, relationship? }` | — | Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same `fullName` with others in a locality. `relationship` is optional, gender-neutral: `parent` \| `spouse` \| `guardian` \| `sibling` \| `child` \| `other` |
+| `careOf` | ➖ | `{ name, relationship? }` | — | Care-of (c/o) reference person used to uniquely identify / disambiguate a customer who may share the same `fullName` with others in a locality. `relationship` is optional, gender-neutral: `parent` \| `spouse` \| `guardian` \| `sibling` \| `child` \| `other` |
 | `installationAddress` | ✅ | Location/2.0 | `ServiceLocation` | GeoJSON Point + PostalAddress |
 | `serviceConnectionDate` | ✅ | date-time | activation date | ISO 8601 with timezone offset |
 
@@ -51,9 +51,7 @@ Extracted from `ElectricityCredential/v1.2` `customerDetails` and published as a
 ```json
 {
   "fullName": "Ravi Kumar",
-  "careOf": [
-    { "name": "Suresh Kumar", "relationship": "parent" }
-  ],
+  "careOf": { "name": "Suresh Kumar", "relationship": "parent" },
   "installationAddress": {
     "geo": {
       "type": "Point",

--- a/specification/schema/CustomerDetails/v1.0/attributes.yaml
+++ b/specification/schema/CustomerDetails/v1.0/attributes.yaml
@@ -59,38 +59,35 @@ components:
             "@id": schema:name
 
         careOf:
-          type: array
-          minItems: 1
+          type: object
           description: >
-            Care-of (c/o) reference person(s) used to uniquely identify /
+            Optional care-of (c/o) reference person used to uniquely identify /
             disambiguate a customer who may share the same fullName with others
-            in a locality (e.g. a village). Each entry pairs a name with an
-            optional, gender-neutral relationship.
+            in a locality (e.g. a village). Pairs a name with an optional,
+            gender-neutral relationship.
+          required:
+            - name
+          additionalProperties: false
           x-jsonld:
             "@id": deg:careOf
-          items:
-            type: object
-            required:
-              - name
-            additionalProperties: false
-            properties:
-              name:
-                type: string
-                minLength: 1
-                maxLength: 200
-                description: >
-                  Name of the care-of / reference person used to disambiguate
-                  the customer.
-                x-jsonld:
-                  "@id": schema:name
-              relationship:
-                type: string
-                enum: [parent, spouse, guardian, sibling, child, other]
-                description: >
-                  Gender-neutral relationship of the reference person to the
-                  customer.
-                x-jsonld:
-                  "@id": deg:relationship
+          properties:
+            name:
+              type: string
+              minLength: 1
+              maxLength: 200
+              description: >
+                Name of the care-of / reference person used to disambiguate
+                the customer.
+              x-jsonld:
+                "@id": schema:name
+            relationship:
+              type: string
+              enum: [parent, spouse, guardian, sibling, child, other]
+              description: >
+                Gender-neutral relationship of the reference person to the
+                customer.
+              x-jsonld:
+                "@id": deg:relationship
 
         installationAddress:
           $ref: "https://schema.beckn.io/Location/2.0/attributes.yaml#/components/schemas/Location"

--- a/specification/schema/CustomerDetails/v1.0/context.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/context.jsonld
@@ -13,7 +13,6 @@
 
     "careOf": {
       "@id": "deg:careOf",
-      "@container": "@set",
       "@context": {
         "name":         { "@id": "schema:name",      "@type": "xsd:string" },
         "relationship": { "@id": "deg:relationship", "@type": "xsd:string" }

--- a/specification/schema/CustomerDetails/v1.0/schema.json
+++ b/specification/schema/CustomerDetails/v1.0/schema.json
@@ -16,25 +16,21 @@
           "description": "Full name of the customer as per ID proof."
         },
         "careOf": {
-          "type": "array",
-          "description": "Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality. Each entry pairs a name with an optional, gender-neutral relationship.",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "required": ["name"],
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 200,
-                "description": "Name of the care-of / reference person used to disambiguate the customer."
-              },
-              "relationship": {
-                "type": "string",
-                "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"],
-                "description": "Gender-neutral relationship of the reference person to the customer."
-              }
+          "type": "object",
+          "description": "Optional care-of (c/o) reference person used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality. Pairs a name with an optional, gender-neutral relationship.",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "description": "Name of the care-of / reference person used to disambiguate the customer."
+            },
+            "relationship": {
+              "type": "string",
+              "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"],
+              "description": "Gender-neutral relationship of the reference person to the customer."
             }
           }
         },

--- a/specification/schema/CustomerDetails/v1.0/vocab.jsonld
+++ b/specification/schema/CustomerDetails/v1.0/vocab.jsonld
@@ -19,7 +19,7 @@
       "@id": "deg:careOf",
       "@type": "rdf:Property",
       "rdfs:label": "Care of",
-      "rdfs:comment": "Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same full name with others in a locality. Each entry pairs a name with an optional gender-neutral relationship.",
+      "rdfs:comment": "Care-of (c/o) reference person used to uniquely identify / disambiguate a customer who may share the same full name with others in a locality. Pairs a name with an optional gender-neutral relationship.",
       "rdfs:domain": { "@id": "deg:CustomerDetails" }
     },
     {

--- a/specification/schema/ElectricityCredential/v1.0/schema.json
+++ b/specification/schema/ElectricityCredential/v1.0/schema.json
@@ -275,25 +275,21 @@
                     "description": "Full name of the customer as per ID proof"
                 },
                 "careOf": {
-                    "type": "array",
-                    "description": "Optional care-of (c/o) reference person(s), used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality. Each entry pairs a name with an optional, gender-neutral relationship.",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "required": ["name"],
-                        "additionalProperties": false,
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 200,
-                                "description": "Name of the care-of / reference person used to disambiguate the customer."
-                            },
-                            "relationship": {
-                                "type": "string",
-                                "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"],
-                                "description": "Gender-neutral relationship of the reference person to the customer."
-                            }
+                    "type": "object",
+                    "description": "Optional care-of (c/o) reference person, used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality. Pairs a name with an optional, gender-neutral relationship.",
+                    "required": ["name"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Name of the care-of / reference person used to disambiguate the customer."
+                        },
+                        "relationship": {
+                            "type": "string",
+                            "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"],
+                            "description": "Gender-neutral relationship of the reference person to the customer."
                         }
                     }
                 },

--- a/specification/schema/ElectricityCredential/v1.1/schema.json
+++ b/specification/schema/ElectricityCredential/v1.1/schema.json
@@ -115,7 +115,7 @@
             "required": ["fullName", "installationAddress", "serviceConnectionDate"],
             "properties": {
                 "fullName": { "type": "string", "minLength": 1, "maxLength": 200 },
-                "careOf": { "type": "array", "minItems": 1, "description": "Optional care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer sharing the same fullName within a locality.", "items": { "type": "object", "required": ["name"], "additionalProperties": false, "properties": { "name": { "type": "string", "minLength": 1, "maxLength": 200 }, "relationship": { "type": "string", "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"] } } } },
+                "careOf": { "type": "object", "description": "Optional care-of (c/o) reference person used to uniquely identify / disambiguate a customer sharing the same fullName within a locality.", "required": ["name"], "additionalProperties": false, "properties": { "name": { "type": "string", "minLength": 1, "maxLength": 200 }, "relationship": { "type": "string", "enum": ["parent", "spouse", "guardian", "sibling", "child", "other"] } } },
                 "installationAddress": { "$ref": "#/$defs/Location" },
                 "serviceConnectionDate": { "type": "string", "format": "date-time" }
             }

--- a/specification/schema/ElectricityCredential/v1.2/examples/example-parallel-metering.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example-parallel-metering.json
@@ -54,7 +54,7 @@
     },
     "customerDetails": {
       "fullName": "Arjun Mehra",
-      "careOf": [{ "name": "Lakshmi Mehra", "relationship": "parent" }],
+      "careOf": { "name": "Lakshmi Mehra", "relationship": "parent" },
       "installationAddress": {
         "geo": {"type": "Point", "coordinates": [77.2090, 28.6139]},
         "address": {"streetAddress": "45 Rohini Sector 9", "addressLocality": "Delhi", "addressRegion": "Delhi", "postalCode": "110085", "addressCountry": "IN"}

--- a/specification/schema/ElectricityCredential/v1.2/examples/example-submetering.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example-submetering.json
@@ -64,7 +64,7 @@
     },
     "customerDetails": {
       "fullName": "Sunita Rao",
-      "careOf": [{ "name": "Prakash Rao", "relationship": "spouse" }],
+      "careOf": { "name": "Prakash Rao", "relationship": "spouse" },
       "installationAddress": {
         "geo": {"type": "Point", "coordinates": [77.5946, 12.9716]},
         "address": {"streetAddress": "12 Residency Road, Flat 101", "addressLocality": "Bengaluru", "addressRegion": "Karnataka", "postalCode": "560025", "addressCountry": "IN"}

--- a/specification/schema/ElectricityCredential/v1.2/examples/example.json
+++ b/specification/schema/ElectricityCredential/v1.2/examples/example.json
@@ -68,7 +68,7 @@
     },
     "customerDetails": {
       "fullName": "Jane Doe",
-      "careOf": [{ "name": "John Doe", "relationship": "parent" }],
+      "careOf": { "name": "John Doe", "relationship": "parent" },
       "installationAddress": {
         "geo": {"type": "Point", "coordinates": [-122.4194, 37.7749]},
         "address": {"streetAddress": "123 Energy Street, Unit 4", "addressLocality": "Metro City", "addressRegion": "Example State", "postalCode": "12345", "addressCountry": "US"}

--- a/specification/schema/ElectricityCredential/v1.2/schema.json
+++ b/specification/schema/ElectricityCredential/v1.2/schema.json
@@ -167,34 +167,30 @@
                     "x-standard": "CIM (IEC 61968-1 Customer.name)"
                 },
                 "careOf": {
-                    "type": "array",
-                    "minItems": 1,
-                    "description": "Care-of (c/o) reference person(s) used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality (e.g. a village). Each entry pairs a name with an optional, gender-neutral relationship.\n",
-                    "items": {
-                        "type": "object",
-                        "required": [
-                            "name"
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 200,
-                                "description": "Name of the care-of / reference person used to disambiguate the customer.\n"
-                            },
-                            "relationship": {
-                                "type": "string",
-                                "enum": [
-                                    "parent",
-                                    "spouse",
-                                    "guardian",
-                                    "sibling",
-                                    "child",
-                                    "other"
-                                ],
-                                "description": "Gender-neutral relationship of the reference person to the customer.\n"
-                            }
+                    "type": "object",
+                    "description": "Care-of (c/o) reference person used to uniquely identify / disambiguate a customer who may share the same fullName with others in a locality (e.g. a village). Pairs a name with an optional, gender-neutral relationship.\n",
+                    "required": [
+                        "name"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Name of the care-of / reference person used to disambiguate the customer.\n"
+                        },
+                        "relationship": {
+                            "type": "string",
+                            "enum": [
+                                "parent",
+                                "spouse",
+                                "guardian",
+                                "sibling",
+                                "child",
+                                "other"
+                            ],
+                            "description": "Gender-neutral relationship of the reference person to the customer.\n"
                         }
                     }
                 },


### PR DESCRIPTION
## Summary

Per chief-architect guidance to keep it simple, `careOf` is changed from an **array** of reference persons to a **single object** `{ name, relationship? }`.

```jsonc
"careOf": { "name": "John Doe", "relationship": "parent" }
```

- `name` — required.
- `relationship` — optional, gender-neutral enum (`parent | spouse | guardian | sibling | child | other`).
- Still optional on `CustomerDetails` (not in `required`).

## Changes

**CustomerDetails/v1.0 leaf (source of truth):** `schema.json`, `attributes.yaml`, `context.jsonld` (dropped the `@set` container), `vocab.jsonld`, `README.md` + parent `README.md`.

**ElectricityCredential inline copies + examples:** `v1.0/schema.json`, `v1.1/schema.json`, `v1.2/schema.json`, and the three `v1.2/examples/*.json`.

## Verification

- All JSON/YAML parse; no `array`-shaped `careOf` remains.
- The three v1.2 examples validate against `ElectricityCredential/v1.2/schema.json` with the new object shape.

> Note: edits were applied by hand rather than via `bundle_schema.py` — the bundler currently wipes the `CustomerDetails` leaf's `$defs` (its root has no `#/$defs` seeds) and errors on the ElectricityCredential graph (`KeyError: ConsumptionProfile`). Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)