### PR TITLE
feat(ledger-ui-client): pre-fill example.env with published buyerapp creds

### DIFF
--- a/devkits/p2p-trading-ies-ledger-ui-client/example.env
+++ b/devkits/p2p-trading-ies-ledger-ui-client/example.env
@@ -1,10 +1,13 @@
 # ── Beckn signing / auth config ──
-SUBSCRIBER_ID=
-RECORD_ID=
-SIGNING_PRIVATE_KEY=
+# Pre-filled with the published wave2 buyerapp (buyerapp.example.com) credentials
+# from devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerapp.yaml.
+# Copy this file to .env and run — you'll see the ledger entries buyerapp is a party to.
+SUBSCRIBER_ID=buyerapp.example.com
+RECORD_ID=76EU8w8ynnqbhderWtVE5KpCmgAoVEXtM8JTCuW3PzUSGdMxtFjzyZ
+SIGNING_PRIVATE_KEY=TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
 
 # ── Ledger server URL ── (if not set, you can provide this at command line. e.g. python server.py --ledger-url https://dummy-ledger-api.com)
-LEDGER_URL=
+LEDGER_URL=https://ies-p2p-energy-ledger.beckn.io
 
 # Show buyerId and sellerId columns in the trade table (default: false)
 SHOW_PARTICIPANT_IDS=false


### PR DESCRIPTION
## What

Populate `devkits/p2p-trading-ies-ledger-ui-client/example.env` with the signing/auth config already published for the wave2 buyerapp so it works as a copy-and-run starting point.

Values are lifted verbatim from `devkits/p2p-trading-ies-wave2/config/local-p2p-trading-buyerapp.yaml` (`buyerapp.example.com`):

| env var | source in buyerapp.yaml |
|---|---|
| `SUBSCRIBER_ID=buyerapp.example.com` | `keyManager.config.networkParticipant` |
| `RECORD_ID=76EU8w8ynnqbhderWtVE5KpCmgAoVEXtM8JTCuW3PzUSGdMxtFjzyZ` | `keyManager.config.keyId` |
| `SIGNING_PRIVATE_KEY=TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=` | `keyManager.config.signingPrivateKey` |
| `LEDGER_URL=https://ies-p2p-energy-ledger.beckn.io` | wave2 IES ledger service (README + on_confirm payloads) |

## Why

Previously every field was blank, so a new user had to trace credentials across the wave2 config. Now they can `cp example.env .env` and immediately see the ledger entries `buyerapp.example.com` is a party to (the ledger service enforces RBAC by `SUBSCRIBER_ID`).