### PR TITLE
fix(p2p-wave2): inject settlement flows on app /bap/receiver forward

### DIFF
--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerapp.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerapp.yaml
@@ -73,6 +73,31 @@ modules:
               uuidKeys: transaction_id,message_id
               role: bap
         steps:
+          # Settlement injection when this app forwards a fully-settled
+          # on_status onward. The settled callback (carrying FINAL_ALLOC) is
+          # emitted by the discom ledger and reaches the app here at
+          # /bap/receiver; degledgerrecorder then forwards it to the peer
+          # (Rule 2a/2b), so this is the app's "send out on_status" point.
+          # Running before degledgerrecorder means the payload it forwards and
+          # records is already enriched. Injection-only (violationActions
+          # empty): the linked rego only yields revenueFlows once FINAL_ALLOC
+          # is present, so non-settled on_status pass through untouched and a
+          # missing/unfetchable policy logs rather than NACKing the callback.
+          - id: contractpolicyenforcer
+            config:
+              actions: "on_status"
+              violationActions: ""
+              cacheTTL: "172800"
+              debugLogging: "true"
+              # Only India Energy Stack policy records on DeDi are accepted.
+              allowedPolicyUrlPrefixes: "https://api.dedi.global/dedi/lookup/indiaenergystack.in"
+              fetchRetries: "2"
+              outputPath: "message.contract.consideration[id=auto-settlement-flows].considerationAttributes"
+              outputMode: "jsonld"
+              outputType: "RevenueFlow"
+              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
+              outputArrayKey: "revenueFlows"
+              entryDefaults: '{"status":{"code":"SETTLED"}}'
           - id: degledgerrecorder
             config:
               # Rule 2 (sender-aware): on_status forwarded based on context.bppId.
@@ -97,6 +122,7 @@ modules:
         - checkPolicy
         - addRoute
         - validateSchema
+        - contractpolicyenforcer
         - degledgerrecorder
 
   - name: bapTxnCaller

--- a/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerapp.yaml
+++ b/devkits/p2p-trading-ies-wave2/config/local-p2p-trading-sellerapp.yaml
@@ -179,6 +179,31 @@ modules:
               uuidKeys: transaction_id,message_id
               role: bap
         steps:
+          # Settlement injection when this app forwards a fully-settled
+          # on_status onward. The settled callback (carrying FINAL_ALLOC) is
+          # emitted by the discom ledger and reaches the app here at
+          # /bap/receiver; degledgerrecorder then forwards it to the peer
+          # (Rule 2a/2b), so this is the app's "send out on_status" point.
+          # Running before degledgerrecorder means the payload it forwards and
+          # records is already enriched. Injection-only (violationActions
+          # empty): the linked rego only yields revenueFlows once FINAL_ALLOC
+          # is present, so non-settled on_status pass through untouched and a
+          # missing/unfetchable policy logs rather than NACKing the callback.
+          - id: contractpolicyenforcer
+            config:
+              actions: "on_status"
+              violationActions: ""
+              cacheTTL: "172800"
+              debugLogging: "true"
+              # Only India Energy Stack policy records on DeDi are accepted.
+              allowedPolicyUrlPrefixes: "https://api.dedi.global/dedi/lookup/indiaenergystack.in"
+              fetchRetries: "2"
+              outputPath: "message.contract.consideration[id=auto-settlement-flows].considerationAttributes"
+              outputMode: "jsonld"
+              outputType: "RevenueFlow"
+              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
+              outputArrayKey: "revenueFlows"
+              entryDefaults: '{"status":{"code":"SETTLED"}}'
           - id: degledgerrecorder
             config:
               # Rule 2 (sender-aware): if context.bppId == own discom participantId
@@ -202,6 +227,7 @@ modules:
         - checkPolicy
         - addRoute
         - validateSchema
+        - contractpolicyenforcer
         - degledgerrecorder
 
   - name: bppTxnCaller


### PR DESCRIPTION
## Problem

A fully-settled \`on_status\` (all seven commitment payload types populated, including \`FINAL_ALLOC\`) lands at the buyer app with **no** \`revenueFlows\` — auto-settlement is never calculated.

## Root cause

\`revenueFlows\` are computed and injected by the ONIX \`contractpolicyenforcer\` step (evaluates the linked seller-discom rego, writes \`message.contract.consideration[id=auto-settlement-flows]\`). The step existed only on the apps' \`/bpp/caller\` handlers — but the settled callback never transits them:

| Hop | Handler | Injector? |
|-----|---------|-----------|
| discom-ledger \`/bpp/caller\` (emitter) | validateSchema, addRoute, sign | ❌ |
| seller/buyer app \`/bap/receiver\` (Rule 2a/2b) | …validateSchema, **degledgerrecorder** | ❌ |
| peer app \`/bap/receiver\` → sandbox | degledgerrecorder | ❌ |

The settled \`on_status\` is emitted by the discom ledger and forwarded peer-to-peer by \`degledgerrecorder\` on the apps' \`/bap/receiver\` — never through a \`/bpp/caller\`.

## Fix

Keep settlement injection **on the trade platforms only** (discom ledgers unchanged). Add \`contractpolicyenforcer\` (actions \`on_status\`, injection-only) to the **buyerapp and sellerapp \`/bap/receiver\`** step chains, **before \`degledgerrecorder\`** — so the app enriches the settled callback it forwards and records. This is the app's "send out on_status" point in the wave2 cascade.

Naturally gated: the rego yields \`revenueFlows\` only when \`FINAL_ALLOC\` is present, so non-settled \`on_status\` pass through untouched — i.e. flows are injected exactly when the app sends an \`on_status\` with full fulfillment details. The existing \`/bpp/caller\` \`on_status\` injectors are left as-is (they cover app-originated callbacks).

Supersedes #458 (which placed the step on the discom ledgers).

## Notes / follow-ups
- Injection depends on the DeDi policy fetch succeeding (checksum bump pending); with \`violationActions\` empty on \`on_status\`, a fetch failure logs and skips rather than NACKing.
- Pre-existing discrepancy left as-is: injector emits \`RevenueFlow/2.0\` context while the reference settled fixtures use \`RevenueFlow/v2.0\`. Worth aligning across all injectors + fixtures separately.

## Test
- Both configs pass YAML lint; \`bapTxnReceiver\` step order verified as \`[validateSign, checkPolicy, addRoute, validateSchema, contractpolicyenforcer, degledgerrecorder]\` on both apps.
- All nodes run \`fidedocker/onix-adapter-deg:v2\`, so the plugin is available.