### PR TITLE
feat(schema): annotate BecknTimeSeries with x-standard (OpenADR 3.1.0)

### DIFF
--- a/specification/schema/BecknTimeSeries/v1.0/attributes.yaml
+++ b/specification/schema/BecknTimeSeries/v1.0/attributes.yaml
@@ -25,6 +25,7 @@ components:
         `payloadType` follows OpenADR's open-string convention — consumer
         profiles (e.g. `DemandFlexPerformance`) MAY restrict it to a
         domain-specific set and add cross-field membership checks.
+      x-standard: "OpenADR 3.1.0"
       x-tags:
         - time-series
         - openadr


### PR DESCRIPTION
## What

Adds a component-level `x-standard: "OpenADR 3.1.0"` to `BecknTimeSeries/v1.0`.

## Why

`BecknTimeSeries` is an OpenADR 3.1.0-aligned envelope — it `$ref`-reuses OpenADR's `interval`, `intervalPeriod`, `valuesMap`, `eventPayloadDescriptor`/`reportPayloadDescriptor` and `point`. The annotation lets field-reference documentation (the IES Accelerator book) state the standard the schema is based on, consistent with the other `x-standard` annotations.

## Safety

- Metadata-only: `x-standard` is an extension key — validation behaviour and already-issued payloads are unchanged.
- The bundler preserves `x-standard`; no `schema.json` currently embeds `BecknTimeSeries`, so no bundle staleness is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)