### PR TITLE
fix(p2p-wave2): inject settlement flows at discom-ledger /bpp/caller

### DIFF
--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-buyerdiscom.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-buyerdiscom.yaml
@@ -175,7 +175,34 @@ modules:
             config:
               uuidKeys: transaction_id,message_id
               role: bpp
+        steps:
+          # Settlement injection at the emitter. This discom finalizes the
+          # trade (inserts FINAL_ALLOC) and emits the settled /on_status here,
+          # so it is the authority that computes and signs the revenue split
+          # from its own linked policy (contractAttributes.policy). The trade
+          # platforms only forward this callback on their /bap/receiver (Rule
+          # 2a/2b via degledgerrecorder) — never through a /bpp/caller — so the
+          # app-side injectors never see it; this is the only hop that can
+          # enrich it. Injection-only (violationActions empty): a missing or
+          # unfetchable policy logs and skips rather than NACKing settlement.
+          # Runs first so validateSchema/sign see the enriched payload.
+          - id: contractpolicyenforcer
+            config:
+              actions: "on_status"
+              violationActions: ""
+              cacheTTL: "172800"
+              debugLogging: "true"
+              # Only India Energy Stack policy records on DeDi are accepted.
+              allowedPolicyUrlPrefixes: "https://api.dedi.global/dedi/lookup/indiaenergystack.in"
+              fetchRetries: "2"
+              outputPath: "message.contract.consideration[id=auto-settlement-flows].considerationAttributes"
+              outputMode: "jsonld"
+              outputType: "RevenueFlow"
+              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
+              outputArrayKey: "revenueFlows"
+              entryDefaults: '{"status":{"code":"SETTLED"}}'
       steps:
+        - contractpolicyenforcer
         - validateSchema
         - addRoute
         - sign

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-sellerdiscom.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-ledger-sellerdiscom.yaml
@@ -175,7 +175,34 @@ modules:
             config:
               uuidKeys: transaction_id,message_id
               role: bpp
+        steps:
+          # Settlement injection at the emitter. This discom finalizes the
+          # trade (inserts FINAL_ALLOC) and emits the settled /on_status here,
+          # so it is the authority that computes and signs the revenue split
+          # from its own linked policy (contractAttributes.policy). The trade
+          # platforms only forward this callback on their /bap/receiver (Rule
+          # 2a/2b via degledgerrecorder) — never through a /bpp/caller — so the
+          # app-side injectors never see it; this is the only hop that can
+          # enrich it. Injection-only (violationActions empty): a missing or
+          # unfetchable policy logs and skips rather than NACKing settlement.
+          # Runs first so validateSchema/sign see the enriched payload.
+          - id: contractpolicyenforcer
+            config:
+              actions: "on_status"
+              violationActions: ""
+              cacheTTL: "172800"
+              debugLogging: "true"
+              # Only India Energy Stack policy records on DeDi are accepted.
+              allowedPolicyUrlPrefixes: "https://api.dedi.global/dedi/lookup/indiaenergystack.in"
+              fetchRetries: "2"
+              outputPath: "message.contract.consideration[id=auto-settlement-flows].considerationAttributes"
+              outputMode: "jsonld"
+              outputType: "RevenueFlow"
+              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
+              outputArrayKey: "revenueFlows"
+              entryDefaults: '{"status":{"code":"SETTLED"}}'
       steps:
+        - contractpolicyenforcer
         - validateSchema
         - addRoute
         - sign


### PR DESCRIPTION
## Problem

In the p2p-trading-ies-wave2 devkit, a fully-settled \`on_status\` (all seven commitment payload types populated, including \`FINAL_ALLOC\`) lands at the buyer app but carries **no** \`revenueFlows\` — auto-settlement is never calculated.

## Root cause

\`revenueFlows\` are not baked into fixtures; they are computed and injected by the ONIX \`contractpolicyenforcer\` step, which evaluates the linked seller-discom rego (\`contractAttributes.policy\`) and writes into \`message.contract.consideration[id=auto-settlement-flows]\`.

That step was wired **only** into the buyer/seller app configs, and only on their \`/bpp/caller\` and \`/bap/caller\` handlers. But the settled \`on_status\` follows this path:

| Hop | Handler | Injector? |
|-----|---------|-----------|
| discom-ledger \`/bpp/caller\` (emitter) | validateSchema, addRoute, sign | ❌ |
| seller/buyer app \`/bap/receiver\` (Rule 2a) | …degledgerrecorder | ❌ |
| peer app \`/bap/receiver\` → sandbox | degledgerrecorder | ❌ |

The settled callback is emitted by the discom ledger's \`/bpp/caller\` and cascaded via \`degledgerrecorder\` over \`/bap/receiver\` hops — it never transits any handler running \`contractpolicyenforcer\`. Neither discom-ledger config contained the step at all. So the rego is never evaluated and nothing is injected.

## Fix

Add \`contractpolicyenforcer\` (actions \`on_status\`, injection-only — \`violationActions\` empty) to **both** discom-ledger \`/bpp/caller\` handlers, running first so \`validateSchema\`/\`sign\` see the enriched payload.

The discom ledger is the correct injection point: it is the node that finalizes the trade (inserts \`FINAL_ALLOC\`), emits the settled callback, and applies **its own** linked policy — so the settlement split is computed and signed by the regulated authority that levies the wheeling/penalty charges. The app-side injectors are left untouched (they cover seller-originated \`on_status\`, which carry no \`FINAL_ALLOC\` and so yield no flows).

## Notes / follow-ups
- Injection still depends on the DeDi policy fetch succeeding (checksum bump pending); with \`violationActions\` empty on \`on_status\`, a fetch failure logs and skips rather than NACKing.
- Pre-existing discrepancy left as-is: injector config emits \`RevenueFlow/2.0\` context while the reference settled fixtures use \`RevenueFlow/v2.0\`. Worth aligning across all injectors + fixtures in a separate change.

## Test
- Both configs pass YAML lint; step wiring verified (\`plugins.steps\` def + \`handler.steps\` order = \`[contractpolicyenforcer, validateSchema, addRoute, sign]\`).
- All nodes run \`fidedocker/onix-adapter-deg:v2\`, so the plugin is available on the ledger ONIX.