### PR TITLE
Add OpenTelemetry-based observability for the P2P Wave 2 devkit.

### DIFF
--- a/devkits/p2p-trading-ies-wave2/config/audit-fields.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/audit-fields.yaml
@@ -1,0 +1,78 @@
+mode: selective
+
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+  phone:
+    maskType: last4
+  sensitive:
+    maskType: replace
+    mask: "[REDACTED]"
+  account:
+    maskType: last4
+
+maskRules:
+  - keys: [email, emailAddress, supportEmail, providerEmail]
+    pattern: email
+  - keys: [phone, telephone, mobile, supportPhone, providerPhone]
+    pattern: phone
+  - keys: [displayName, fullName, accountHolderName]
+    pattern: sensitive
+  - keys: [accountNumber, vpa]
+    pattern: account
+  - keys: [paymentURL, txnRef, paidAt]
+    pattern: sensitive
+
+pathOverrides: []
+
+selectedFields:
+  default:
+    - context.transactionId
+    - context.messageId
+    - context.action
+    - context.networkId
+    - context.domain
+    - context.bapId
+    - context.bppId
+    - message.contract.id
+    - message.contract.status
+  confirm:
+    - context.transactionId
+    - context.messageId
+    - context.action
+    - context.networkId
+    - context.bapId
+    - context.bppId
+    - message.contract.id
+    - message.contract.status
+    - message.contract.commitments
+  on_confirm:
+    - context.transactionId
+    - context.messageId
+    - context.action
+    - context.networkId
+    - context.bapId
+    - context.bppId
+    - message.contract.id
+    - message.contract.status
+    - message.contract.commitments
+  status:
+    - context.transactionId
+    - context.messageId
+    - context.action
+    - context.networkId
+    - context.bapId
+    - context.bppId
+    - message.contract.id
+    - message.contract.status
+  on_status:
+    - context.transactionId
+    - context.messageId
+    - context.action
+    - context.networkId
+    - context.bapId
+    - context.bppId
+    - message.contract.id
+    - message.contract.status
+    - message.contract.commitments

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerapp.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerapp.yaml
@@ -16,6 +16,25 @@ http:
     idle: 30
 pluginManager:
   root: ./plugins
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-buyerapp"
+      serviceVersion: "1.0.0"
+      environment: "development"
+      domain: "p2p-trading-wave2"
+      producer: "buyerapp.example.com"
+      producerType: "bap"
+      otlpEndpoint: "otel-collector-buyerapp:4317"
+      enableMetrics: "true"
+      networkMetricsGranularity: "2min"
+      networkMetricsFrequency: "4min"
+      enableTracing: "true"
+      enableLogs: "true"
+      timeInterval: "5"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      cacheTTL: "3600"
 modules:
   - name: bapTxnReceiver
     path: /bap/receiver/

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerdiscom.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerdiscom.yaml
@@ -16,6 +16,25 @@ http:
     idle: 30
 pluginManager:
   root: ./plugins
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-buyerdiscom"
+      serviceVersion: "1.0.0"
+      environment: "development"
+      domain: "p2p-trading-wave2"
+      producer: "buyerdiscom.example.com"
+      producerType: "bpp"
+      otlpEndpoint: "otel-collector-buyerdiscom:4317"
+      enableMetrics: "true"
+      networkMetricsGranularity: "2min"
+      networkMetricsFrequency: "4min"
+      enableTracing: "true"
+      enableLogs: "true"
+      timeInterval: "5"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      cacheTTL: "3600"
 
 # BuyerDiscom *actor* — the buyer's distribution utility, distinct from
 # the buyer-discom-ledger TSP. Symmetric counterpart to sellerdiscom.

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-buyerdiscom.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-buyerdiscom.yaml
@@ -16,6 +16,25 @@ http:
     idle: 30
 pluginManager:
   root: ./plugins
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-ledger-buyerdiscom"
+      serviceVersion: "1.0.0"
+      environment: "development"
+      domain: "p2p-trading-wave2"
+      producer: "buyer-discom-ledger.example.com"
+      producerType: "bap"
+      otlpEndpoint: "otel-collector-ledger-buyerdiscom:4317"
+      enableMetrics: "true"
+      networkMetricsGranularity: "2min"
+      networkMetricsFrequency: "4min"
+      enableTracing: "true"
+      enableLogs: "true"
+      timeInterval: "5"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      cacheTTL: "3600"
 modules:
   # /bpp/receiver — incoming /status from buyerapp /bpp/receiver cascade
   # (seller-initiated sub-tx asking about buyer-discom allocation). Beckn

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-sellerdiscom.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-sellerdiscom.yaml
@@ -16,6 +16,25 @@ http:
     idle: 30
 pluginManager:
   root: ./plugins
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-ledger-sellerdiscom"
+      serviceVersion: "1.0.0"
+      environment: "development"
+      domain: "p2p-trading-wave2"
+      producer: "seller-discom-ledger.example.com"
+      producerType: "bpp"
+      otlpEndpoint: "otel-collector-ledger-sellerdiscom:4317"
+      enableMetrics: "true"
+      networkMetricsGranularity: "2min"
+      networkMetricsFrequency: "4min"
+      enableTracing: "true"
+      enableLogs: "true"
+      timeInterval: "5"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      cacheTTL: "3600"
 modules:
   # /bpp/receiver — request actions (status) where the ledger plays BPP-receiver.
   # Beckn convention: status is a request → requester=BAP, responder=BPP.

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerapp.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerapp.yaml
@@ -16,6 +16,25 @@ http:
     idle: 30
 pluginManager:
   root: ./plugins
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-sellerapp"
+      serviceVersion: "1.0.0"
+      environment: "development"
+      domain: "p2p-trading-wave2"
+      producer: "sellerapp.example.com"
+      producerType: "bpp"
+      otlpEndpoint: "otel-collector-sellerapp:4317"
+      enableMetrics: "true"
+      networkMetricsGranularity: "2min"
+      networkMetricsFrequency: "4min"
+      enableTracing: "true"
+      enableLogs: "true"
+      timeInterval: "5"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      cacheTTL: "3600"
 modules:
   - name: bppTxnReceiver
     path: /bpp/receiver/

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerdiscom.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerdiscom.yaml
@@ -16,6 +16,25 @@ http:
     idle: 30
 pluginManager:
   root: ./plugins
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-sellerdiscom"
+      serviceVersion: "1.0.0"
+      environment: "development"
+      domain: "p2p-trading-wave2"
+      producer: "sellerdiscom.example.com"
+      producerType: "bpp"
+      otlpEndpoint: "otel-collector-sellerdiscom:4317"
+      enableMetrics: "true"
+      networkMetricsGranularity: "2min"
+      networkMetricsFrequency: "4min"
+      enableTracing: "true"
+      enableLogs: "true"
+      timeInterval: "5"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      cacheTTL: "3600"
 
 # Sellerdiscom *actor* — the seller's distribution utility, distinct from
 # the seller-discom-ledger TSP. Today discoms push meter actuals via the

--- a/devkits/p2p-trading-ies-wave2/install/docker-compose.yml
+++ b/devkits/p2p-trading-ies-wave2/install/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       RABBITMQ_ADDR: rabbitmq:5672
       RABBITMQ_USER: admin
       RABBITMQ_PASS: admin123
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-buyerapp:4317
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
@@ -54,6 +56,9 @@ services:
     command: ["./server", "--config=/app/config/local-p2p-trading-buyerapp.yaml"]
     networks:
       - bap_side
+    depends_on:
+      otel-collector-buyerapp:
+        condition: service_started
 
   sandbox-buyerapp:
     container_name: sandbox-buyerapp
@@ -102,6 +107,8 @@ services:
       RABBITMQ_ADDR: rabbitmq:5672
       RABBITMQ_USER: admin
       RABBITMQ_PASS: admin123
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-sellerapp:4317
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
@@ -109,6 +116,9 @@ services:
     command: ["./server", "--config=/app/config/local-p2p-trading-sellerapp.yaml"]
     networks:
       - bpp_side
+    depends_on:
+      otel-collector-sellerapp:
+        condition: service_started
 
   sandbox-sellerapp:
     container_name: sandbox-sellerapp
@@ -153,6 +163,8 @@ services:
       - "8083:8083"
     environment:
       CONFIG_FILE: "/app/config/local-p2p-trading-ledger-sellerdiscom.yaml"
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-ledger-sellerdiscom:4317
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
@@ -163,6 +175,8 @@ services:
     depends_on:
       redis-ledger:
         condition: service_healthy
+      otel-collector-ledger-sellerdiscom:
+        condition: service_started
 
   sandbox-ledger-sellerdiscom:
     container_name: sandbox-ledger-sellerdiscom
@@ -196,6 +210,8 @@ services:
       - "8084:8084"
     environment:
       CONFIG_FILE: "/app/config/local-p2p-trading-ledger-buyerdiscom.yaml"
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-ledger-buyerdiscom:4317
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
@@ -206,6 +222,8 @@ services:
     depends_on:
       redis-ledger:
         condition: service_healthy
+      otel-collector-ledger-buyerdiscom:
+        condition: service_started
 
   sandbox-ledger-buyerdiscom:
     container_name: sandbox-ledger-buyerdiscom
@@ -253,6 +271,8 @@ services:
       - "8085:8085"
     environment:
       CONFIG_FILE: "/app/config/local-p2p-trading-buyerdiscom.yaml"
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-buyerdiscom:4317
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
@@ -263,6 +283,8 @@ services:
     depends_on:
       redis-buyerdiscom:
         condition: service_healthy
+      otel-collector-buyerdiscom:
+        condition: service_started
 
   # ---------- Seller Discom Actor (the utility itself, distinct from the
   #            seller-discom-ledger TSP). New Beckn-native replacement for
@@ -288,6 +310,8 @@ services:
       - "8086:8086"
     environment:
       CONFIG_FILE: "/app/config/local-p2p-trading-sellerdiscom.yaml"
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-sellerdiscom:4317
     volumes:
       - ../config:/app/config
       - ../schemas:/app/schemas
@@ -298,6 +322,184 @@ services:
     depends_on:
       redis-sellerdiscom:
         condition: service_healthy
+      otel-collector-sellerdiscom:
+        condition: service_started
+
+  # ---------- Observability ----------
+  otel-collector-buyerapp:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-buyerapp
+    command: ["--config=/etc/otel/config.yaml"]
+    environment:
+      OTEL_NODE_NAME: buyerapp
+    volumes:
+      - ./observability/otel-collector-node.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - bap_side
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  otel-collector-sellerapp:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-sellerapp
+    command: ["--config=/etc/otel/config.yaml"]
+    environment:
+      OTEL_NODE_NAME: sellerapp
+    volumes:
+      - ./observability/otel-collector-node.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - bpp_side
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  otel-collector-ledger-buyerdiscom:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-ledger-buyerdiscom
+    command: ["--config=/etc/otel/config.yaml"]
+    environment:
+      OTEL_NODE_NAME: ledger-buyerdiscom
+    volumes:
+      - ./observability/otel-collector-node.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - bap_side
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  otel-collector-ledger-sellerdiscom:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-ledger-sellerdiscom
+    command: ["--config=/etc/otel/config.yaml"]
+    environment:
+      OTEL_NODE_NAME: ledger-sellerdiscom
+    volumes:
+      - ./observability/otel-collector-node.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - bpp_side
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  otel-collector-buyerdiscom:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-buyerdiscom
+    command: ["--config=/etc/otel/config.yaml"]
+    environment:
+      OTEL_NODE_NAME: buyerdiscom
+    volumes:
+      - ./observability/otel-collector-node.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - bap_side
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  otel-collector-sellerdiscom:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-sellerdiscom
+    command: ["--config=/etc/otel/config.yaml"]
+    environment:
+      OTEL_NODE_NAME: sellerdiscom
+    volumes:
+      - ./observability/otel-collector-node.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - bpp_side
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  otel-collector-network:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector-network
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./observability/otel-collector-network.yaml:/etc/otel/config.yaml:ro
+    networks:
+      - observability
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: p2p-wave2-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - observability
+    depends_on:
+      otel-collector-network:
+        condition: service_started
+
+  loki:
+    image: grafana/loki:latest
+    container_name: p2p-wave2-loki
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./observability/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    ports:
+      - "3100:3100"
+    networks:
+      - observability
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: p2p-wave2-promtail
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - ./observability/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - observability
+    depends_on:
+      loki:
+        condition: service_started
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: p2p-wave2-zipkin
+    ports:
+      - "9411:9411"
+    networks:
+      - observability
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: p2p-wave2-grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: http://localhost:3005
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3005:3000"
+    networks:
+      - observability
+    depends_on:
+      prometheus:
+        condition: service_started
+      loki:
+        condition: service_started
+      promtail:
+        condition: service_started
+      zipkin:
+        condition: service_started
 
   # ---------- Host router (only container on both sides) ----------
   # Caddy listens on :9000 and routes by Host header. Network aliases below
@@ -336,3 +538,10 @@ networks:
     driver: bridge
   bpp_side:
     driver: bridge
+  observability:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/devkits/p2p-trading-ies-wave2/install/observability/README.md
+++ b/devkits/p2p-trading-ies-wave2/install/observability/README.md
@@ -1,0 +1,460 @@
+# P2P Wave 2 Observability
+
+OpenTelemetry-based monitoring for the P2P Wave 2 devkit. Provides Grafana
+dashboards backed by Prometheus (metrics), Loki (logs), and Zipkin (traces).
+
+---
+
+## Architecture Overview
+
+```
+ONIX adapter (×6)
+  → companion OTel collector (one per adapter)
+    → network OTel collector (single, shared)
+      → Prometheus   (metrics)
+      → Loki         (structured logs + audit logs)
+      → Zipkin       (distributed traces)
+        → Grafana    (dashboards + explore)
+
+Docker container stdout/stderr
+  → Promtail
+    → Loki
+      → Grafana Explore
+```
+
+Each ONIX adapter exports OTLP/gRPC telemetry to its own **companion
+collector**. The companion collector:
+
+- exposes app-level metrics on `:8889` for Prometheus to scrape directly.
+- filters and forwards network-level metrics, traces, and logs to a shared
+  **network collector**.
+
+The network collector aggregates signals from all adapters, rewrites Beckn
+`transaction_id` into a deterministic trace ID, and exports to Prometheus,
+Zipkin, and Loki.
+
+**Promtail** separately tails Docker container stdout/stderr via the Docker
+socket and pushes those logs to Loki. This gives immediate container-log
+visibility even before the ONIX `otelsetup` plugin emits OTel audit records.
+
+### Adapter → Collector Mapping
+
+| ONIX Adapter             | Companion Collector                  | Prometheus Port |
+| ------------------------ | ------------------------------------ | --------------- |
+| `onix-buyerapp`          | `otel-collector-buyerapp`            | `:8889`         |
+| `onix-sellerapp`         | `otel-collector-sellerapp`           | `:8889`         |
+| `onix-buyerdiscom`       | `otel-collector-buyerdiscom`         | `:8889`         |
+| `onix-sellerdiscom`      | `otel-collector-sellerdiscom`        | `:8889`         |
+| `onix-ledger-buyerdiscom`| `otel-collector-ledger-buyerdiscom`  | `:8889`         |
+| `onix-ledger-sellerdiscom`| `otel-collector-ledger-sellerdiscom` | `:8889`         |
+
+All companion collectors use the same config file
+(`observability/otel-collector-node.yaml`), differentiated only by the
+`OTEL_NODE_NAME` environment variable set in `docker-compose.yml`.
+
+---
+
+## Quick Start
+
+From `DEG/devkits/p2p-trading-ies-wave2/install`:
+
+```bash
+docker compose up -d
+```
+
+After changing observability compose/config files, recreate the stack so stale
+containers and old mounted configs are removed:
+
+```bash
+docker compose down --remove-orphans
+docker compose up -d --force-recreate
+```
+
+### UIs
+
+| Service    | Local URL                    | Credentials     |
+| ---------- | ---------------------------- | --------------- |
+| Grafana    | <http://localhost:3005>       | `admin` / `admin` |
+| Prometheus | <http://localhost:9090>       | —               |
+| Loki       | <http://localhost:3100>       | —               |
+| Zipkin     | <http://localhost:9411>       | —               |
+
+Open Grafana → **Dashboards** → **P2P Wave 2** folder →
+**P2P Wave 2 Observability**.
+
+---
+
+## What To Customise When You Fork / Deploy
+
+> **If you are setting up this devkit for a new participant, network, or
+> deployment environment, update the values listed below.** The observability
+> configs ship with example placeholder values (`*.example.com`) that must
+> match your actual Beckn subscriber IDs and network topology.
+
+### 1. ONIX Adapter Configs — `otelsetup` Plugin Block
+
+Each adapter YAML in `config/` has a top-level `plugins.otelsetup` section.
+This is what tells the ONIX adapter _"send your telemetry here, and tag it
+with these identifiers"_:
+
+```yaml
+plugins:
+  otelsetup:
+    id: otelsetup
+    config:
+      serviceName: "p2p-wave2-buyerapp"           # ① unique per adapter
+      producer: "buyerapp.example.com"             # ② your subscriber ID
+      producerType: "bap"                          # ③ "bap" or "bpp"
+      otlpEndpoint: "otel-collector-buyerapp:4317" # ④ collector hostname
+      enableMetrics: "true"
+      enableTracing: "true"
+      enableLogs: "true"
+      auditFieldsConfig: "/app/config/audit-fields.yaml"
+```
+
+Here is what each of the four key fields means and when you need to change it:
+
+---
+
+#### ① `serviceName` — "Who am I in Grafana?"
+
+This is the **display name** that appears on every metric, trace, and log
+record emitted by this adapter. Grafana uses it to let you filter dashboards
+to a specific adapter.
+
+- Must be **unique across all adapters** in the stack. If two adapters share
+  the same `serviceName`, their metrics will be mixed together and you won't
+  be able to tell them apart in Grafana.
+- Can be any string you like — it's purely for human readability.
+- Convention: `p2p-wave2-<role>` (e.g. `p2p-wave2-buyerapp`,
+  `p2p-wave2-sellerapp`).
+
+**Where it shows up:**
+
+- Grafana → Loki log panel → `service_name` label
+- Grafana → Prometheus → `service` label on metrics
+- Zipkin → `serviceName` in trace explorer
+
+**When to change:** Always set this to something meaningful for your
+deployment. The default values work for the demo, but in a multi-team setup
+you'll want names that identify the operator.
+
+---
+
+#### ② `producer` — "What is my Beckn subscriber ID?"
+
+This is the **most important field to change** when you fork the devkit.
+
+The `producer` value must be your **Beckn subscriber ID** — the exact same
+value you set as `networkParticipant` in the `keyManager` plugin section of
+the same config file. For example, if your key manager says:
+
+```yaml
+keyManager:
+  id: simplekeymanager
+  config:
+    networkParticipant: buyerapp.yourcompany.com   # ← this value
+```
+
+then your otelsetup must say:
+
+```yaml
+producer: "buyerapp.yourcompany.com"               # ← must match
+```
+
+**Why it matters:** The network observer (the central entity monitoring all
+participants) uses `producer` to **attribute telemetry to a specific
+participant**. If all adapters have the same producer value (e.g. the
+default `"beckn"`), the network observer sees all traffic as coming from one
+participant and cannot distinguish buyer from seller.
+
+**What happens if you get it wrong:**
+
+- If `producer` doesn't match your actual subscriber ID → network-level
+  dashboards will show an unknown participant name and cross-node correlation
+  will break.
+- If all adapters share the same `producer` → all traffic merges into one
+  bucket in the network view.
+
+---
+
+#### ③ `producerType` — "Am I a BAP or BPP?"
+
+Tells the network observer whether this adapter is a **buyer-side (BAP)** or
+**seller-side (BPP)** participant.
+
+| Value | Meaning | Use for |
+| ----- | ------- | ------- |
+| `"bap"` | Beckn Application Platform (buyer side) | `buyerapp`, `ledger-buyerdiscom` |
+| `"bpp"` | Beckn Provider Platform (seller side) | `sellerapp`, `sellerdiscom`, `buyerdiscom`, `ledger-sellerdiscom` |
+
+> **Note:** Some adapters (like `buyerapp`) have both `/bap/` and `/bpp/`
+> modules. The `producerType` reflects the adapter's **primary network
+> identity**, not every module it happens to host.
+
+**What happens if you get it wrong:** Network dashboards will miscategorise
+the participant. A seller will show up in the buyer section or vice versa.
+This doesn't break data flow, but makes monitoring confusing.
+
+---
+
+#### ④ `otlpEndpoint` — "Where do I send my telemetry?"
+
+This is the hostname and port of the **companion OTel collector** that
+receives this adapter's telemetry over OTLP/gRPC.
+
+- In the local Docker Compose setup, this is the **Docker service name** of
+  the companion collector container (e.g. `otel-collector-buyerapp:4317`).
+  Docker DNS resolves this automatically inside the compose network.
+- Port `4317` is the standard OTLP/gRPC port.
+
+**When to change:**
+
+- **Local compose (default):** Don't change. The Docker service names in
+  `docker-compose.yml` already match.
+- **Remote/VM deployment:** Replace the Docker service name with the
+  collector's reachable hostname or IP address:
+  ```yaml
+  otlpEndpoint: "otel-collector.your-vm.internal:4317"
+  ```
+- **Renamed collectors:** If you rename a collector service in
+  `docker-compose.yml`, update this to match.
+
+**What happens if you get it wrong:** The adapter will fail to connect to
+the collector. You'll see gRPC connection errors in the adapter container
+logs and no telemetry will appear in Grafana.
+
+---
+
+#### Putting It All Together — Example
+
+Suppose you're forking this devkit for a company called "GreenGrid" with
+subscriber IDs registered on the Beckn network. Here's what you'd change
+for the buyer app:
+
+**Before (default demo values):**
+
+```yaml
+config:
+  serviceName: "p2p-wave2-buyerapp"
+  producer: "buyerapp.example.com"
+  producerType: "bap"
+  otlpEndpoint: "otel-collector-buyerapp:4317"
+```
+
+**After (your deployment):**
+
+```yaml
+config:
+  serviceName: "greengrid-buyerapp"
+  producer: "bap.greengrid.energy"
+  producerType: "bap"
+  otlpEndpoint: "otel-collector-buyerapp:4317"   # unchanged for local compose
+```
+
+You'd do the same for each of the 6 adapter config files, matching the
+`producer` to the subscriber ID in that adapter's `keyManager` section.
+
+---
+
+**Files to update (one per adapter):**
+
+| File | `producer` should match | `producerType` |
+| ---- | ----------------------- | -------------- |
+| `config/local-p2p-trading-buyerapp.yaml` | Your buyer app subscriber ID | `bap` |
+| `config/local-p2p-trading-sellerapp.yaml` | Your seller app subscriber ID | `bpp` |
+| `config/local-p2p-trading-buyerdiscom.yaml` | Your buyer discom subscriber ID | `bpp` |
+| `config/local-p2p-trading-sellerdiscom.yaml` | Your seller discom subscriber ID | `bpp` |
+| `config/local-p2p-trading-ledger-buyerdiscom.yaml` | Your buyer discom ledger subscriber ID | `bap` |
+| `config/local-p2p-trading-ledger-sellerdiscom.yaml` | Your seller discom ledger subscriber ID | `bpp` |
+
+### 2. Docker Compose — OTLP Endpoint Environment Variables
+
+Each ONIX adapter service in `install/docker-compose.yml` has:
+
+```yaml
+environment:
+  OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector-buyerapp:4317
+  OTEL_EXPORTER_OTLP_INSECURE: "true"
+```
+
+**When to change:**
+- If you move the collector to a **remote host/VM**, replace the Docker
+  service name with the collector's reachable hostname or IP
+  (e.g. `otel-collector.yourvm.internal:4317`).
+- If you enable **TLS** on the collector, set
+  `OTEL_EXPORTER_OTLP_INSECURE: "false"`.
+
+### 3. Audit Fields — `config/audit-fields.yaml`
+
+Controls which Beckn payload fields are exported in audit logs and which
+sensitive fields are masked.
+
+**When to change:**
+- Add fields you want to see in Grafana log panels
+  (e.g. `message.contract.commitments[*].quantity`).
+- Add masking rules for new sensitive fields specific to your domain.
+
+### 4. Prometheus Scrape Config — `observability/prometheus.yml`
+
+Lists all collector scrape targets. **Only change if** you add/remove
+adapters or rename collector services.
+
+### 5. Grafana Dashboard — `observability/grafana/provisioning/dashboards/json/`
+
+The provisioned dashboard JSON auto-loads on startup. If you add custom
+panels or modify queries, edit the JSON directly or export from the Grafana
+UI and replace the file. Grafana will pick up changes within 30 seconds
+(configured via `updateIntervalSeconds` in `dashboards.yml`).
+
+### 6. Collector Configs (Rarely Changed)
+
+| File | Purpose | Change when… |
+| ---- | ------- | ------------ |
+| `observability/otel-collector-node.yaml` | Shared per-node collector config | You need to add app-level trace/log exporters, change batch sizes, or adjust network filters |
+| `observability/otel-collector-network.yaml` | Shared network collector config | You switch trace backend (e.g. Zipkin → Jaeger), change Loki endpoint, or adjust the `transform/beckn_ids` processor |
+
+---
+
+## Telemetry Flow in Detail
+
+```
+1. Beckn request → ONIX adapter
+2. otelsetup plugin emits metrics + traces + audit logs via OTLP/gRPC
+3. Companion collector receives on :4317
+   ├── metrics/app   → Prometheus scrapes :8889 (all metrics, full fidelity)
+   ├── metrics/network → filtered (only http_request_count) → network collector
+   ├── traces/network  → filtered (only spans with transaction_id/sender.id) → network collector
+   └── logs/network    → all logs → network collector
+4. Network collector
+   ├── metrics → Prometheus scrapes :8890
+   ├── traces  → transform/beckn_ids (tx_id → TraceID) → Zipkin
+   └── logs    → Loki (OTLP HTTP)
+5. Grafana reads from Prometheus + Loki + Zipkin
+```
+
+Separately:
+
+```
+Docker container stdout/stderr → Promtail → Loki → Grafana Explore
+```
+
+---
+
+## Grafana Dashboard Panels
+
+The **P2P Wave 2 Observability** dashboard includes:
+
+| Panel | Data Source | What It Shows |
+| ----- | ----------- | ------------- |
+| Request rate by Beckn action | Prometheus | `confirm`, `on_confirm`, `status`, `on_status` request rates |
+| Request rate by node and status | Prometheus | Per-adapter breakdown with HTTP status codes |
+| Participant traffic | Prometheus | Sender → recipient traffic flows |
+| ONIX step p95 latency | Prometheus | 95th percentile latency for each ONIX processing step |
+| ONIX logs by transaction ID | Loki | Filtered audit logs — use the `transactionId` variable |
+
+**Template variables:**
+- `transactionId` — textbox filter for log panel. Paste a Beckn
+  `transaction_id` to narrow logs to one transaction.
+
+**External links:**
+- Zipkin traces — click the "Zipkin traces" link in the dashboard header to
+  open the Zipkin UI for distributed trace investigation.
+
+---
+
+## Loki Queries (Grafana Explore)
+
+Select the **Loki** datasource in Grafana Explore. Useful queries:
+
+```logql
+# All P2P Wave 2 container logs (via Promtail)
+{compose_project="install"}
+
+# Specific adapter container logs
+{service="onix-buyerapp"}
+{service="onix-sellerapp"}
+
+# All ONIX adapter logs
+{service=~"onix-.*"}
+
+# Filter by Beckn action
+{service=~"onix-.*"} |= "confirm"
+
+# Filter by transaction ID
+{service=~"onix-.*"} |= "your-transaction-id-here"
+
+# OTel audit logs from the network collector
+{service_name=~"p2p-wave2-.*"}
+
+# Collector internal logs
+{service="otel-collector-network"}
+```
+
+---
+
+## Verification Checklist
+
+After starting the stack and running a P2P flow:
+
+- [ ] `docker compose ps` — all services are `Up`
+- [ ] Prometheus (`http://localhost:9090/targets`) — all 7 scrape targets
+      show `UP`
+- [ ] Grafana dashboard shows non-zero request rate panels
+- [ ] Loki returns results for `{compose_project="install"}`
+- [ ] Zipkin shows traces when searching by `serviceName`
+
+### Common Problems
+
+| Symptom | Likely Cause | Fix |
+| ------- | ------------ | --- |
+| Dashboard panels are empty | Time range doesn't include test requests | Set Grafana time range to "Last 15 minutes" and run a flow |
+| Prometheus targets show `DOWN` | Collector containers not running | `docker compose ps` — check collector containers are `Up` |
+| No Loki labels in Explore | Promtail not running or Docker socket not mounted | Check `p2p-wave2-promtail` is running; confirm `/var/run/docker.sock` is accessible |
+| Zipkin shows no traces | ONIX image missing `otelsetup` plugin | Verify the adapter image (`fidedocker/onix-adapter-deg:v2`) includes the plugin |
+| Collector logs show "unknown exporter" | Exporter name typo in collector YAML | Ensure exporters use `otlphttp` (no underscore), not `otlp_http` |
+| Logs appear in Promtail but not in OTel audit panel | Loki label mismatch for OTLP-ingested logs | Query with `{service_name=~"p2p-wave2-.*"}` (underscore) instead of `{service=~"..."}` |
+
+---
+
+## VM / Remote Deployment
+
+For hosting the receiver stack on a VM (e.g. the ledger-service VM):
+
+1. Run only the receiver services on the VM: `otel-collector-network`,
+   `prometheus`, `loki`, `promtail`, `zipkin`, `grafana`.
+2. Keep collector, Prometheus, Loki, and Zipkin ports **internal** (not
+   exposed to the public internet).
+3. Expose only Grafana through the VM's existing public ingress (e.g.
+   nginx/Caddy on `:3000`).
+4. Update each ONIX adapter's `otelsetup.otlpEndpoint` to point to the
+   VM-hosted collector:
+   ```yaml
+   otlpEndpoint: "otel-collector.your-vm.internal:4317"
+   ```
+5. Ensure port `4317` (OTLP/gRPC) is reachable from ONIX nodes to the
+   collector host.
+6. For TLS: configure the collector to serve TLS and set
+   `OTEL_EXPORTER_OTLP_INSECURE: "false"` on each ONIX adapter.
+
+---
+
+## File Reference
+
+```
+observability/
+├── README.md                              ← this file
+├── otel-collector-node.yaml               ← shared per-adapter collector config
+├── otel-collector-network.yaml            ← network-level collector config
+├── prometheus.yml                         ← Prometheus scrape targets
+├── loki-config.yml                        ← Loki storage and schema config
+├── promtail-config.yml                    ← Promtail Docker log tailing config
+└── grafana/
+    └── provisioning/
+        ├── datasources/
+        │   └── datasources.yml            ← Prometheus + Loki + Zipkin datasources
+        └── dashboards/
+            ├── dashboards.yml             ← dashboard auto-discovery config
+            └── json/
+                └── p2p-wave2-dashboard.json ← pre-built Grafana dashboard
+```

--- a/devkits/p2p-trading-ies-wave2/install/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: P2P Wave 2
+    orgId: 1
+    folder: P2P Wave 2
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/devkits/p2p-trading-ies-wave2/install/observability/grafana/provisioning/dashboards/json/p2p-wave2-dashboard.json
+++ b/devkits/p2p-trading-ies-wave2/install/observability/grafana/provisioning/dashboards/json/p2p-wave2-dashboard.json
@@ -1,0 +1,129 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": true,
+      "title": "Zipkin traces",
+      "type": "link",
+      "url": "http://localhost:9411"
+    }
+  ],
+  "panels": [
+    { "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "title": "P2P Beckn Traffic", "type": "row" },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\".*http_request_count(_total)?\"}[5m])) by (action)",
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate by Beckn action",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\".*http_request_count(_total)?\"}[5m])) by (http_status_code, observability_node)",
+          "legendFormat": "{{observability_node}} {{http_status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate by node and status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\".*http_request_count(_total)?\"}[5m])) by (sender_id, recipient_id)",
+          "legendFormat": "{{sender_id}} -> {{recipient_id}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate({__name__=~\".*http_request_count(_total)?\"}[5m])) by (sender_id, recipient_id)",
+          "hide": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Participant traffic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate({__name__=~\".*step_execution_duration_seconds_bucket\"}[5m])) by (le, module, step))",
+          "legendFormat": "{{module}} {{step}}",
+          "refId": "A"
+        }
+      ],
+      "title": "ONIX step p95 latency",
+      "type": "timeseries"
+    },
+    { "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }, "id": 6, "title": "Logs", "type": "row" },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "id": 10,
+      "options": { "dedupStrategy": "none", "enableLogDetails": true, "showCommonLabels": false, "showLabels": false, "wrapLogMessage": true },
+      "targets": [
+        {
+          "expr": "{service_name=~\"p2p-wave2-.*\"} |= `${transactionId}`",
+          "refId": "A"
+        }
+      ],
+      "title": "ONIX logs by transaction ID",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["p2p-wave2", "otel", "beckn"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "", "value": "" },
+        "hide": 0,
+        "label": "Transaction ID",
+        "name": "transactionId",
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "",
+  "title": "P2P Wave 2 Observability",
+  "uid": "p2p-wave2-observability",
+  "version": 1,
+  "weekStart": ""
+}

--- a/devkits/p2p-trading-ies-wave2/install/observability/grafana/provisioning/datasources/datasources.yml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+  - name: Zipkin
+    uid: zipkin
+    type: zipkin
+    access: proxy
+    url: http://zipkin:9411
+    editable: false

--- a/devkits/p2p-trading-ies-wave2/install/observability/loki-config.yml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/loki-config.yml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true

--- a/devkits/p2p-trading-ies-wave2/install/observability/otel-collector-network.yaml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/otel-collector-network.yaml
@@ -1,0 +1,55 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  transform/beckn_ids:
+    error_mode: ignore
+    trace_statements:
+      - set(span.attributes["_beckn_tx"], span.attributes["transaction_id"]) where span.attributes["transaction_id"] != nil
+      - replace_pattern(span.attributes["_beckn_tx"], "-", "") where span.attributes["_beckn_tx"] != nil
+      - set(span.trace_id, TraceID(span.attributes["_beckn_tx"])) where span.attributes["_beckn_tx"] != nil
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8890
+    const_labels:
+      observability: p2p-wave2-network
+  zipkin:
+    endpoint: http://zipkin:9411/api/v2/spans
+    format: json
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+    compression: gzip
+  debug:
+    verbosity: basic
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [transform/beckn_ids, batch]
+      exporters: [zipkin]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/loki, debug]
+  telemetry:
+    logs:
+      level: info

--- a/devkits/p2p-trading-ies-wave2/install/observability/otel-collector-node.yaml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/otel-collector-node.yaml
@@ -1,0 +1,58 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+  filter/network_metrics:
+    error_mode: ignore
+    metrics:
+      metric:
+        - 'IsMatch(name, ".*http_request_count.*") == false'
+  filter/network_traces:
+    error_mode: ignore
+    traces:
+      span:
+        - 'attributes["transaction_id"] == nil and attributes["sender.id"] == nil'
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    const_labels:
+      observability_node: ${env:OTEL_NODE_NAME}
+  otlphttp/network:
+    endpoint: http://otel-collector-network:4318
+    compression: gzip
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics/app:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    metrics/network:
+      receivers: [otlp]
+      processors: [filter/network_metrics, batch]
+      exporters: [otlphttp/network]
+    traces/network:
+      receivers: [otlp]
+      processors: [filter/network_traces, batch]
+      exporters: [otlphttp/network]
+    logs/network:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/network]
+  telemetry:
+    logs:
+      level: info

--- a/devkits/p2p-trading-ies-wave2/install/observability/prometheus.yml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/prometheus.yml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: otel-collector-network
+    static_configs:
+      - targets: ["otel-collector-network:8890"]
+  - job_name: otel-collector-buyerapp
+    static_configs:
+      - targets: ["otel-collector-buyerapp:8889"]
+  - job_name: otel-collector-sellerapp
+    static_configs:
+      - targets: ["otel-collector-sellerapp:8889"]
+  - job_name: otel-collector-ledger-buyerdiscom
+    static_configs:
+      - targets: ["otel-collector-ledger-buyerdiscom:8889"]
+  - job_name: otel-collector-ledger-sellerdiscom
+    static_configs:
+      - targets: ["otel-collector-ledger-sellerdiscom:8889"]
+  - job_name: otel-collector-buyerdiscom
+    static_configs:
+      - targets: ["otel-collector-buyerdiscom:8889"]
+  - job_name: otel-collector-sellerdiscom
+    static_configs:
+      - targets: ["otel-collector-sellerdiscom:8889"]

--- a/devkits/p2p-trading-ies-wave2/install/observability/promtail-config.yml
+++ b/devkits/p2p-trading-ies-wave2/install/observability/promtail-config.yml
@@ -1,0 +1,28 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker-containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        regex: install
+        action: keep
+      - source_labels: [__meta_docker_container_name]
+        regex: "/(.*)"
+        target_label: container
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: service
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label: stream


### PR DESCRIPTION
This change enables the ONIX otelsetup plugin across all P2P Wave 2 adapter configs, including buyer app, seller app, buyer/seller DISCOM actors, and buyer/seller DISCOM ledger adapters. Each adapter now exports metrics, traces, and logs to its companion OTel collector with a unique service name and participant identity.

The devkit compose setup now includes a local observability stack:
- companion OTel collector per ONIX adapter
- shared network OTel collector
- Prometheus for metrics
- Loki for logs
- Promtail for Docker container log collection
- Zipkin for traces
- Grafana for dashboards and Explore

The observability stack supports monitoring of Beckn P2P traffic across actions such as confirm, on_confirm, status, and on_status. Telemetry is correlated using Beckn context fields including transaction id, message id, action, BAP/BPP ids, participant identity, and contract fields where available.

This also adds:
- audit field config for searchable and masked Beckn log fields
- Prometheus scrape configuration for all collectors
- Loki and Promtail configuration for container and telemetry logs
- Grafana datasource provisioning for Prometheus, Loki, and Zipkin
- a provisioned P2P Wave 2 Grafana dashboard
- README documentation covering architecture, startup, verification, queries, and deployment notes