### PR TITLE
chore(schema): use schema.beckn.io IRIs for EvCharging v1.0 vocab namespaces

### DIFF
--- a/specification/schema/EvChargingOffer/v1.0/vocab.jsonld
+++ b/specification/schema/EvChargingOffer/v1.0/vocab.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "beckn": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/EvChargingOffer/v1.0/#",
+    "beckn": "https://schema.beckn.io/EvChargingOffer/1.0/#",
     "schema": "https://schema.org/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",

--- a/specification/schema/EvChargingPointOperator/v1.0/vocab.jsonld
+++ b/specification/schema/EvChargingPointOperator/v1.0/vocab.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "beckn": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/EvChargingPointOperator/v1.0/#",
+    "beckn": "https://schema.beckn.io/EvChargingPointOperator/1.0/#",
     "schema": "https://schema.org/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",

--- a/specification/schema/EvChargingService/v1.0/vocab.jsonld
+++ b/specification/schema/EvChargingService/v1.0/vocab.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "beckn": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/EvChargingService/v1.0/#",
+    "beckn": "https://schema.beckn.io/EvChargingService/1.0/#",
     "schema": "https://schema.org/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",

--- a/specification/schema/EvChargingSession/v1.0/vocab.jsonld
+++ b/specification/schema/EvChargingSession/v1.0/vocab.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "beckn": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/EvChargingSession/v1.0/#",
+    "beckn": "https://schema.beckn.io/EvChargingSession/1.0/#",
     "schema": "https://schema.org/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",


### PR DESCRIPTION
## What

Replaces the internal `beckn` namespace IRI in four published vocab files — the last `raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/schema/EvCharging…` references in the repo:

| File | New namespace |
|---|---|
| `EvChargingOffer/v1.0/vocab.jsonld` | `https://schema.beckn.io/EvChargingOffer/1.0/#` |
| `EvChargingSession/v1.0/vocab.jsonld` | `https://schema.beckn.io/EvChargingSession/1.0/#` |
| `EvChargingService/v1.0/vocab.jsonld` | `https://schema.beckn.io/EvChargingService/1.0/#` |
| `EvChargingPointOperator/v1.0/vocab.jsonld` | `https://schema.beckn.io/EvChargingPointOperator/1.0/#` |

## Why it's safe (conformance check)

- The namespace is **internal to each vocab**: it only mints the IRIs of the vocab's own RDF nodes (`beckn:ChargingService` → `<…/1.0/#ChargingService>`).
- The paired `context.jsonld` files map payload terms via the **relative** `"beckn": "./vocab.jsonld#"` prefix — payload expansion never touches the raw URL. `attributes.yaml` and `context.jsonld` are unchanged, so already-issued payloads and schema validation are unaffected.
- Nothing else in the repo references the old `…/v1.0/#` IRIs (verified by grep).
- Identity check requested: the published `schema.beckn.io/<Class>/1.0/vocab.jsonld` copies are byte-identical to these files pre-change; they update in lockstep when this merges. The new namespace also actually dereferences (the old raw URL was branch-layout-dependent).

Follow-up to #446/#447/#448.