### PR TITLE
chore: compact example payloads + sandbox fixtures (demand-flex + p2p-wave2)

### DIFF
--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/confirm-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/confirm-request.json
@@ -38,42 +38,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -85,11 +56,7 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
@@ -100,65 +67,23 @@
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN001",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Nexon EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 30.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Nexon EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:001"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:mgmotor.co.in:vin:VIN002",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "MG",
-                          "model": "ZS EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 44.5,
-                          "telemetryProvider": "mg-imotion"
-                        },
+                        "attributes": {"make": "MG", "model": "ZS EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 44.5, "telemetryProvider": "mg-imotion"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:002"]
                       }
                     ],
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "POWER",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "SOC_END",
-                        "readingType": "DIRECT_READ",
-                        "units": "KWH",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LAT",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LON",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "POWER", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SOC_END", "readingType": "DIRECT_READ", "units": "KWH", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LAT", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"}
                     ]
                   }
                 }
@@ -169,32 +94,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/discover-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/discover-request.json
@@ -11,7 +11,10 @@
   },
   "message": {
     "intent": {
-      "filters": {"type": "jsonpath", "expression": "$.catalogs[*] ? (@.provider.id == 'tpddl-north-delhi' && exists(@.resources) && @.offers[*].validUntil >= '2026-03-30T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start >= '2026-04-01T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start < '2026-04-02T00:00:00Z')"}
+      "filters": {
+        "type": "jsonpath",
+        "expression": "$.catalogs[*] ? (@.provider.id == 'tpddl-north-delhi' && exists(@.resources) && @.offers[*].validUntil >= '2026-03-30T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start >= '2026-04-01T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start < '2026-04-02T00:00:00Z')"
+      }
     }
   }
 }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/init-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/init-request.json
@@ -36,42 +36,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -83,18 +54,8 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           },
@@ -102,32 +63,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-confirm-response.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-confirm-response.json
@@ -36,42 +36,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -84,18 +55,8 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           },
@@ -103,32 +64,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-init-response.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-init-response.json
@@ -36,42 +36,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -83,18 +54,8 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           },
@@ -102,32 +63,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-select-response.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-select-response.json
@@ -35,42 +35,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -81,14 +52,7 @@
             "offerAttributes": {
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
-              "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {"role": "seller", "participantId": null}
-              ]
+              "inputs": [{"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}}, {"role": "seller", "participantId": null}]
             }
           }
         }
@@ -97,10 +61,7 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-pull.json
@@ -14,15 +14,7 @@
         "transactionId": "01ac9817-da6f-4f6f-908e-bec6f9b2b8cd",
         "messageId": "e403fe18-94ba-4986-9908-4d0d2e7f133b",
         "timestamp": "2026-04-01T10:34:30Z",
-        "tags": [
-          {
-            "descriptor": {"code": "pagination"},
-            "list": [
-              {"descriptor": {"code": "pageCursor"}, "value": "evt-bulk-001-p2"},
-              {"descriptor": {"code": "collectionId"}, "value": "perf-evt-bulk-001-actuals"}
-            ]
-          }
-        ]
+        "tags": [{"descriptor": {"code": "pagination"}, "list": [{"descriptor": {"code": "pageCursor"}, "value": "evt-bulk-001-p2"}, {"descriptor": {"code": "collectionId"}, "value": "perf-evt-bulk-001-actuals"}]}]
       },
       "message": {"ref": {"id": "contract-flex-bulk-001", "performance": [{"id": "perf-evt-bulk-001-actuals"}]}}
     },
@@ -63,42 +55,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -110,11 +73,7 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
@@ -128,25 +87,10 @@
                       "schemaContext": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/participatingMeters.jsonld",
                       "sizeBytes": 920000
                     },
-                    "participatingMetersDigest": {
-                      "count": 12000,
-                      "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"
-                    },
+                    "participatingMetersDigest": {"count": 12000, "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"},
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "BASELINE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}
                     ]
                   }
                 }
@@ -157,18 +101,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -190,23 +124,10 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}]
                 }
               },
               {
@@ -215,50 +136,22 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}]
                 }
               }
             ],
-            "pageInfo": {
-              "@type": "PageInfo",
-              "sequence": 1,
-              "pageSize": 4000,
-              "total": 12000,
-              "isLast": false,
-              "cursor": "evt-bulk-001-p2",
-              "nextCursor": "evt-bulk-001-p3",
-              "collectionId": "perf-evt-bulk-001-actuals"
-            }
+            "pageInfo": {"@type": "PageInfo", "sequence": 1, "pageSize": 4000, "total": 12000, "isLast": false, "cursor": "evt-bulk-001-p2", "nextCursor": "evt-bulk-001-p3", "collectionId": "perf-evt-bulk-001-actuals"}
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals-paged-push.json
@@ -41,42 +41,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -88,11 +59,7 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
@@ -107,25 +74,10 @@
                       "schemaContext": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/participatingMeters.jsonld",
                       "sizeBytes": 920000
                     },
-                    "participatingMetersDigest": {
-                      "count": 12000,
-                      "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"
-                    },
+                    "participatingMetersDigest": {"count": 12000, "sha256OfSortedIds": "sha256:b3a8e0e1f9ab1bfe3a14b4e95f3a0e1c2d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a"},
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "BASELINE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}
                     ]
                   }
                 }
@@ -136,18 +88,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -169,23 +111,10 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}]
                 }
               },
               {
@@ -194,48 +123,22 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}]
                 }
               }
             ],
-            "pageInfo": {
-              "@type": "PageInfo",
-              "sequence": 0,
-              "pageSize": 4000,
-              "total": 12000,
-              "isLast": false,
-              "collectionId": "perf-evt-bulk-001-actuals"
-            }
+            "pageInfo": {"@type": "PageInfo", "sequence": 0, "pageSize": 4000, "total": 12000, "isLast": false, "collectionId": "perf-evt-bulk-001-actuals"}
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-actuals.json
@@ -39,42 +39,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -86,97 +57,41 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
-                    "participatingMeters": [
-                      "did:web:tpddl.delhi.gov.in:meters:001",
-                      "did:web:tpddl.delhi.gov.in:meters:002",
-                      "did:web:tpddl.delhi.gov.in:meters:003"
-                    ],
+                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002", "did:web:tpddl.delhi.gov.in:meters:003"],
                     "energyResources": [
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN001",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Nexon EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 30.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Nexon EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:001"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:mgmotor.co.in:vin:VIN002",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "MG",
-                          "model": "ZS EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 44.5,
-                          "telemetryProvider": "mg-imotion"
-                        },
+                        "attributes": {"make": "MG", "model": "ZS EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 44.5, "telemetryProvider": "mg-imotion"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:002"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN003",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Tigor EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 26.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Tigor EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 26.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:003"]
                       }
                     ],
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "POWER",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "SOC_END",
-                        "readingType": "DIRECT_READ",
-                        "units": "KWH",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LAT",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LON",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "POWER", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SOC_END", "readingType": "DIRECT_READ", "units": "KWH", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LAT", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"}
                     ]
                   }
                 }
@@ -187,18 +102,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -219,23 +124,10 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}]
                 }
               },
               {
@@ -244,23 +136,10 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}]
                 }
               }
             ]
@@ -270,14 +149,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-baselines.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-baselines.json
@@ -39,42 +39,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -86,97 +57,41 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
-                    "participatingMeters": [
-                      "did:web:tpddl.delhi.gov.in:meters:001",
-                      "did:web:tpddl.delhi.gov.in:meters:002",
-                      "did:web:tpddl.delhi.gov.in:meters:003"
-                    ],
+                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002", "did:web:tpddl.delhi.gov.in:meters:003"],
                     "energyResources": [
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN001",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Nexon EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 30.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Nexon EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:001"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:mgmotor.co.in:vin:VIN002",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "MG",
-                          "model": "ZS EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 44.5,
-                          "telemetryProvider": "mg-imotion"
-                        },
+                        "attributes": {"make": "MG", "model": "ZS EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 44.5, "telemetryProvider": "mg-imotion"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:002"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN003",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Tigor EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 26.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Tigor EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 26.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:003"]
                       }
                     ],
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "POWER",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "SOC_END",
-                        "readingType": "DIRECT_READ",
-                        "units": "KWH",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LAT",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LON",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "POWER", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SOC_END", "readingType": "DIRECT_READ", "units": "KWH", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LAT", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"}
                     ]
                   }
                 }
@@ -187,18 +102,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -218,18 +123,8 @@
                 "telemetry": {
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-                  "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
-                  ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}
-                  ]
+                  "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"}],
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}]
                 }
               },
               {
@@ -237,18 +132,8 @@
                 "telemetry": {
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-                  "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
-                  ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}
-                  ]
+                  "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"}],
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}]
                 }
               }
             ]
@@ -258,14 +143,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-resource-telemetry.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-resource-telemetry.json
@@ -40,42 +40,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -87,90 +58,40 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
-                    "participatingMeters": [
-                      "did:web:tpddl.delhi.gov.in:meters:001",
-                      "did:web:tpddl.delhi.gov.in:meters:002",
-                      "did:web:tpddl.delhi.gov.in:meters:003"
-                    ],
+                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002", "did:web:tpddl.delhi.gov.in:meters:003"],
                     "energyResources": [
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN001",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Nexon EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 30.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Nexon EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:001"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:mgmotor.co.in:vin:VIN002",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "MG",
-                          "model": "ZS EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 44.5,
-                          "telemetryProvider": "mg-imotion"
-                        },
+                        "attributes": {"make": "MG", "model": "ZS EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 44.5, "telemetryProvider": "mg-imotion"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:002"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN003",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Tigor EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 26.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Tigor EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 26.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:003"]
                       }
                     ],
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "SOC_END",
-                        "readingType": "DIRECT_READ",
-                        "units": "KWH",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LAT",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LON",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SOC_END", "readingType": "DIRECT_READ", "units": "KWH", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LAT", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"}
                     ]
                   }
                 }
@@ -181,18 +102,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -222,15 +133,7 @@
                     {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "units": "DEGREES"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [
-                        {"type": "USAGE", "values": [1.0]},
-                        {"type": "SOC_END", "values": [20.5]},
-                        {"type": "GPS_LAT", "values": [28.6139]},
-                        {"type": "GPS_LON", "values": [77.209]}
-                      ]
-                    },
+                    {"id": 0, "payloads": [{"type": "USAGE", "values": [1.0]}, {"type": "SOC_END", "values": [20.5]}, {"type": "GPS_LAT", "values": [28.6139]}, {"type": "GPS_LON", "values": [77.209]}]},
                     {"id": 1, "payloads": [{"type": "USAGE", "values": [1.0]}, {"type": "SOC_END", "values": [21.0]}]},
                     {"id": 2, "payloads": [{"type": "USAGE", "values": [1.0]}, {"type": "SOC_END", "values": [21.5]}]},
                     {"id": 3, "payloads": [{"type": "USAGE", "values": [1.0]}, {"type": "SOC_END", "values": [22.0]}]}
@@ -249,15 +152,7 @@
                     {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "units": "DEGREES"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [
-                        {"type": "USAGE", "values": [0.0]},
-                        {"type": "SOC_END", "values": [31.0]},
-                        {"type": "GPS_LAT", "values": [28.628]},
-                        {"type": "GPS_LON", "values": [77.241]}
-                      ]
-                    },
+                    {"id": 0, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [31.0]}, {"type": "GPS_LAT", "values": [28.628]}, {"type": "GPS_LON", "values": [77.241]}]},
                     {"id": 1, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [31.0]}]},
                     {"id": 2, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [31.0]}]},
                     {"id": 3, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [31.0]}]}
@@ -276,15 +171,7 @@
                     {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "units": "DEGREES"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [
-                        {"type": "USAGE", "values": [0.0]},
-                        {"type": "SOC_END", "values": [12.5]},
-                        {"type": "GPS_LAT", "values": [28.545]},
-                        {"type": "GPS_LON", "values": [77.1925]}
-                      ]
-                    },
+                    {"id": 0, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [12.5]}, {"type": "GPS_LAT", "values": [28.545]}, {"type": "GPS_LON", "values": [77.1925]}]},
                     {"id": 1, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [12.0]}]},
                     {"id": 2, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [11.5]}]},
                     {"id": 3, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [11.0]}]}
@@ -298,14 +185,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-settled.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/on-status-response-settled.json
@@ -37,42 +37,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -85,18 +56,8 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           },
@@ -104,18 +65,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -136,23 +87,10 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [50]}]}]
                 }
               },
               {
@@ -161,23 +99,10 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}
-                  ]
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}, {"type": "USAGE", "values": [5]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}, {"type": "USAGE", "values": [45]}]}]
                 }
               }
             ]
@@ -187,14 +112,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        },
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"},
         "revenueFlows": [
           {"role": "buyer", "value": -436.25, "currency": "INR", "description": "Net payable across 2 flex slots"},
           {"role": "seller", "value": 436.25, "currency": "INR", "description": "Net receivable across 2 flex slots"}

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/publish-catalog.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/publish-catalog.json
@@ -8,21 +8,10 @@
     "transactionId": "b1c2d3e4-f5a6-7890-abcd-ef1122334455",
     "messageId": "c1d2e3f4-a5b6-7890-abcd-ef2233445566",
     "timestamp": "2026-03-28T06:00:00Z",
-    "schemaContext": [
-      "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
-      "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld",
-      "https://schema.nfh.global/DEGContract/v2.0/context.jsonld"
-    ]
+    "schemaContext": ["https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld", "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld", "https://schema.nfh.global/DEGContract/v2.0/context.jsonld"]
   },
   "message": {
-    "publishDirectives": [
-      {
-        "catalogId": "catalog-flex-tpddl-2026-04",
-        "catalogType": "REGULAR",
-        "updateMode": "MERGE",
-        "visibleTo": ["nfh.global/testnet-deg"]
-      }
-    ],
+    "publishDirectives": [{"catalogId": "catalog-flex-tpddl-2026-04", "catalogType": "REGULAR", "updateMode": "MERGE", "visibleTo": ["nfh.global/testnet-deg"]}],
     "catalogs": [
       {
         "id": "catalog-flex-tpddl-2026-04",
@@ -33,10 +22,7 @@
         "resources": [
           {
             "id": "flex-need-north-delhi-apr1",
-            "descriptor": {
-              "name": "Peak Demand Flex - North Delhi",
-              "shortDesc": "Two 30-min procurement tranches, Apr 1 08:30-09:30 UTC"
-            },
+            "descriptor": {"name": "Peak Demand Flex - North Delhi", "shortDesc": "Two 30-min procurement tranches, Apr 1 08:30-09:30 UTC"},
             "quantity": {"unitCode": "kW", "unitQuantity": 200, "@type": "Quantity"},
             "resourceAttributes": {
               "@context": "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld",
@@ -44,42 +30,13 @@
               "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
               "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
               "payloadDescriptors": [
-                {
-                  "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                  "payloadType": "CAPACITY_REQUESTED",
-                  "units": "KW",
-                  "insertedBy": "buyer"
-                },
-                {
-                  "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                  "payloadType": "PRICE",
-                  "units": "INR_PER_KWH",
-                  "insertedBy": "buyer"
-                },
-                {
-                  "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                  "payloadType": "SHORTFALL_PENALTY",
-                  "units": "INR_PER_KWH",
-                  "insertedBy": "buyer"
-                }
+                {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
               ],
               "intervals": [
-                {
-                  "id": 0,
-                  "payloads": [
-                    {"type": "CAPACITY_REQUESTED", "values": [150]},
-                    {"type": "PRICE", "values": [3.5]},
-                    {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                  ]
-                },
-                {
-                  "id": 1,
-                  "payloads": [
-                    {"type": "CAPACITY_REQUESTED", "values": [200]},
-                    {"type": "PRICE", "values": [4.0]},
-                    {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                  ]
-                }
+                {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
               ]
             }
           }
@@ -87,10 +44,7 @@
         "offers": [
           {
             "id": "offer-flex-001",
-            "descriptor": {
-              "name": "North Delhi Evening Flex",
-              "shortDesc": "Apply per-slot capacity against the published tranche prices"
-            },
+            "descriptor": {"name": "North Delhi Evening Flex", "shortDesc": "Apply per-slot capacity against the published tranche prices"},
             "resourceIds": ["flex-need-north-delhi-apr1"],
             "validUntil": "2026-03-31T08:30:00Z",
             "availableTo": [],
@@ -101,19 +55,9 @@
                 "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
                 "@type": "DEGContract",
                 "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-                "policy": {
-                  "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-                  "queryPath": "data.deg.contracts.demand_flex"
-                }
+                "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
               },
-              "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {"role": "seller", "participantId": null}
-              ]
+              "inputs": [{"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}}, {"role": "seller", "participantId": null}]
             }
           }
         ]

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/select-request.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/select-request.json
@@ -34,42 +34,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -80,14 +51,7 @@
             "offerAttributes": {
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
-              "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {"role": "seller", "participantId": null}
-              ]
+              "inputs": [{"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}}, {"role": "seller", "participantId": null}]
             }
           }
         }
@@ -96,10 +60,7 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/examples/update-request-opt-in.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/examples/update-request-opt-in.json
@@ -35,42 +35,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -82,21 +53,11 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": [
-                      "did:web:tpddl.delhi.gov.in:meters:001",
-                      "did:web:tpddl.delhi.gov.in:meters:002",
-                      "did:web:tpddl.delhi.gov.in:meters:003"
-                    ]
-                  }
+                  "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002", "did:web:tpddl.delhi.gov.in:meters:003"]}
                 }
               ]
             }
@@ -105,32 +66,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_confirm.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_confirm.json
@@ -39,42 +39,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -86,11 +57,7 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
@@ -101,65 +68,23 @@
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN001",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Nexon EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 30.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Nexon EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:001"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:mgmotor.co.in:vin:VIN002",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "MG",
-                          "model": "ZS EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 44.5,
-                          "telemetryProvider": "mg-imotion"
-                        },
+                        "attributes": {"make": "MG", "model": "ZS EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 44.5, "telemetryProvider": "mg-imotion"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:002"]
                       }
                     ],
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "POWER",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "SOC_END",
-                        "readingType": "DIRECT_READ",
-                        "units": "KWH",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LAT",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LON",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "POWER", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SOC_END", "readingType": "DIRECT_READ", "units": "KWH", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LAT", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"}
                     ]
                   }
                 }
@@ -170,32 +95,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_init.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_init.json
@@ -36,42 +36,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -83,18 +54,8 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           },
@@ -102,32 +63,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_select.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_select.json
@@ -35,42 +35,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -81,14 +52,7 @@
             "offerAttributes": {
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
-              "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {"role": "seller", "participantId": null}
-              ]
+              "inputs": [{"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}}, {"role": "seller", "participantId": null}]
             }
           }
         }
@@ -97,10 +61,7 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_status.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_status.json
@@ -37,42 +37,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -84,21 +55,11 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": [
-                      "did:web:tpddl.delhi.gov.in:meters:001",
-                      "did:web:tpddl.delhi.gov.in:meters:002",
-                      "did:web:tpddl.delhi.gov.in:meters:003"
-                    ]
-                  }
+                  "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002", "did:web:tpddl.delhi.gov.in:meters:003"]}
                 }
               ]
             }
@@ -107,18 +68,8 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
@@ -138,18 +89,8 @@
                 "telemetry": {
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-                  "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
-                  ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}
-                  ]
+                  "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"}],
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}]
                 }
               },
               {
@@ -157,18 +98,8 @@
                 "telemetry": {
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-                  "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
-                  ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}
-                  ]
+                  "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"}],
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [75]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [100]}]}]
                 }
               }
             ]
@@ -178,14 +109,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_update.json
+++ b/devkits/demand-flex/uc1-bdr-w-baselining/responses/bpp/on_update.json
@@ -37,42 +37,13 @@
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
                 "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "PRICE",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  },
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "SHORTFALL_PENALTY",
-                    "units": "INR_PER_KWH",
-                    "insertedBy": "buyer"
-                  }
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"},
+                  {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY", "units": "INR_PER_KWH", "insertedBy": "buyer"}
                 ],
                 "intervals": [
-                  {
-                    "id": 0,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [150]},
-                      {"type": "PRICE", "values": [3.5]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  },
-                  {
-                    "id": 1,
-                    "payloads": [
-                      {"type": "CAPACITY_REQUESTED", "values": [200]},
-                      {"type": "PRICE", "values": [4.0]},
-                      {"type": "SHORTFALL_PENALTY", "values": [1.5]}
-                    ]
-                  }
+                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}
                 ]
               }
             }
@@ -84,18 +55,8 @@
               "@context": "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
               "@type": "DemandFlexBuyOffer",
               "inputs": [
-                {
-                  "role": "buyer",
-                  "participantId": "tpddl-north-delhi",
-                  "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}
-                },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "buyer", "participantId": "tpddl-north-delhi", "inputs": {"currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}}},
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           },
@@ -103,32 +64,16 @@
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
-            "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
-            ],
-            "intervals": [
-              {"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
-              {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}
-            ]
+            "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}],
+            "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]}]
           }
         }
       ],
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/confirm-request.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/confirm-request.json
@@ -37,18 +37,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -62,28 +52,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -94,34 +70,12 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}]}
             ]
           }
         }
@@ -129,14 +83,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -147,12 +95,7 @@
             "@type": "SettlementTerm",
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/discover-request.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/discover-request.json
@@ -9,5 +9,12 @@
     "messageId": "e2f3a4b5-c6d7-8901-abcd-ef7890123456",
     "timestamp": "2026-06-14T09:00:00Z"
   },
-  "message": {"intent": {"filters": {"type": "jsonpath", "expression": "$.catalogs[*] ? (@.provider.id == 'tpddl-north-delhi' && exists(@.resources) && @.offers[*].validity.endDate >= '2026-06-13T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start >= '2026-06-15T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start < '2026-06-16T00:00:00Z')"}}}
+  "message": {
+    "intent": {
+      "filters": {
+        "type": "jsonpath",
+        "expression": "$.catalogs[*] ? (@.provider.id == 'tpddl-north-delhi' && exists(@.resources) && @.offers[*].validity.endDate >= '2026-06-13T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start >= '2026-06-15T00:00:00Z' && @.resources[*].resourceAttributes.intervalPeriod.start < '2026-06-16T00:00:00Z')"
+      }
+    }
+  }
 }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/init-request.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/init-request.json
@@ -35,18 +35,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -60,21 +50,9 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           }
@@ -83,14 +61,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -101,12 +73,7 @@
             "@type": "SettlementTerm",
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-confirm-response.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-confirm-response.json
@@ -38,18 +38,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -63,28 +53,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -95,50 +71,14 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_CLEARED",
-                "units": "KW",
-                "insertedBy": "buyer"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CLEARING_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "buyer"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_CLEARED", "units": "KW", "insertedBy": "buyer"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CLEARING_PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]},
-                  {"type": "CAPACITY_CLEARED", "values": [50]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]},
-                  {"type": "CAPACITY_CLEARED", "values": [45]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}, {"type": "CAPACITY_CLEARED", "values": [50]}, {"type": "CLEARING_PRICE", "values": [3.5]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}, {"type": "CAPACITY_CLEARED", "values": [45]}, {"type": "CLEARING_PRICE", "values": [3.5]}]}
             ]
           }
         }
@@ -146,14 +86,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -165,12 +99,7 @@
             "amount": {"currency": "INR", "value": 332.5},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-init-response.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-init-response.json
@@ -35,18 +35,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -60,21 +50,9 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           }
@@ -83,14 +61,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -101,12 +73,7 @@
             "@type": "SettlementTerm",
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-select-response.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-select-response.json
@@ -34,18 +34,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -59,13 +49,7 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {"role": "seller", "participantId": null}
               ]
@@ -77,10 +61,7 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}]
     }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-actuals.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-actuals.json
@@ -38,18 +38,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -63,28 +53,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -95,50 +71,14 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_CLEARED",
-                "units": "KW",
-                "insertedBy": "buyer"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CLEARING_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "buyer"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_CLEARED", "units": "KW", "insertedBy": "buyer"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CLEARING_PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]},
-                  {"type": "CAPACITY_CLEARED", "values": [50]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]},
-                  {"type": "CAPACITY_CLEARED", "values": [45]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}, {"type": "CAPACITY_CLEARED", "values": [50]}, {"type": "CLEARING_PRICE", "values": [3.5]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}, {"type": "CAPACITY_CLEARED", "values": [45]}, {"type": "CLEARING_PRICE", "values": [3.5]}]}
             ]
           }
         }
@@ -160,28 +100,12 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [{"type": "BASELINE", "values": [55.0]}, {"type": "USAGE", "values": [30.0]}]
-                    },
-                    {
-                      "id": 1,
-                      "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [27.5]}]
-                    }
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [55.0]}, {"type": "USAGE", "values": [30.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [27.5]}]}
                   ]
                 }
               },
@@ -191,28 +115,12 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [25.0]}]
-                    },
-                    {
-                      "id": 1,
-                      "payloads": [{"type": "BASELINE", "values": [45.0]}, {"type": "USAGE", "values": [22.5]}]
-                    }
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [25.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [45.0]}, {"type": "USAGE", "values": [22.5]}]}
                   ]
                 }
               }
@@ -223,14 +131,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -242,12 +144,7 @@
             "amount": {"currency": "INR", "value": 332.5},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-baselines.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-baselines.json
@@ -38,18 +38,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -63,28 +53,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -95,50 +71,14 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_CLEARED",
-                "units": "KW",
-                "insertedBy": "buyer"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CLEARING_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "buyer"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_CLEARED", "units": "KW", "insertedBy": "buyer"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CLEARING_PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]},
-                  {"type": "CAPACITY_CLEARED", "values": [50]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]},
-                  {"type": "CAPACITY_CLEARED", "values": [45]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}, {"type": "CAPACITY_CLEARED", "values": [50]}, {"type": "CLEARING_PRICE", "values": [3.5]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}, {"type": "CAPACITY_CLEARED", "values": [45]}, {"type": "CLEARING_PRICE", "values": [3.5]}]}
             ]
           }
         }
@@ -159,18 +99,8 @@
                 "telemetry": {
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                  "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
-                  ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [55.0]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [50.0]}]}
-                  ]
+                  "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"}],
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [55.0]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [50.0]}]}]
                 }
               },
               {
@@ -178,18 +108,8 @@
                 "telemetry": {
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                  "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
-                  ],
-                  "intervals": [
-                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [50.0]}]},
-                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [45.0]}]}
-                  ]
+                  "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"}],
+                  "intervals": [{"id": 0, "payloads": [{"type": "BASELINE", "values": [50.0]}]}, {"id": 1, "payloads": [{"type": "BASELINE", "values": [45.0]}]}]
                 }
               }
             ]
@@ -199,14 +119,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -218,12 +132,7 @@
             "amount": {"currency": "INR", "value": 332.5},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-resource-telemetry.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-resource-telemetry.json
@@ -39,18 +39,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -64,13 +54,7 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
@@ -82,58 +66,22 @@
                         "@type": "EnergyResource",
                         "id": "did:web:tatamotors.com:vin:VIN001",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "Tata",
-                          "model": "Nexon EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 30.0,
-                          "telemetryProvider": "tata-evp-telematics"
-                        },
+                        "attributes": {"make": "Tata", "model": "Nexon EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 30.0, "telemetryProvider": "tata-evp-telematics"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:001"]
                       },
                       {
                         "@type": "EnergyResource",
                         "id": "did:web:mgmotor.co.in:vin:VIN002",
                         "type": "EV_CHARGER",
-                        "attributes": {
-                          "make": "MG",
-                          "model": "ZS EV",
-                          "ratedPowerKw": 7.0,
-                          "energyCapacityKwh": 44.5,
-                          "telemetryProvider": "mg-imotion"
-                        },
+                        "attributes": {"make": "MG", "model": "ZS EV", "ratedPowerKw": 7.0, "energyCapacityKwh": 44.5, "telemetryProvider": "mg-imotion"},
                         "parentResources": ["did:web:tpddl.delhi.gov.in:meters:002"]
                       }
                     ],
                     "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "SOC_END",
-                        "readingType": "DIRECT_READ",
-                        "units": "KWH",
-                        "cardinality": "PER_INTERVAL"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LAT",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      },
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "GPS_LON",
-                        "readingType": "DIRECT_READ",
-                        "units": "DEGREES",
-                        "cardinality": "PER_EVENT"
-                      }
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SOC_END", "readingType": "DIRECT_READ", "units": "KWH", "cardinality": "PER_INTERVAL"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LAT", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"},
+                      {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "readingType": "DIRECT_READ", "units": "DEGREES", "cardinality": "PER_EVENT"}
                     ]
                   }
                 }
@@ -168,15 +116,7 @@
                     {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "units": "DEGREES"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [
-                        {"type": "USAGE", "values": [1.0]},
-                        {"type": "SOC_END", "values": [20.5]},
-                        {"type": "GPS_LAT", "values": [28.6139]},
-                        {"type": "GPS_LON", "values": [77.209]}
-                      ]
-                    },
+                    {"id": 0, "payloads": [{"type": "USAGE", "values": [1.0]}, {"type": "SOC_END", "values": [20.5]}, {"type": "GPS_LAT", "values": [28.6139]}, {"type": "GPS_LON", "values": [77.209]}]},
                     {"id": 1, "payloads": [{"type": "USAGE", "values": [1.0]}, {"type": "SOC_END", "values": [21.5]}]}
                   ]
                 }
@@ -193,15 +133,7 @@
                     {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "GPS_LON", "units": "DEGREES"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [
-                        {"type": "USAGE", "values": [0.0]},
-                        {"type": "SOC_END", "values": [31.0]},
-                        {"type": "GPS_LAT", "values": [28.628]},
-                        {"type": "GPS_LON", "values": [77.241]}
-                      ]
-                    },
+                    {"id": 0, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [31.0]}, {"type": "GPS_LAT", "values": [28.628]}, {"type": "GPS_LON", "values": [77.241]}]},
                     {"id": 1, "payloads": [{"type": "USAGE", "values": [0.0]}, {"type": "SOC_END", "values": [31.0]}]}
                   ]
                 }
@@ -213,14 +145,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}]
     }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-settled.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/on-status-response-settled.json
@@ -39,18 +39,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -64,28 +54,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -96,50 +72,14 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_CLEARED",
-                "units": "KW",
-                "insertedBy": "buyer"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CLEARING_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "buyer"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_CLEARED", "units": "KW", "insertedBy": "buyer"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CLEARING_PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]},
-                  {"type": "CAPACITY_CLEARED", "values": [50]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]},
-                  {"type": "CAPACITY_CLEARED", "values": [45]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}, {"type": "CAPACITY_CLEARED", "values": [50]}, {"type": "CLEARING_PRICE", "values": [3.5]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}, {"type": "CAPACITY_CLEARED", "values": [45]}, {"type": "CLEARING_PRICE", "values": [3.5]}]}
             ]
           }
         }
@@ -161,28 +101,12 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [{"type": "BASELINE", "values": [55.0]}, {"type": "USAGE", "values": [30.0]}]
-                    },
-                    {
-                      "id": 1,
-                      "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [27.5]}]
-                    }
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [55.0]}, {"type": "USAGE", "values": [30.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [27.5]}]}
                   ]
                 }
               },
@@ -192,28 +116,12 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [25.0]}]
-                    },
-                    {
-                      "id": 1,
-                      "payloads": [{"type": "BASELINE", "values": [45.0]}, {"type": "USAGE", "values": [22.5]}]
-                    }
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [25.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [45.0]}, {"type": "USAGE", "values": [22.5]}]}
                   ]
                 }
               }
@@ -224,14 +132,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -243,12 +145,7 @@
             "amount": {"currency": "INR", "value": 332.5},
             "settlementStatus": "COMPLETE",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         },
@@ -258,18 +155,8 @@
             "@context": "https://schema.nfh.global/RevenueFlow/v2.0/context.jsonld",
             "@type": "RevenueFlow",
             "revenueFlows": [
-              {
-                "role": "seller",
-                "value": 332.5,
-                "currency": "INR",
-                "description": "PAC clearing payment to GreenFlex Aggregator"
-              },
-              {
-                "role": "buyer",
-                "value": -332.5,
-                "currency": "INR",
-                "description": "PAC clearing cost to TPDDL North Delhi"
-              }
+              {"role": "seller", "value": 332.5, "currency": "INR", "description": "PAC clearing payment to GreenFlex Aggregator"},
+              {"role": "buyer", "value": -332.5, "currency": "INR", "description": "PAC clearing cost to TPDDL North Delhi"}
             ]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/publish-catalog.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/publish-catalog.json
@@ -8,21 +8,10 @@
     "transactionId": "c2d3e4f5-a6b7-8901-abcd-ef5678901234",
     "messageId": "d1e2f3a4-b5c6-7890-abcd-ef6789012345",
     "timestamp": "2026-06-14T08:00:00Z",
-    "schemaContext": [
-      "https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld",
-      "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld",
-      "https://schema.nfh.global/Quantity/context.jsonld"
-    ]
+    "schemaContext": ["https://schema.nfh.global/DemandFlexBuyOffer/v2.0/context.jsonld", "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld", "https://schema.nfh.global/Quantity/context.jsonld"]
   },
   "message": {
-    "publishDirectives": [
-      {
-        "catalogId": "catalog-flex-tpddl-2026-06",
-        "catalogType": "REGULAR",
-        "updateMode": "MERGE",
-        "visibleTo": ["nfh.global/testnet-deg"]
-      }
-    ],
+    "publishDirectives": [{"catalogId": "catalog-flex-tpddl-2026-06", "catalogType": "REGULAR", "updateMode": "MERGE", "visibleTo": ["nfh.global/testnet-deg"]}],
     "catalogs": [
       {
         "id": "catalog-flex-tpddl-2026-06",
@@ -33,37 +22,21 @@
         "resources": [
           {
             "id": "flex-need-north-delhi-jun15",
-            "descriptor": {
-              "name": "Evening Peak Demand Flex - North Delhi",
-              "shortDesc": "200 kW curtailment needed Jun 15, 7-9pm IST"
-            },
+            "descriptor": {"name": "Evening Peak Demand Flex - North Delhi", "shortDesc": "200 kW curtailment needed Jun 15, 7-9pm IST"},
             "resourceAttributes": {
               "@context": "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld",
               "@type": "DemandFlexNeed",
               "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
               "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-              "payloadDescriptors": [
-                {
-                  "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                  "payloadType": "CAPACITY_REQUESTED",
-                  "units": "KW",
-                  "insertedBy": "buyer"
-                }
-              ],
-              "intervals": [
-                {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-              ]
+              "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+              "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
             }
           }
         ],
         "offers": [
           {
             "id": "offer-pac-001",
-            "descriptor": {
-              "name": "Pay-As-Clear Demand Flex Auction",
-              "shortDesc": "Submit a bid curve per hour; clearing price set by market at 5:30pm IST"
-            },
+            "descriptor": {"name": "Pay-As-Clear Demand Flex Auction", "shortDesc": "Submit a bid curve per hour; clearing price set by market at 5:30pm IST"},
             "resourceIds": ["flex-need-north-delhi-jun15"],
             "validity": {"startDate": "2026-06-14T00:00:00Z", "endDate": "2026-06-15T12:00:00Z"},
             "availableTo": [],
@@ -74,22 +47,13 @@
                 "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
                 "@type": "DEGContract",
                 "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-                "policy": {
-                  "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-                  "queryPath": "data.deg.contracts.demand_flex_pac"
-                }
+                "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
               },
               "inputs": [
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {"role": "seller", "participantId": null}
               ]

--- a/devkits/demand-flex/uc2-bid-curve-pac/examples/select-request.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/examples/select-request.json
@@ -26,28 +26,15 @@
           "resources": [
             {
               "id": "flex-need-north-delhi-jun15",
-              "descriptor": {
-                "name": "Evening Peak Demand Flex - North Delhi",
-                "shortDesc": "200 kW curtailment needed Jun 15, 7-9pm IST"
-              },
+              "descriptor": {"name": "Evening Peak Demand Flex - North Delhi", "shortDesc": "200 kW curtailment needed Jun 15, 7-9pm IST"},
               "quantity": {"unitCode": "kW", "unitQuantity": 90, "@type": "Quantity"},
               "resourceAttributes": {
                 "@context": "https://schema.nfh.global/DemandFlexNeed/v2.0/context.jsonld",
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -61,13 +48,7 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {"role": "seller", "participantId": null}
               ]
@@ -79,10 +60,7 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}]
     }

--- a/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_confirm.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_confirm.json
@@ -38,18 +38,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -63,28 +53,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -95,50 +71,14 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_CLEARED",
-                "units": "KW",
-                "insertedBy": "buyer"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CLEARING_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "buyer"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_CLEARED", "units": "KW", "insertedBy": "buyer"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CLEARING_PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]},
-                  {"type": "CAPACITY_CLEARED", "values": [50]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]},
-                  {"type": "CAPACITY_CLEARED", "values": [45]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}, {"type": "CAPACITY_CLEARED", "values": [50]}, {"type": "CLEARING_PRICE", "values": [3.5]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}, {"type": "CAPACITY_CLEARED", "values": [45]}, {"type": "CLEARING_PRICE", "values": [3.5]}]}
             ]
           }
         }
@@ -146,14 +86,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -165,12 +99,7 @@
             "amount": {"currency": "INR", "value": 332.5},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_init.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_init.json
@@ -35,18 +35,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -60,21 +50,9 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
-                {
-                  "role": "seller",
-                  "participantId": "greenflex-agg",
-                  "inputs": {
-                    "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]
-                  }
-                }
+                {"role": "seller", "participantId": "greenflex-agg", "inputs": {"participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"]}}
               ]
             }
           }
@@ -83,14 +61,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -101,12 +73,7 @@
             "@type": "SettlementTerm",
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_select.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_select.json
@@ -34,18 +34,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -59,13 +49,7 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {"role": "seller", "participantId": null}
               ]
@@ -77,10 +61,7 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": null}],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}]
     }

--- a/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_status.json
+++ b/devkits/demand-flex/uc2-bid-curve-pac/responses/bpp/on_status.json
@@ -38,18 +38,8 @@
                 "@type": "DemandFlexNeed",
                 "location": {"geo": {"type": "Point", "coordinates": [77.209, 28.6139]}},
                 "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
-                "payloadDescriptors": [
-                  {
-                    "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                    "payloadType": "CAPACITY_REQUESTED",
-                    "units": "KW",
-                    "insertedBy": "buyer"
-                  }
-                ],
-                "intervals": [
-                  {"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]},
-                  {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}
-                ]
+                "payloadDescriptors": [{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_REQUESTED", "units": "KW", "insertedBy": "buyer"}],
+                "intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}, {"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}]}]
               }
             }
           ],
@@ -63,28 +53,14 @@
                 {
                   "role": "buyer",
                   "participantId": "tpddl-north-delhi",
-                  "inputs": {
-                    "clearingMethod": "PAY-AS-CLEAR",
-                    "clearingTime": "2026-06-15T12:00:00Z",
-                    "currency": "INR",
-                    "baselineMethodology": {"bestOf": 5, "outOf": 10},
-                    "penaltyRate": 0.5
-                  }
+                  "inputs": {"clearingMethod": "PAY-AS-CLEAR", "clearingTime": "2026-06-15T12:00:00Z", "currency": "INR", "baselineMethodology": {"bestOf": 5, "outOf": 10}, "penaltyRate": 0.5}
                 },
                 {
                   "role": "seller",
                   "participantId": "greenflex-agg",
                   "inputs": {
                     "participatingMeters": ["did:web:tpddl.delhi.gov.in:meters:001", "did:web:tpddl.delhi.gov.in:meters:002"],
-                    "reportDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "USAGE",
-                        "readingType": "DIRECT_READ",
-                        "units": "KW",
-                        "cardinality": "PER_INTERVAL"
-                      }
-                    ]
+                    "reportDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "readingType": "DIRECT_READ", "units": "KW", "cardinality": "PER_INTERVAL"}]
                   }
                 }
               ]
@@ -95,50 +71,14 @@
             "@type": "TimeSeries",
             "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "OFFER_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_OFFERED",
-                "units": "KW",
-                "insertedBy": "seller"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CAPACITY_CLEARED",
-                "units": "KW",
-                "insertedBy": "buyer"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "CLEARING_PRICE",
-                "units": "INR_PER_KWH",
-                "insertedBy": "buyer"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "OFFER_PRICE", "units": "INR_PER_KWH", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_OFFERED", "units": "KW", "insertedBy": "seller"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CAPACITY_CLEARED", "units": "KW", "insertedBy": "buyer"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "CLEARING_PRICE", "units": "INR_PER_KWH", "insertedBy": "buyer"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]},
-                  {"type": "CAPACITY_CLEARED", "values": [50]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]},
-                  {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]},
-                  {"type": "CAPACITY_CLEARED", "values": [45]},
-                  {"type": "CLEARING_PRICE", "values": [3.5]}
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [90, 70, 50, 30]}, {"type": "CAPACITY_CLEARED", "values": [50]}, {"type": "CLEARING_PRICE", "values": [3.5]}]},
+              {"id": 1, "payloads": [{"type": "OFFER_PRICE", "values": [1.5, 2.5, 3.5, 5.0]}, {"type": "CAPACITY_OFFERED", "values": [80, 60, 45, 25]}, {"type": "CAPACITY_CLEARED", "values": [45]}, {"type": "CLEARING_PRICE", "values": [3.5]}]}
             ]
           }
         }
@@ -160,28 +100,12 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [{"type": "BASELINE", "values": [55.0]}, {"type": "USAGE", "values": [30.0]}]
-                    },
-                    {
-                      "id": 1,
-                      "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [27.5]}]
-                    }
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [55.0]}, {"type": "USAGE", "values": [30.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [27.5]}]}
                   ]
                 }
               },
@@ -191,28 +115,12 @@
                   "@type": "TimeSeries",
                   "intervalPeriod": {"start": "2026-06-15T13:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "BASELINE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    },
-                    {
-                      "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                      "payloadType": "USAGE",
-                      "units": "KW",
-                      "readingType": "DIRECT_READ"
-                    }
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BASELINE", "units": "KW", "readingType": "DIRECT_READ"},
+                    {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "USAGE", "units": "KW", "readingType": "DIRECT_READ"}
                   ],
                   "intervals": [
-                    {
-                      "id": 0,
-                      "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [25.0]}]
-                    },
-                    {
-                      "id": 1,
-                      "payloads": [{"type": "BASELINE", "values": [45.0]}, {"type": "USAGE", "values": [22.5]}]
-                    }
+                    {"id": 0, "payloads": [{"type": "BASELINE", "values": [50.0]}, {"type": "USAGE", "values": [25.0]}]},
+                    {"id": 1, "payloads": [{"type": "BASELINE", "values": [45.0]}, {"type": "USAGE", "values": [22.5]}]}
                   ]
                 }
               }
@@ -223,14 +131,8 @@
       "contractAttributes": {
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
-        "roles": [
-          {"role": "buyer", "participantId": "tpddl-north-delhi"},
-          {"role": "seller", "participantId": "greenflex-agg"}
-        ],
-        "policy": {
-          "url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego",
-          "queryPath": "data.deg.contracts.demand_flex_pac"
-        }
+        "roles": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
+        "policy": {"url": "https://raw.githubusercontent.com/beckn/DEG/refs/heads/main/specification/policies/demand-flex-pac-contractpolicy.rego", "queryPath": "data.deg.contracts.demand_flex_pac"}
       },
       "participants": [{"role": "buyer", "participantId": "tpddl-north-delhi"}, {"role": "seller", "participantId": "greenflex-agg"}],
       "consideration": [
@@ -242,12 +144,7 @@
             "amount": {"currency": "INR", "value": 332.5},
             "settlementStatus": "PENDING",
             "paymentTrigger": "ON_FULFILLMENT",
-            "payTo": {
-              "accountHolderName": "GreenFlex Aggregator Pvt Ltd",
-              "accountNumber": "4567890123456",
-              "branchCode": "ICIC0002345",
-              "bankName": "ICICI Bank"
-            },
+            "payTo": {"accountHolderName": "GreenFlex Aggregator Pvt Ltd", "accountNumber": "4567890123456", "branchCode": "ICIC0002345", "bankName": "ICICI Bank"},
             "acceptedPaymentMethods": ["BANK_TRANSFER"]
           }
         }

--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_confirm.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_confirm.json
@@ -11,7 +11,5 @@
     "messageId": "0eb2efea-cdf5-4e7d-a8c2-bafe23453ff3",
     "timestamp": "2026-04-25T10:10:10Z"
   },
-  "message": {
-    "ack": { "status": "ACK" }
-  }
+  "message": {"ack": {"status": "ACK"}}
 }

--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status.json
@@ -21,168 +21,36 @@
   "message": {
     "contract": {
       "id": "contract-p2p-001",
-      "status": {
-        "code": "ACTIVE"
-      },
+      "status": {"code": "ACTIVE"},
       "commitments": [
         {
           "id": "commitment-p2p-001",
-          "status": {
-            "descriptor": {
-              "code": "ACTIVE"
-            }
-          },
+          "status": {"descriptor": {"code": "ACTIVE"}},
           "resources": [
             {
               "id": "energy-resource-solar-001",
-              "descriptor": {
-                "name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"
-              },
-              "quantity": {
-                "@type": "Quantity",
-                "unitCode": "KWH",
-                "unitQuantity": 35.0
-              },
-              "resourceAttributes": {
-                "@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld",
-                "@type": "EnergyResource",
-                "type": "SOLAR",
-                "id": "TEST_METER_SELLER_001"
-              }
+              "descriptor": {"name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"},
+              "quantity": {"@type": "Quantity", "unitCode": "KWH", "unitQuantity": 35.0},
+              "resourceAttributes": {"@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld", "@type": "EnergyResource", "type": "SOLAR", "id": "TEST_METER_SELLER_001"}
             }
           ],
-          "offer": {
-            "id": "offer-p2p-001",
-            "resourceIds": [
-              "energy-resource-solar-001"
-            ]
-          },
+          "offer": {"id": "offer-p2p-001", "resourceIds": ["energy-resource-solar-001"]},
           "commitmentAttributes": {
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
-            "intervalPeriod": {
-              "start": "2026-04-26T04:30:00Z",
-              "duration": "PT1H"
-            },
+            "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "PRICE_PER_KWH",
-                "currency": "INR",
-                "insertedBy": "sellerPlatform"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "REQUESTED_QTY",
-                "units": "KWH",
-                "insertedBy": "buyerPlatform"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "FINAL_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE_PER_KWH", "currency": "INR", "insertedBy": "sellerPlatform"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "REQUESTED_QTY", "units": "KWH", "insertedBy": "buyerPlatform"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_STATUS", "units": "STRING", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_STATUS", "units": "STRING", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "FINAL_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": []
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": []
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": [
-                      18.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": []
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": []
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": []
-                  }
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": []
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": []
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": [
-                      14.2
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": []
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": []
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": []
-                  }
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "PRICE_PER_KWH", "values": []}, {"type": "REQUESTED_QTY", "values": []}, {"type": "BUYER_DISCOM_ALLOC", "values": [18.5]}, {"type": "BUYER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "SELLER_DISCOM_ALLOC", "values": []}, {"type": "SELLER_DISCOM_STATUS", "values": []}, {"type": "FINAL_ALLOC", "values": []}]},
+              {"id": 1, "payloads": [{"type": "PRICE_PER_KWH", "values": []}, {"type": "REQUESTED_QTY", "values": []}, {"type": "BUYER_DISCOM_ALLOC", "values": [14.2]}, {"type": "BUYER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "SELLER_DISCOM_ALLOC", "values": []}, {"type": "SELLER_DISCOM_STATUS", "values": []}, {"type": "FINAL_ALLOC", "values": []}]}
             ]
           }
         }
@@ -191,77 +59,18 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [
-          {
-            "role": "buyerPlatform",
-            "participantId": "buyerapp.example.com"
-          },
-          {
-            "role": "sellerPlatform",
-            "participantId": "sellerapp.example.com"
-          },
-          {
-            "role": "buyerDiscom",
-            "participantId": "buyer-discom-ledger.example.com"
-          },
-          {
-            "role": "sellerDiscom",
-            "participantId": "seller-discom-ledger.example.com"
-          }
+          {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
+          {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
+          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
+          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
         ],
-        "policy": {
-          "url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1",
-          "queryPath": "data.deg.contracts.p2p_trading"
-        }
+        "policy": {"url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1", "queryPath": "data.deg.contracts.p2p_trading"}
       },
       "participants": [
-        {
-          "role": "sellerPlatform",
-          "participantId": "sellerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_SELLER_001",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "utilityCustomerId": "TEST_CUST_SELLER_001",
-            "platformUrl": "http://sellerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerPlatform",
-          "participantId": "buyerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_BUYER_001",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "utilityCustomerId": "TEST_CUST_BUYER_001",
-            "platformUrl": "http://buyerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "ledgerUrl": "http://buyer-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://buyer-discom.example.com:9000"
-          }
-        },
-        {
-          "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "ledgerUrl": "http://seller-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://seller-discom.example.com:9000"
-          }
-        }
+        {"role": "sellerPlatform", "participantId": "sellerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_SELLER_001", "utilityId": "TEST_DISCOM_SELLER", "utilityCustomerId": "TEST_CUST_SELLER_001", "platformUrl": "http://sellerapp.example.com:9000"}},
+        {"role": "buyerPlatform", "participantId": "buyerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_BUYER_001", "utilityId": "TEST_DISCOM_BUYER", "utilityCustomerId": "TEST_CUST_BUYER_001", "platformUrl": "http://buyerapp.example.com:9000"}},
+        {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "http://buyer-discom-ledger.example.com:9000", "platformUrl": "http://buyer-discom.example.com:9000"}},
+        {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "http://seller-discom-ledger.example.com:9000", "platformUrl": "http://seller-discom.example.com:9000"}}
       ]
     }
   }

--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/on_status_settled.json
@@ -23,188 +23,36 @@
   "message": {
     "contract": {
       "id": "contract-p2p-001",
-      "status": {
-        "code": "COMPLETE"
-      },
+      "status": {"code": "COMPLETE"},
       "commitments": [
         {
           "id": "commitment-p2p-001",
-          "status": {
-            "descriptor": {
-              "code": "CLOSED"
-            }
-          },
+          "status": {"descriptor": {"code": "CLOSED"}},
           "resources": [
             {
               "id": "energy-resource-solar-001",
-              "descriptor": {
-                "name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"
-              },
-              "quantity": {
-                "@type": "Quantity",
-                "unitCode": "KWH",
-                "unitQuantity": 35.0
-              },
-              "resourceAttributes": {
-                "@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld",
-                "@type": "EnergyResource",
-                "type": "SOLAR",
-                "id": "TEST_METER_SELLER_001"
-              }
+              "descriptor": {"name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"},
+              "quantity": {"@type": "Quantity", "unitCode": "KWH", "unitQuantity": 35.0},
+              "resourceAttributes": {"@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld", "@type": "EnergyResource", "type": "SOLAR", "id": "TEST_METER_SELLER_001"}
             }
           ],
-          "offer": {
-            "id": "offer-p2p-001",
-            "resourceIds": [
-              "energy-resource-solar-001"
-            ]
-          },
+          "offer": {"id": "offer-p2p-001", "resourceIds": ["energy-resource-solar-001"]},
           "commitmentAttributes": {
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
-            "intervalPeriod": {
-              "start": "2026-04-26T04:30:00Z",
-              "duration": "PT1H"
-            },
+            "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "PRICE_PER_KWH",
-                "currency": "INR",
-                "insertedBy": "sellerPlatform"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "REQUESTED_QTY",
-                "units": "KWH",
-                "insertedBy": "buyerPlatform"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "FINAL_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE_PER_KWH", "currency": "INR", "insertedBy": "sellerPlatform"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "REQUESTED_QTY", "units": "KWH", "insertedBy": "buyerPlatform"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_STATUS", "units": "STRING", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_STATUS", "units": "STRING", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "FINAL_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      12.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      20.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": [
-                      18.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": [
-                      19.2
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": [
-                      18.5
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      14.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      15.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": [
-                      14.2
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": [
-                      14.7
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": [
-                      14.2
-                    ]
-                  }
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "PRICE_PER_KWH", "values": [12.5]}, {"type": "REQUESTED_QTY", "values": [20.5]}, {"type": "BUYER_DISCOM_ALLOC", "values": [18.5]}, {"type": "BUYER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "SELLER_DISCOM_ALLOC", "values": [19.2]}, {"type": "SELLER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "FINAL_ALLOC", "values": [18.5]}]},
+              {"id": 1, "payloads": [{"type": "PRICE_PER_KWH", "values": [14.5]}, {"type": "REQUESTED_QTY", "values": [15.5]}, {"type": "BUYER_DISCOM_ALLOC", "values": [14.2]}, {"type": "BUYER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "SELLER_DISCOM_ALLOC", "values": [14.7]}, {"type": "SELLER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "FINAL_ALLOC", "values": [14.2]}]}
             ]
           }
         }
@@ -213,77 +61,18 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [
-          {
-            "role": "buyerPlatform",
-            "participantId": "buyerapp.example.com"
-          },
-          {
-            "role": "sellerPlatform",
-            "participantId": "sellerapp.example.com"
-          },
-          {
-            "role": "buyerDiscom",
-            "participantId": "buyer-discom-ledger.example.com"
-          },
-          {
-            "role": "sellerDiscom",
-            "participantId": "seller-discom-ledger.example.com"
-          }
+          {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
+          {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
+          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
+          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
         ],
-        "policy": {
-          "url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1",
-          "queryPath": "data.deg.contracts.p2p_trading"
-        }
+        "policy": {"url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1", "queryPath": "data.deg.contracts.p2p_trading"}
       },
       "participants": [
-        {
-          "role": "sellerPlatform",
-          "participantId": "sellerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_SELLER_001",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "utilityCustomerId": "TEST_CUST_SELLER_001",
-            "platformUrl": "http://sellerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerPlatform",
-          "participantId": "buyerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_BUYER_001",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "utilityCustomerId": "TEST_CUST_BUYER_001",
-            "platformUrl": "http://buyerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "ledgerUrl": "http://buyer-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://buyer-discom.example.com:9000"
-          }
-        },
-        {
-          "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "ledgerUrl": "http://seller-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://seller-discom.example.com:9000"
-          }
-        }
+        {"role": "sellerPlatform", "participantId": "sellerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_SELLER_001", "utilityId": "TEST_DISCOM_SELLER", "utilityCustomerId": "TEST_CUST_SELLER_001", "platformUrl": "http://sellerapp.example.com:9000"}},
+        {"role": "buyerPlatform", "participantId": "buyerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_BUYER_001", "utilityId": "TEST_DISCOM_BUYER", "utilityCustomerId": "TEST_CUST_BUYER_001", "platformUrl": "http://buyerapp.example.com:9000"}},
+        {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "http://buyer-discom-ledger.example.com:9000", "platformUrl": "http://buyer-discom.example.com:9000"}},
+        {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "http://seller-discom-ledger.example.com:9000", "platformUrl": "http://seller-discom.example.com:9000"}}
       ],
       "consideration": [
         {
@@ -315,7 +104,17 @@
           "id": "settlement-p2p-001",
           "considerationId": "payment-term-p2p-001",
           "status": "COMPLETE",
-          "settlementAttributes": {"@context": "https://schema.nfh.global/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST", "energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+          "settlementAttributes": {
+            "@context": "https://schema.nfh.global/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST",
+            "energyValue": 437.15,
+            "sellerPlatformFee": 13.11,
+            "buyerPlatformFee": 8.74,
+            "totalPayable": 459.0,
+            "paidAt": "2026-04-26T07:30:00Z",
+            "txnRef": "TXN-P2P-001-SETTLED"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/status-request.json
+++ b/devkits/p2p-trading-ies-wave2/responses/buyerdiscom/status-request.json
@@ -10,10 +10,7 @@
     "transactionId": "bdledger-status-001",
     "messageId": "bdledger-status-msg-001",
     "timestamp": "2026-04-26T05:35:00Z",
-    "schemaContext": [
-      "https://schema.nfh.global/DatasetItem/1.1/context.jsonld",
-      "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld"
-    ]
+    "schemaContext": ["https://schema.nfh.global/DatasetItem/1.1/context.jsonld", "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld"]
   },
   "message": {
     "contract": {
@@ -41,13 +38,7 @@
                     "resourceName": "TEST_METER_BUYER_001",
                     "clientName": "TEST_DISCOM_BUYER",
                     "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
-                    "payloadDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "ENERGY_CONSUMPTION",
-                        "units": "KWH"
-                      }
-                    ],
+                    "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "ENERGY_CONSUMPTION", "units": "KWH"}],
                     "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": []}]}]
                   },
                   {
@@ -56,13 +47,7 @@
                     "resourceName": "TEST_METER_BUYER_002",
                     "clientName": "TEST_DISCOM_BUYER",
                     "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
-                    "payloadDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "ENERGY_CONSUMPTION",
-                        "units": "KWH"
-                      }
-                    ],
+                    "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "ENERGY_CONSUMPTION", "units": "KWH"}],
                     "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": []}]}]
                   }
                 ]

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_confirm.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_confirm.json
@@ -11,7 +11,5 @@
     "messageId": "84757a33-45ec-47d6-8564-b02873f4d809",
     "timestamp": "2026-04-25T10:10:10Z"
   },
-  "message": {
-    "ack": { "status": "ACK" }
-  }
+  "message": {"ack": {"status": "ACK"}}
 }

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status.json
@@ -21,168 +21,36 @@
   "message": {
     "contract": {
       "id": "contract-p2p-001",
-      "status": {
-        "code": "ACTIVE"
-      },
+      "status": {"code": "ACTIVE"},
       "commitments": [
         {
           "id": "commitment-p2p-001",
-          "status": {
-            "descriptor": {
-              "code": "ACTIVE"
-            }
-          },
+          "status": {"descriptor": {"code": "ACTIVE"}},
           "resources": [
             {
               "id": "energy-resource-solar-001",
-              "descriptor": {
-                "name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"
-              },
-              "quantity": {
-                "@type": "Quantity",
-                "unitCode": "KWH",
-                "unitQuantity": 35.0
-              },
-              "resourceAttributes": {
-                "@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld",
-                "@type": "EnergyResource",
-                "type": "SOLAR",
-                "id": "TEST_METER_SELLER_001"
-              }
+              "descriptor": {"name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"},
+              "quantity": {"@type": "Quantity", "unitCode": "KWH", "unitQuantity": 35.0},
+              "resourceAttributes": {"@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld", "@type": "EnergyResource", "type": "SOLAR", "id": "TEST_METER_SELLER_001"}
             }
           ],
-          "offer": {
-            "id": "offer-p2p-001",
-            "resourceIds": [
-              "energy-resource-solar-001"
-            ]
-          },
+          "offer": {"id": "offer-p2p-001", "resourceIds": ["energy-resource-solar-001"]},
           "commitmentAttributes": {
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
-            "intervalPeriod": {
-              "start": "2026-04-26T04:30:00Z",
-              "duration": "PT1H"
-            },
+            "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "PRICE_PER_KWH",
-                "currency": "INR",
-                "insertedBy": "sellerPlatform"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "REQUESTED_QTY",
-                "units": "KWH",
-                "insertedBy": "buyerPlatform"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "FINAL_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE_PER_KWH", "currency": "INR", "insertedBy": "sellerPlatform"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "REQUESTED_QTY", "units": "KWH", "insertedBy": "buyerPlatform"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_STATUS", "units": "STRING", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_STATUS", "units": "STRING", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "FINAL_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": []
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": []
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": []
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": []
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": [
-                      19.2
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": []
-                  }
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": []
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": []
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": []
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": []
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": [
-                      14.7
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": []
-                  }
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "PRICE_PER_KWH", "values": []}, {"type": "REQUESTED_QTY", "values": []}, {"type": "BUYER_DISCOM_ALLOC", "values": []}, {"type": "BUYER_DISCOM_STATUS", "values": []}, {"type": "SELLER_DISCOM_ALLOC", "values": [19.2]}, {"type": "SELLER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "FINAL_ALLOC", "values": []}]},
+              {"id": 1, "payloads": [{"type": "PRICE_PER_KWH", "values": []}, {"type": "REQUESTED_QTY", "values": []}, {"type": "BUYER_DISCOM_ALLOC", "values": []}, {"type": "BUYER_DISCOM_STATUS", "values": []}, {"type": "SELLER_DISCOM_ALLOC", "values": [14.7]}, {"type": "SELLER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "FINAL_ALLOC", "values": []}]}
             ]
           }
         }
@@ -191,77 +59,18 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [
-          {
-            "role": "buyerPlatform",
-            "participantId": "buyerapp.example.com"
-          },
-          {
-            "role": "sellerPlatform",
-            "participantId": "sellerapp.example.com"
-          },
-          {
-            "role": "buyerDiscom",
-            "participantId": "buyer-discom-ledger.example.com"
-          },
-          {
-            "role": "sellerDiscom",
-            "participantId": "seller-discom-ledger.example.com"
-          }
+          {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
+          {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
+          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
+          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
         ],
-        "policy": {
-          "url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1",
-          "queryPath": "data.deg.contracts.p2p_trading"
-        }
+        "policy": {"url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1", "queryPath": "data.deg.contracts.p2p_trading"}
       },
       "participants": [
-        {
-          "role": "sellerPlatform",
-          "participantId": "sellerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_SELLER_001",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "utilityCustomerId": "TEST_CUST_SELLER_001",
-            "platformUrl": "http://sellerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerPlatform",
-          "participantId": "buyerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_BUYER_001",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "utilityCustomerId": "TEST_CUST_BUYER_001",
-            "platformUrl": "http://buyerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "ledgerUrl": "http://buyer-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://buyer-discom.example.com:9000"
-          }
-        },
-        {
-          "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "ledgerUrl": "http://seller-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://seller-discom.example.com:9000"
-          }
-        }
+        {"role": "sellerPlatform", "participantId": "sellerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_SELLER_001", "utilityId": "TEST_DISCOM_SELLER", "utilityCustomerId": "TEST_CUST_SELLER_001", "platformUrl": "http://sellerapp.example.com:9000"}},
+        {"role": "buyerPlatform", "participantId": "buyerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_BUYER_001", "utilityId": "TEST_DISCOM_BUYER", "utilityCustomerId": "TEST_CUST_BUYER_001", "platformUrl": "http://buyerapp.example.com:9000"}},
+        {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "http://buyer-discom-ledger.example.com:9000", "platformUrl": "http://buyer-discom.example.com:9000"}},
+        {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "http://seller-discom-ledger.example.com:9000", "platformUrl": "http://seller-discom.example.com:9000"}}
       ]
     }
   }

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/on_status_settled.json
@@ -23,188 +23,36 @@
   "message": {
     "contract": {
       "id": "contract-p2p-001",
-      "status": {
-        "code": "COMPLETE"
-      },
+      "status": {"code": "COMPLETE"},
       "commitments": [
         {
           "id": "commitment-p2p-001",
-          "status": {
-            "descriptor": {
-              "code": "CLOSED"
-            }
-          },
+          "status": {"descriptor": {"code": "CLOSED"}},
           "resources": [
             {
               "id": "energy-resource-solar-001",
-              "descriptor": {
-                "name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"
-              },
-              "quantity": {
-                "@type": "Quantity",
-                "unitCode": "KWH",
-                "unitQuantity": 35.0
-              },
-              "resourceAttributes": {
-                "@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld",
-                "@type": "EnergyResource",
-                "type": "SOLAR",
-                "id": "TEST_METER_SELLER_001"
-              }
+              "descriptor": {"name": "Solar energy slot - 2026-04-26 10:00-12:00 IST"},
+              "quantity": {"@type": "Quantity", "unitCode": "KWH", "unitQuantity": 35.0},
+              "resourceAttributes": {"@context": "https://schema.nfh.global/EnergyResource/v2.0/context.jsonld", "@type": "EnergyResource", "type": "SOLAR", "id": "TEST_METER_SELLER_001"}
             }
           ],
-          "offer": {
-            "id": "offer-p2p-001",
-            "resourceIds": [
-              "energy-resource-solar-001"
-            ]
-          },
+          "offer": {"id": "offer-p2p-001", "resourceIds": ["energy-resource-solar-001"]},
           "commitmentAttributes": {
             "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
             "@type": "TimeSeries",
-            "intervalPeriod": {
-              "start": "2026-04-26T04:30:00Z",
-              "duration": "PT1H"
-            },
+            "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
             "payloadDescriptors": [
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "PRICE_PER_KWH",
-                "currency": "INR",
-                "insertedBy": "sellerPlatform"
-              },
-              {
-                "objectType": "EVENT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "REQUESTED_QTY",
-                "units": "KWH",
-                "insertedBy": "buyerPlatform"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "BUYER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "buyerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "SELLER_DISCOM_STATUS",
-                "units": "STRING",
-                "insertedBy": "sellerDiscom"
-              },
-              {
-                "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                "payloadType": "FINAL_ALLOC",
-                "units": "KWH",
-                "insertedBy": "sellerDiscom"
-              }
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE_PER_KWH", "currency": "INR", "insertedBy": "sellerPlatform"},
+              {"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "REQUESTED_QTY", "units": "KWH", "insertedBy": "buyerPlatform"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "BUYER_DISCOM_STATUS", "units": "STRING", "insertedBy": "buyerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "SELLER_DISCOM_STATUS", "units": "STRING", "insertedBy": "sellerDiscom"},
+              {"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "FINAL_ALLOC", "units": "KWH", "insertedBy": "sellerDiscom"}
             ],
             "intervals": [
-              {
-                "id": 0,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      12.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      20.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": [
-                      18.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": [
-                      19.2
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": [
-                      18.5
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": 1,
-                "payloads": [
-                  {
-                    "type": "PRICE_PER_KWH",
-                    "values": [
-                      14.5
-                    ]
-                  },
-                  {
-                    "type": "REQUESTED_QTY",
-                    "values": [
-                      15.5
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_ALLOC",
-                    "values": [
-                      14.2
-                    ]
-                  },
-                  {
-                    "type": "BUYER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_ALLOC",
-                    "values": [
-                      14.7
-                    ]
-                  },
-                  {
-                    "type": "SELLER_DISCOM_STATUS",
-                    "values": [
-                      "COMPLETED"
-                    ]
-                  },
-                  {
-                    "type": "FINAL_ALLOC",
-                    "values": [
-                      14.2
-                    ]
-                  }
-                ]
-              }
+              {"id": 0, "payloads": [{"type": "PRICE_PER_KWH", "values": [12.5]}, {"type": "REQUESTED_QTY", "values": [20.5]}, {"type": "BUYER_DISCOM_ALLOC", "values": [18.5]}, {"type": "BUYER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "SELLER_DISCOM_ALLOC", "values": [19.2]}, {"type": "SELLER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "FINAL_ALLOC", "values": [18.5]}]},
+              {"id": 1, "payloads": [{"type": "PRICE_PER_KWH", "values": [14.5]}, {"type": "REQUESTED_QTY", "values": [15.5]}, {"type": "BUYER_DISCOM_ALLOC", "values": [14.2]}, {"type": "BUYER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "SELLER_DISCOM_ALLOC", "values": [14.7]}, {"type": "SELLER_DISCOM_STATUS", "values": ["COMPLETED"]}, {"type": "FINAL_ALLOC", "values": [14.2]}]}
             ]
           }
         }
@@ -213,77 +61,18 @@
         "@context": "https://schema.nfh.global/DEGContract/v2.0/context.jsonld",
         "@type": "DEGContract",
         "roles": [
-          {
-            "role": "buyerPlatform",
-            "participantId": "buyerapp.example.com"
-          },
-          {
-            "role": "sellerPlatform",
-            "participantId": "sellerapp.example.com"
-          },
-          {
-            "role": "buyerDiscom",
-            "participantId": "buyer-discom-ledger.example.com"
-          },
-          {
-            "role": "sellerDiscom",
-            "participantId": "seller-discom-ledger.example.com"
-          }
+          {"role": "buyerPlatform", "participantId": "buyerapp.example.com"},
+          {"role": "sellerPlatform", "participantId": "sellerapp.example.com"},
+          {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com"},
+          {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com"}
         ],
-        "policy": {
-          "url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1",
-          "queryPath": "data.deg.contracts.p2p_trading"
-        }
+        "policy": {"url": "https://api.dedi.global/dedi/lookup/indiaenergystack.in/ies-policies/ies-p2p-network-settlement-rego-policy-v1", "queryPath": "data.deg.contracts.p2p_trading"}
       },
       "participants": [
-        {
-          "role": "sellerPlatform",
-          "participantId": "sellerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_SELLER_001",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "utilityCustomerId": "TEST_CUST_SELLER_001",
-            "platformUrl": "http://sellerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerPlatform",
-          "participantId": "buyerapp.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld",
-            "@type": "EnergyCustomer",
-            "meterId": "TEST_METER_BUYER_001",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "utilityCustomerId": "TEST_CUST_BUYER_001",
-            "platformUrl": "http://buyerapp.example.com:9000"
-          }
-        },
-        {
-          "role": "buyerDiscom",
-          "participantId": "buyer-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_BUYER",
-            "ledgerUrl": "http://buyer-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://buyer-discom.example.com:9000"
-          }
-        },
-        {
-          "role": "sellerDiscom",
-          "participantId": "seller-discom-ledger.example.com",
-          "participantAttributes": {
-            "@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld",
-            "@type": "DiscomLedgerProvider",
-            "utilityId": "TEST_DISCOM_SELLER",
-            "ledgerUrl": "http://seller-discom-ledger.example.com:9000",
-
-            "platformUrl": "http://seller-discom.example.com:9000"
-          }
-        }
+        {"role": "sellerPlatform", "participantId": "sellerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_SELLER_001", "utilityId": "TEST_DISCOM_SELLER", "utilityCustomerId": "TEST_CUST_SELLER_001", "platformUrl": "http://sellerapp.example.com:9000"}},
+        {"role": "buyerPlatform", "participantId": "buyerapp.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/EnergyCustomer/v2.0/context.jsonld", "@type": "EnergyCustomer", "meterId": "TEST_METER_BUYER_001", "utilityId": "TEST_DISCOM_BUYER", "utilityCustomerId": "TEST_CUST_BUYER_001", "platformUrl": "http://buyerapp.example.com:9000"}},
+        {"role": "buyerDiscom", "participantId": "buyer-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_BUYER", "ledgerUrl": "http://buyer-discom-ledger.example.com:9000", "platformUrl": "http://buyer-discom.example.com:9000"}},
+        {"role": "sellerDiscom", "participantId": "seller-discom-ledger.example.com", "participantAttributes": {"@context": "https://schema.nfh.global/DiscomLedgerProvider/v1.0/context.jsonld", "@type": "DiscomLedgerProvider", "utilityId": "TEST_DISCOM_SELLER", "ledgerUrl": "http://seller-discom-ledger.example.com:9000", "platformUrl": "http://seller-discom.example.com:9000"}}
       ],
       "consideration": [
         {
@@ -315,7 +104,17 @@
           "id": "settlement-p2p-001",
           "considerationId": "payment-term-p2p-001",
           "status": "COMPLETE",
-          "settlementAttributes": {"@context": "https://schema.nfh.global/SettlementTerm/2.0/context.jsonld", "@type": "SettlementTerm", "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST", "energyValue": 437.15, "sellerPlatformFee": 13.11, "buyerPlatformFee": 8.74, "totalPayable": 459.0, "paidAt": "2026-04-26T07:30:00Z", "txnRef": "TXN-P2P-001-SETTLED"}
+          "settlementAttributes": {
+            "@context": "https://schema.nfh.global/SettlementTerm/2.0/context.jsonld",
+            "@type": "SettlementTerm",
+            "settlementFor": "Solar energy P2P trade: 32.7 kWh delivered on 2026-04-26 10:00-12:00 IST",
+            "energyValue": 437.15,
+            "sellerPlatformFee": 13.11,
+            "buyerPlatformFee": 8.74,
+            "totalPayable": 459.0,
+            "paidAt": "2026-04-26T07:30:00Z",
+            "txnRef": "TXN-P2P-001-SETTLED"
+          }
         }
       ]
     }

--- a/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/status-request.json
+++ b/devkits/p2p-trading-ies-wave2/responses/sellerdiscom/status-request.json
@@ -10,10 +10,7 @@
     "transactionId": "sdledger-status-001",
     "messageId": "sdledger-status-msg-001",
     "timestamp": "2026-04-26T05:35:00Z",
-    "schemaContext": [
-      "https://schema.nfh.global/DatasetItem/1.1/context.jsonld",
-      "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld"
-    ]
+    "schemaContext": ["https://schema.nfh.global/DatasetItem/1.1/context.jsonld", "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld"]
   },
   "message": {
     "contract": {
@@ -41,13 +38,7 @@
                     "resourceName": "TEST_METER_SELLER_001",
                     "clientName": "TEST_DISCOM_SELLER",
                     "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
-                    "payloadDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "ENERGY_CONSUMPTION",
-                        "units": "KWH"
-                      }
-                    ],
+                    "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "ENERGY_CONSUMPTION", "units": "KWH"}],
                     "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": []}]}]
                   },
                   {
@@ -56,13 +47,7 @@
                     "resourceName": "TEST_METER_SELLER_002",
                     "clientName": "TEST_DISCOM_SELLER",
                     "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
-                    "payloadDescriptors": [
-                      {
-                        "objectType": "REPORT_PAYLOAD_DESCRIPTOR",
-                        "payloadType": "ENERGY_CONSUMPTION",
-                        "units": "KWH"
-                      }
-                    ],
+                    "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "ENERGY_CONSUMPTION", "units": "KWH"}],
                     "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": []}]}]
                   }
                 ]


### PR DESCRIPTION
Runs the repo formatter `scripts/compact_examples.py` so the (TimeSeries-heavy) devkit payloads are easy to read — one line per `payloadDescriptor` / `interval` / `reportDescriptor` / `role` / `participant` / `revenueFlow`, larger structures stay expanded.

## Scope
- **demand-flex** — all `examples/` (uc1 + uc2). uc1 dropped ~2687 → 1593 lines.
- **demand-flex + p2p-trading-ies-wave2** — all `responses/` sandbox fixtures (17 files).
- **p2p-trading-ies-wave2** `examples/` already followed the convention (0/16 changed) — no-op, confirmed.

## Safety
- **Formatting only** — content unchanged (the formatter reloads JSON and re-emits the same data). All JSON valid.
- Reuses `generate_postman_collection.py`'s `_format_payload`, so on-disk examples match the generated Postman bodies exactly — **postman regeneration is a no-op**.
- demand-flex uc1 **arazzo re-run passes end-to-end** (all ACK) against the recompacted response fixtures; settlement still 436.25; network rego clean.