### PR TITLE
docs(ledger-api): expose per-line price and networkId in ledger records

### DIFF
--- a/specification/api/deg_contract_ledger.yaml
+++ b/specification/api/deg_contract_ledger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: DEG Ledger Service API
-  version: 0.3.0
+  version: 0.4.0
   description: |
     DEG Ledger Service stores an immutable, multi-party ledger view of a DEG trade lifecycle.
 
@@ -106,6 +106,8 @@ paths:
                     - tradeType: ENERGY
                       tradeQty: 12.5
                       tradeUnit: KWH
+                      pricePerUnit: 14.5
+                      priceCurrency: INR
                   clientReference: "buyer-create-0001"
       responses:
         "200":
@@ -210,6 +212,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/ledgerGetResponse"
               examples:
+                single:
+                  summary: One record including per-line price and networkId
+                  value:
+                    records:
+                      - creationTime: "2026-01-15T10:20:31Z"
+                        recordId: "rec-9f8a2c"
+                        transactionId: "tx-123"
+                        orderItemId: "item-1"
+                        platformIdBuyer: "bap.buyer-platform.example"
+                        platformIdSeller: "bpp.seller-platform.example"
+                        discomIdBuyer: "DISCOM_A"
+                        discomIdSeller: "DISCOM_B"
+                        buyerId: "CA-0000123"
+                        sellerId: "DER-9981"
+                        tradeTime: "2026-01-15T10:20:30Z"
+                        deliveryStartTime: "2026-01-15T11:00:00Z"
+                        deliveryEndTime: "2026-01-15T11:30:00Z"
+                        tradeDetails:
+                          - tradeType: ENERGY
+                            tradeQty: 12.5
+                            tradeUnit: KWH
+                            pricePerUnit: 14.5
+                            priceCurrency: INR
+                        statusBuyerDiscom: COMPLETED
+                        statusSellerDiscom: COMPLETED
+                        networkId: "indiaenergystack.in/test-ies-p2p-trading-network"
+                        rowDigest: "sha256:6d7a...f09c"
+                    count: 1
                 empty:
                   value:
                     records: []
@@ -577,6 +607,12 @@ components:
           $ref: "#/components/schemas/tradeType"
         tradeUnit:
           $ref: "#/components/schemas/tradeUnit"
+        pricePerUnit:
+          type: number
+          description: Agreed price per tradeUnit (e.g., per KWH) for this trade line
+        priceCurrency:
+          type: string
+          description: ISO 4217 currency code for pricePerUnit (e.g., INR)
 
     validationMetric:
       type: object
@@ -666,6 +702,14 @@ components:
           $ref: "#/components/schemas/tradeStatus"
         statusSellerDiscom:
           $ref: "#/components/schemas/tradeStatus"
+        networkId:
+          type: string
+          description: >
+            Identifier of the network the trade was executed on
+            (e.g., "indiaenergystack.in/p2p-trading-network").
+            By convention, a network name segment beginning with "test"
+            (e.g., "indiaenergystack.in/test-ies-p2p-trading-network")
+            marks the trade as a test trade.
         rowDigest:
           type: string
           description: Digest of the canonical row state (implementation-specific)


### PR DESCRIPTION
## What

Adds two optional read surfaces to the Contract Ledger API spec (`specification/api/deg_contract_ledger.yaml`) so ledger UI clients can display trade price and distinguish test trades:

- **`tradeDetail.pricePerUnit` + `tradeDetail.priceCurrency`** (optional) — agreed price per `tradeUnit`, mirroring the wire contract where the `PRICE_PER_KWH` interval payload sits beside `REQUESTED_QTY`. Since `ledgerPutRequest` reuses `tradeDetail`, platforms can also write these with no extra schema.
- **`ledgerRecord.networkId`** (optional) — already captured internally on every record, now exposed in `/ledger/get` responses. By convention, a network name segment beginning with `test` (e.g. `indiaenergystack.in/test-ies-p2p-trading-network`) marks the trade as a test trade; no separate boolean flag is introduced.

Also adds a populated `/ledger/get` response example demonstrating both fields, extends the `/ledger/put` example, and bumps `info.version` to 0.4.0.

## Compatibility

All new fields are optional and no `required` list changed — existing ledger UI clients and already-issued payloads remain conformant. Both spec examples validate against their schemas.

## Follow-up (out of scope here)

deg-ledgr-service needs a small change to serve these fields: the Onix requestMapper (`config/mappings/ledger-request-mappings.yaml`) currently drops `PRICE_PER_KWH` when building `tradeDetails`, and the `/ledger/get` projection (`mapDbRecordToLedgerRecord`) must pass through `networkId` and the price fields from stored details.