### PR TITLE
chore(demand-flex): regenerate BUYER postman for enriched discover query

### DIFF
--- a/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BUYER-DEG.postman_collection.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/postman/demand-flex-uc1-bdr-w-baselining.BUYER-DEG.postman_collection.json
@@ -48,7 +48,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"context\": {\n    \"networkId\": \"{{domain}}\",\n    \"version\": \"{{version}}\",\n    \"action\": \"discover\",\n    \"bapId\": \"{{bap_id}}\",\n    \"bapUri\": \"{{bap_host_root}}/bap/receiver\",\n    \"transactionId\": \"{{transaction_id}}\",\n    \"messageId\": \"{{$guid}}\",\n    \"timestamp\": \"{{iso_date}}\"\n  },\n  \"message\": {\"intent\": {\"filters\": {\"type\": \"jsonpath\", \"expression\": \"$.catalogs[*].resources[*] ? (@.resourceAttributes.direction == 'REDUCE')\"}}}\n}",
+              "raw": "{\n  \"context\": {\n    \"networkId\": \"{{domain}}\",\n    \"version\": \"{{version}}\",\n    \"action\": \"discover\",\n    \"bapId\": \"{{bap_id}}\",\n    \"bapUri\": \"{{bap_host_root}}/bap/receiver\",\n    \"transactionId\": \"{{transaction_id}}\",\n    \"messageId\": \"{{$guid}}\",\n    \"timestamp\": \"{{iso_date}}\"\n  },\n  \"message\": {\n    \"intent\": {\n      \"filters\": {\n        \"type\": \"jsonpath\",\n        \"expression\": \"$.catalogs[*] ? (@.provider.id == 'tpddl-north-delhi' && exists(@.resources) && @.offers[*].validUntil >= '2026-03-30T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start >= '2026-04-01T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start < '2026-04-02T00:00:00Z')\"\n      }\n    }\n  }\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/devkits/demand-flex/uc2-bid-curve-pac/postman/demand-flex-uc2-bid-curve-pac.BUYER-DEG.postman_collection.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/postman/demand-flex-uc2-bid-curve-pac.BUYER-DEG.postman_collection.json
@@ -48,7 +48,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"context\": {\n    \"networkId\": \"{{domain}}\",\n    \"version\": \"{{version}}\",\n    \"action\": \"discover\",\n    \"bapId\": \"{{bap_id}}\",\n    \"bapUri\": \"{{bap_host_root}}/bap/receiver\",\n    \"transactionId\": \"{{transaction_id}}\",\n    \"messageId\": \"{{$guid}}\",\n    \"timestamp\": \"{{iso_date}}\"\n  },\n  \"message\": {\"filters\": {\"resources\": \"$.catalogs[*].resources[*] ? (@.resourceAttributes.direction == 'REDUCE')\"}}\n}",
+              "raw": "{\n  \"context\": {\n    \"networkId\": \"{{domain}}\",\n    \"version\": \"{{version}}\",\n    \"action\": \"discover\",\n    \"bapId\": \"{{bap_id}}\",\n    \"bapUri\": \"{{bap_host_root}}/bap/receiver\",\n    \"transactionId\": \"{{transaction_id}}\",\n    \"messageId\": \"{{$guid}}\",\n    \"timestamp\": \"{{iso_date}}\"\n  },\n  \"message\": {\n    \"intent\": {\n      \"filters\": {\n        \"type\": \"jsonpath\",\n        \"expression\": \"$.catalogs[*] ? (@.provider.id == 'tpddl-north-delhi' && exists(@.resources) && @.offers[*].validity.endDate >= '2026-06-13T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start >= '2026-06-15T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start < '2026-06-16T00:00:00Z')\"\n      }\n    }\n  }\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
Follow-up to #453. The enriched discover query (publisher `provider.id` + time-of-offer window) merged into the example `discover-request.json` files, but the **regenerated postman collections did not land** in that merge — main's BUYER collections still carry the old `direction`-based filter.

Regenerates both BUYER collections (SELLER collections are unaffected — discover is a buyer action) so they match the discover examples already on main.

- Diff is the discover `expression` only (verified not a `_postman_id`-only churn).
- Both collections validate 0-invalid against beckn-core (postman generator).