### PR TITLE
feat(demand-flex): enforce TimeSeries type-coverage on DemandFlexNeed in network rego

### DIFF
--- a/devkits/demand-flex/policies/demand_flex_networkpolicy.rego
+++ b/devkits/demand-flex/policies/demand_flex_networkpolicy.rego
@@ -78,6 +78,38 @@ violations contains msg if {
 	msg := sprintf("meter %s: payload type '%s' used in intervals but not declared in payloadDescriptors", [meter.meterId, payload.type])
 }
 
+# ----- 1b) DemandFlexNeed cross-field type-coverage -------------------
+# The unified DemandFlexNeed is itself a BecknTimeSeries (carried inline in
+# resourceAttributes). The beckn-onix extended schema validator resolves only a
+# single @type per object, so it cannot also validate the object against the
+# TimeSeries schema — the same structural check (1) is therefore enforced here
+# for the need series. Any resourceAttributes carrying `intervals` is treated as
+# the need TimeSeries; applies to both the bound contract and catalog publish.
+# A need with intervals but no payloadDescriptors flags every used type.
+
+_demand_flex_needs contains ra if {
+	some c in input.message.contract.commitments
+	some r in c.resources
+	ra := r.resourceAttributes
+	ra.intervals
+}
+
+_demand_flex_needs contains ra if {
+	some cat in input.message.catalogs
+	some r in cat.resources
+	ra := r.resourceAttributes
+	ra.intervals
+}
+
+violations contains msg if {
+	some ra in _demand_flex_needs
+	declared_types := {d.payloadType | some d in ra.payloadDescriptors}
+	some interval in ra.intervals
+	some payload in interval.payloads
+	not payload.type in declared_types
+	msg := sprintf("DemandFlexNeed: payload type '%s' used in intervals but not declared in payloadDescriptors", [payload.type])
+}
+
 # ----- 2a) PER_EVENT — exactly one occurrence across intervals --------
 
 violations contains msg if {

--- a/specification/policies/demand-flex-networkpolicy.rego
+++ b/specification/policies/demand-flex-networkpolicy.rego
@@ -3,12 +3,16 @@
 # Network-level gate evaluated by the BPP's `checkPolicy` step.
 # Fires NACK when `violations` is non-empty.
 #
-# The `violations` rule combines two checks:
+# The `violations` rule combines these checks:
 #
 #   1. BecknTimeSeries cross-field type-coverage. Every `payloadType`
 #      used in `intervals[*].payloads[*].type` MUST be declared in
 #      `payloadDescriptors[*].payloadType`. Catches typos like
-#      "BASELIN" or undocumented signals on the wire.
+#      "BASELIN" or undocumented signals on the wire. Applied to both
+#      per-meter telemetry (1) and the DemandFlexNeed series in
+#      resourceAttributes (1b) — the need is itself a BecknTimeSeries but
+#      beckn-onix's extended validator resolves only one @type per object,
+#      so the TimeSeries structural check is enforced here.
 #
 #   2. PER_EVENT / PER_INTERVAL cardinality against the seller's
 #      committed `reportDescriptors[]` (from
@@ -82,6 +86,38 @@ violations contains msg if {
 	some payload in interval.payloads
 	not payload.type in declared_types
 	msg := sprintf("meter %s: payload type '%s' used in intervals but not declared in payloadDescriptors", [meter.meterId, payload.type])
+}
+
+# ----- 1b) DemandFlexNeed cross-field type-coverage -------------------
+# The unified DemandFlexNeed is itself a BecknTimeSeries (carried inline in
+# resourceAttributes). The beckn-onix extended schema validator resolves only a
+# single @type per object, so it cannot also validate the object against the
+# TimeSeries schema — the same structural check (1) is therefore enforced here
+# for the need series. Any resourceAttributes carrying `intervals` is treated as
+# the need TimeSeries; applies to both the bound contract and catalog publish.
+# A need with intervals but no payloadDescriptors flags every used type.
+
+_demand_flex_needs contains ra if {
+	some c in input.message.contract.commitments
+	some r in c.resources
+	ra := r.resourceAttributes
+	ra.intervals
+}
+
+_demand_flex_needs contains ra if {
+	some cat in input.message.catalogs
+	some r in cat.resources
+	ra := r.resourceAttributes
+	ra.intervals
+}
+
+violations contains msg if {
+	some ra in _demand_flex_needs
+	declared_types := {d.payloadType | some d in ra.payloadDescriptors}
+	some interval in ra.intervals
+	some payload in interval.payloads
+	not payload.type in declared_types
+	msg := sprintf("DemandFlexNeed: payload type '%s' used in intervals but not declared in payloadDescriptors", [payload.type])
 }
 
 # ----- 2a) PER_EVENT — exactly one occurrence across intervals --------

--- a/specification/policies/test/demand-flex-networkpolicy_test.rego
+++ b/specification/policies/test/demand-flex-networkpolicy_test.rego
@@ -99,3 +99,52 @@ test_typo_isolated_to_one_meter if {
 	contains(v, "der://meter/001")
 	contains(v, "BASLN")
 }
+
+# ---------------------------------------------------------------------------
+# 1b) DemandFlexNeed cross-field type-coverage (need is itself a TimeSeries)
+# ---------------------------------------------------------------------------
+
+_valid_need := {
+	"intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
+	"payloadDescriptors": [
+		{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED"},
+		{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE"},
+		{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY"},
+	],
+	"intervals": [
+		{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+	],
+}
+
+_need_input(ra) := {"message": {"contract": {"commitments": [{"resources": [{"resourceAttributes": ra}]}]}}}
+
+# clean need → no violations
+test_need_type_coverage_ok if {
+	count(violations) == 0 with input as _need_input(_valid_need)
+}
+
+# undeclared payload type in the need → violation naming DemandFlexNeed + the type
+test_need_type_coverage_violation if {
+	bad := json.patch(_valid_need, [{"op": "add", "path": "/intervals/0/payloads/-", "value": {"type": "MYSTERY", "values": [1]}}])
+	vs := violations with input as _need_input(bad)
+	some v in vs
+	contains(v, "DemandFlexNeed")
+	contains(v, "MYSTERY")
+}
+
+# need missing payloadDescriptors → every used type flagged
+test_need_missing_descriptors_violation if {
+	bad := json.patch(_valid_need, [{"op": "remove", "path": "/payloadDescriptors"}])
+	vs := violations with input as _need_input(bad)
+	some v in vs
+	contains(v, "DemandFlexNeed")
+}
+
+# same check applies at catalog publish time
+test_need_type_coverage_catalog if {
+	bad := json.patch(_valid_need, [{"op": "add", "path": "/intervals/0/payloads/-", "value": {"type": "MYSTERY", "values": [1]}}])
+	inp := {"message": {"catalogs": [{"resources": [{"resourceAttributes": bad}]}]}}
+	vs := violations with input as inp
+	some v in vs
+	contains(v, "MYSTERY")
+}


### PR DESCRIPTION
## Why

The unified `DemandFlexNeed` is structurally a `BecknTimeSeries` carried inline in `resourceAttributes`. But beckn-onix's extended schema validator (`schemav2validator`) resolves only a **single `@type`** per object (`@type` is read as a string; an array is silently skipped), so it validates the object against the `DemandFlexNeed` component schema only — it can't *also* validate it against the `TimeSeries` schema. The TimeSeries cross-field constraint (which JSON-Schema can't express anyway) therefore has to be enforced in the rego.

## What

Applies the **same** structural check already used for per-meter telemetry — every `intervals[*].payloads[*].type` must be declared in `payloadDescriptors[*].payloadType` — to the `DemandFlexNeed` series as well (new rule **1b**):

- Covers both the bound contract (`commitments[*].resources[*].resourceAttributes`) and catalog publish (`catalogs[*].resources[*].resourceAttributes`).
- A need with `intervals` but no `payloadDescriptors` flags every used type.
- Generic (keys off `intervals` presence), so it applies to both uc1 (`CAPACITY_REQUESTED`/`PRICE`/`SHORTFALL_PENALTY`) and uc2 (`CAPACITY_REQUESTED`) needs.

Mirrored in both rego copies (spec canonical + devkit).

## Validation

- `opa test` — **9/9** on both copies (4 new tests: clean need, undeclared type, missing descriptors, catalog path).
- No false positives: verified `[]` violations against the real uc1 (publish/confirm/settled) and uc2 (confirm) example payloads.