### PR TITLE
fix(data-exchange): adopt validateVC step id and onix-adapter-deg:v2 image

### DIFF
--- a/build/Dockerfile.onix-adapter-deg
+++ b/build/Dockerfile.onix-adapter-deg
@@ -48,7 +48,8 @@ RUN go build -buildmode=plugin -o /workspace/beckn-onix/plugins/degledgerrecorde
 # Build DEG settlement flows plugin
 RUN go build -buildmode=plugin -o /workspace/beckn-onix/plugins/settlementflows.so ./settlementflows/cmd/plugin.go
 
-# vcvalidator is upstreamed into beckn-onix (built above by install/build-plugins.sh).
+# vcvalidator is upstreamed into beckn-onix (built above by install/build-plugins.sh
+# as validateVC.so — the step id is validateVC).
 
 # Create minimal runtime image
 # Using debian-slim (glibc) for Go plugin (.so) compatibility with the bookworm builder.

--- a/devkits/data-exchange/config/local-simple-bpp.yaml
+++ b/devkits/data-exchange/config/local-simple-bpp.yaml
@@ -75,7 +75,7 @@ modules:
           # credential rejection is deterministic regardless of the request
           # signature (the vc-validation workflow posts unsigned negative
           # cases directly to this receiver).
-          - id: vcvalidator
+          - id: validateVC
             config:
               enabled: "true"
               actions: "confirm"
@@ -85,9 +85,16 @@ modules:
               requireProof: "true"
               failOpen: "false"
               httpTimeout: "10"
+              maxCredentials: "10"
+              # SSRF guard: did:web/revocation fetches to private, loopback or
+              # link-local addresses are blocked. The devkit VC is did:key with
+              # no credentialStatus, so verification is fully offline; flip to
+              # "true" only if you point credentials at issuers/registries on
+              # the local docker network.
+              allowPrivateNetworks: "false"
               debugLogging: "true"
       steps:
-        - vcvalidator
+        - validateVC
         - validateSign
         - addRoute
         - validateSchema

--- a/devkits/data-exchange/install/docker-compose.yml
+++ b/devkits/data-exchange/install/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       retries: 5
 
   onix-bap:
-    image: ${ONIX_ADAPTER_IMAGE:-fidedocker/onix-adapter-deg:w-deg-plugins-v1}
+    image: ${ONIX_ADAPTER_IMAGE:-fidedocker/onix-adapter-deg:v2}
     container_name: onix-bap
     ports:
       - "8081:8081"
@@ -94,7 +94,7 @@ services:
       retries: 5
 
   onix-bpp:
-    image: ${ONIX_ADAPTER_IMAGE:-fidedocker/onix-adapter-deg:w-deg-plugins-v1}
+    image: ${ONIX_ADAPTER_IMAGE:-fidedocker/onix-adapter-deg:v2}
     container_name: onix-bpp
     ports:
       - "8082:8082"

--- a/devkits/data-exchange/uc1-meter-data/workflows/run-vc-validation.sh
+++ b/devkits/data-exchange/uc1-meter-data/workflows/run-vc-validation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Runner for vc-validation.arazzo.yaml.
 #
-# Exercises the beckn-onix `vcvalidator` step plugin end-to-end against the
+# Exercises the beckn-onix `validateVC` step plugin end-to-end against the
 # running data-exchange devkit (docker compose up -d in install/). The shared
 # run-arazzo.sh treats every NACK as a failure — the opposite of what the
 # negative cases assert here — so this dedicated runner drives the cases with
@@ -12,7 +12,7 @@
 # CREDENTIAL_EXPIRED, …) appears inside error.message.
 #
 #   Positive case  → BAP caller (signs) → BPP receiver → ACK (HTTP 200)
-#   Negative cases → BPP receiver directly. vcvalidator is the first pipeline
+#   Negative cases → BPP receiver directly. validateVC is the first pipeline
 #                    step, so it NACKs before signature/schema validation and
 #                    rejection is deterministic and offline.
 #
@@ -78,7 +78,7 @@ if [ "$HTTP" = "200" ] && [ "$status" = "ACK" ]; then
 elif [[ "$errmsg" == *INVALID_PROOF* || "$errmsg" == *ISSUER_MISMATCH* \
   || "$errmsg" == *CREDENTIAL_EXPIRED* || "$errmsg" == *CREDENTIAL_REVOKED* \
   || "$errmsg" == *DID_RESOLUTION_FAILED* || "$errmsg" == *INVALID_CREDENTIAL* ]]; then
-  echo "  ✗ valid VC was rejected by vcvalidator — HTTP $HTTP, message=$errmsg"
+  echo "  ✗ valid VC was rejected by validateVC — HTTP $HTTP, message=$errmsg"
   echo "      body: $(echo "$BODY" | jq -c . 2>/dev/null || echo "$BODY")"
   fail=$((fail + 1))
 else

--- a/devkits/data-exchange/uc1-meter-data/workflows/vc-validation.arazzo.yaml
+++ b/devkits/data-exchange/uc1-meter-data/workflows/vc-validation.arazzo.yaml
@@ -1,9 +1,9 @@
 arazzo: 1.0.1
 info:
-  title: Energy Data Exchange — UC1 VC Validation (DEG vcvalidator plugin)
+  title: Energy Data Exchange — UC1 VC Validation (beckn-onix validateVC step)
   version: 2.0.0
   description: >
-    Asserts the beckn-onix `vcvalidator` step plugin. The plugin is wired as
+    Asserts the beckn-onix `validateVC` step plugin. The plugin is wired as
     the first pipeline step on the BPP receiver (see
     config/local-simple-bpp.yaml) and gates the `confirm` action: it verifies
     the Verifiable Credential carried in the confirm receiver participant (a
@@ -15,7 +15,7 @@ info:
 
     Positive case flows through the BAP caller (which signs the request) so the
     full pipeline returns an ACK. Negative cases POST directly to the BPP
-    receiver — vcvalidator runs before signature/schema validation, so the
+    receiver — validateVC runs before signature/schema validation, so the
     rejection is deterministic and offline.
 
     Run with the dedicated runner (the shared run-arazzo.sh treats every NACK


### PR DESCRIPTION
## What

Follow-up to beckn-onix [#831](https://github.com/beckn/beckn-onix/pull/831)'s review round, which renamed the VC validator plugin id from `vcvalidator` to **`validateVC`** (built as `validateVC.so`) and added SSRF hardening + a per-request credential cap.

- **`local-simple-bpp.yaml`** — step id `vcvalidator` → `validateVC`; the new `maxCredentials` and `allowPrivateNetworks` knobs are declared explicitly. The devkit VC is `did:key` and the did:web/DEDI fixtures resolve to public hosts (`ameetdesh.github.io`, `api.dedi.global`), so the SSRF guard stays at its secure default (`allowPrivateNetworks: "false"`).
- **`docker-compose.yml`** — default adapter image `w-deg-plugins-v1` → `v2`, converging with the demand-flex and p2p-trading-ies-wave2 devkits.
- **vc-validation workflow** prose/runner updated for the new step id.
- **Dockerfile comment** notes the `.so` output name.

## Verification

Against `onix-adapter-deg:v2` rebuilt from beckn-onix `feat/vcvalidator-plugin` (f474008) with DEG main plugins:

| check | result |
|---|---|
| `run-vc-validation.sh` (valid / tampered / expired / wrong-issuer) | 4/4 |
| did:web unrevoked via BAP caller (public did:web + DEDI fetch through guarded client) | ACK |
| did:web revoked direct to BPP (DEDI record exists) | 401 `CREDENTIAL_REVOKED` |
| crafted VC with `did:web` issuer on a docker-internal host | 401 `DID_RESOLUTION_FAILED: … blocked dial to non-public address "172.19.0.2:443"` |
| `data-exchange.arazzo.yaml` | 4/5 workflows — `discover` (Redocly JSONPath bug) and `publish-catalog` HTTP 500 (routing-config mismatch) are pre-existing failures, verified unrelated |

## Notes

The `fidedocker/onix-adapter-deg:v2` tag must be republished from a beckn-onix checkout containing #831 before this merges — the current published v2 has no `validateVC.so`, so the BPP adapter would fail to resolve the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)