### PR TITLE
feat(schema): annotate trading & demand-flex fields with x-standard

### DIFF
--- a/specification/schema/DEGContract/v2.0/attributes.yaml
+++ b/specification/schema/DEGContract/v2.0/attributes.yaml
@@ -89,5 +89,6 @@ components:
                 type: string
                 minLength: 3
                 maxLength: 3
+                x-standard: "ISO 4217"
               description:
                 type: string

--- a/specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml
@@ -144,6 +144,7 @@ components:
                   description: Total meter count in the cohort.
                 sha256OfSortedIds:
                   type: string
+                  x-standard: "SHA-256 (FIPS 180-4)"
                   pattern: "^sha256:[0-9a-f]{64}$"
                   description: >
                     `sha256:<64-hex>` of the cohort's meter IDs after

--- a/specification/schema/DemandFlexNeed/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexNeed/v2.0/attributes.yaml
@@ -45,12 +45,14 @@ components:
             startDate:
               type: string
               format: date-time
+              x-standard: "ISO 8601 (UTC, RFC 3339 profile)"
               pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$'
               description: Event start time in UTC.
               example: "2026-04-01T14:00:00Z"
             endDate:
               type: string
               format: date-time
+              x-standard: "ISO 8601 (UTC, RFC 3339 profile)"
               pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$'
               description: Event end time in UTC.
               example: "2026-04-01T16:00:00Z"
@@ -76,6 +78,7 @@ components:
 
         location:
           description: Geographic area where flex is needed (GeoJSON).
+          x-standard: "GeoJSON (RFC 7946)"
           x-jsonld:
             "@id": location
           type: object

--- a/specification/schema/RevenueFlow/v2.0/attributes.yaml
+++ b/specification/schema/RevenueFlow/v2.0/attributes.yaml
@@ -50,6 +50,7 @@ components:
                 type: string
                 minLength: 3
                 maxLength: 3
+                x-standard: "ISO 4217"
                 description: ISO-4217 currency code.
                 example: "INR"
               description:


### PR DESCRIPTION
## What

Adds `x-standard` annotations to fields in the P2P-trading (wave2) and demand-flex attribute schemas that derive from a recognised standard:

| Schema | Field | Standard |
|--------|-------|----------|
| `DemandFlexNeed` | `eventWindow.startDate`, `eventWindow.endDate` | ISO 8601 (UTC, RFC 3339 profile) |
| `DemandFlexNeed` | `location` | GeoJSON (RFC 7946) |
| `DemandFlexBuyOffer` | `…participatingMetersDigest.sha256OfSortedIds` | SHA-256 (FIPS 180-4) |
| `RevenueFlow` | `revenueFlows[].currency` | ISO 4217 |
| `DEGContract` | `revenueFlows[].currency` | ISO 4217 |

## Why

`x-standard` lets downstream field-reference documentation (e.g. the IES Accelerator book) state the standard a field is based on. It's the same annotation already used across the IES schemas.

## Safety

- Metadata-only: `x-standard` is an OpenAPI/JSON-Schema extension key — validation behaviour and already-issued payloads are unchanged.
- The bundler preserves `x-standard` (not in `STRIP_KEYS`), so it flows into compiled `schema.json` on next bundle. No `schema.json` currently embeds these schemas, so this PR introduces no bundle staleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)