### PR TITLE
fix(wave2): align seller sandbox fixtures with the canonical IES ledger identities

### DIFF
--- a/devkits/p2p-trading-ies-wave2/responses/sellerapp/on_confirm.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerapp/on_confirm.json
@@ -57,16 +57,16 @@
         "roles": [
           {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
           {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
-          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
-          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
+          {"role": "buyerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io"},
+          {"role": "sellerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io"}
         ],
         "policy": {"url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1", "queryPath": "data.deg.contracts.p2p_trading"}
       },
       "participants": [
         {"role": "sellerPlatform", "participantId": "sellerapp.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_SELLER_001", "utilityId": "TEST_DISCOM_SELLER", "utilityCustomerId": "TEST_CUST_SELLER_001", "platformUrl": "http://sellerapp.example.com:9000"}},
         {"role": "buyerPlatform", "participantId": "buyerapp.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_BUYER_001", "utilityId": "TEST_DISCOM_BUYER", "utilityCustomerId": "TEST_CUST_BUYER_001", "platformUrl": "http://buyerapp.example.com:9000"}},
-        {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "http://buyer-discom-ledger.example.com:9000", "platformUrl": "http://buyer-discom.example.com:9000"}},
-        {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "http://seller-discom-ledger.example.com:9000", "platformUrl": "http://seller-discom.example.com:9000"}}
+        {"role": "buyerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io", "platformUrl": "http://buyer-discom.example.com:9000"}},
+        {"role": "sellerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io", "platformUrl": "http://seller-discom.example.com:9000"}}
       ],
       "id": "contract-p2p-001",
       "consideration": [

--- a/devkits/p2p-trading-ies-wave2/responses/sellerapp/on_init.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerapp/on_init.json
@@ -57,16 +57,16 @@
         "roles": [
           {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
           {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
-          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
-          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
+          {"role": "buyerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io"},
+          {"role": "sellerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io"}
         ],
         "policy": {"url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1", "queryPath": "data.deg.contracts.p2p_trading"}
       },
       "participants": [
         {"role": "sellerPlatform", "participantId": "sellerapp.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_SELLER_001", "utilityId": "TEST_DISCOM_SELLER", "utilityCustomerId": "TEST_CUST_SELLER_001", "platformUrl": "http://sellerapp.example.com:9000"}},
         {"role": "buyerPlatform", "participantId": "buyerapp.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_BUYER_001", "utilityId": "TEST_DISCOM_BUYER", "utilityCustomerId": "TEST_CUST_BUYER_001", "platformUrl": "http://buyerapp.example.com:9000"}},
-        {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "http://buyer-discom-ledger.example.com:9000", "platformUrl": "http://buyer-discom.example.com:9000"}},
-        {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "http://seller-discom-ledger.example.com:9000", "platformUrl": "http://seller-discom.example.com:9000"}}
+        {"role": "buyerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io", "platformUrl": "http://buyer-discom.example.com:9000"}},
+        {"role": "sellerDiscom", "participantId": "ies-p2p-energy-ledger.beckn.io", "participantAttributes": {"@context": "https://schema.beckn.io/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "https://ies-p2p-energy-ledger.beckn.io", "platformUrl": "http://seller-discom.example.com:9000"}}
       ],
       "consideration": [
         {


### PR DESCRIPTION
## Symptom

on_confirm cascaded the ledger write to `http://seller-discom-ledger.example.com:9000` even though the confirm sent from postman carried `https://ies-p2p-energy-ledger.beckn.io` ledger URLs.

## Root cause — sandbox fixture, as suspected

The sandbox builds callbacks by taking the fixture's `message` **verbatim** (only `context` is rebuilt from the request). The `responses/sellerapp/{on_init,on_confirm}.json` fixtures still declared the devkit-local `*-discom-ledger.example.com` participantIds/ledgerUrls, so whatever the request declared was replaced — and `degledgerrecorder` (`ledgerUriSource: payload`) cascaded to the fixture's URL.

## Fix

Both discom roles in the two fixtures now use `participantId: ies-p2p-energy-ledger.beckn.io` and `ledgerUrl: https://ies-p2p-energy-ledger.beckn.io`, mirroring the postman collections' default variable values (8-line diff per file). The uc1 example responses are deliberately untouched: the arazzo local-bridge flow POSTs those explicitly and keeps cascading to the local ledger containers.

## Verification (live)

From the BUYER collection with default variables: `init` → ACK with clean `on_init`; `confirm` → `degledgerrecorder` outgoing request is now `POST https://ies-p2p-energy-ledger.beckn.io/bap/receiver/on_confirm`, and the deployed ledger responds `200 {"message":{"status":"ACK"},"details":{"action":"on_confirm","processed":2}}`. The on_confirm delivered to the buyer carries the consistent contract (ledger identities in both `roles[]` and `participants[]`).