### PR TITLE
fix(p2p-wave2): scope N1 role-completeness to trade-scope contracts

### DIFF
--- a/specification/policies/p2p-trading-ies-wave2-networkpolicy.rego
+++ b/specification/policies/p2p-trading-ies-wave2-networkpolicy.rego
@@ -11,8 +11,9 @@
 #
 # ── contract validation (when message.contract exists) ──
 #
-# N1.  Required roles: buyerPlatform, sellerPlatform, buyerDiscom, sellerDiscom
-#      must all be present in contractAttributes.roles; no unknown values allowed.
+# N1.  Required roles: when contractAttributes.roles is non-empty, it must declare
+#      buyerPlatform, sellerPlatform, buyerDiscom and sellerDiscom; no unknown
+#      values allowed. Skipped for discom-internal contracts that carry no roles.
 # N2.  Participant utilityIds: seller and buyer participants must each have a
 #      non-empty utilityId.
 # N3.  Inter-discom: buyer and seller must have different utilityIds.
@@ -150,6 +151,13 @@ _allowed_roles := {"buyerPlatform", "sellerPlatform", "buyerDiscom", "sellerDisc
 
 _contract_violations contains msg if {
 	roles_present := {r.role | some r in _contract.contractAttributes.roles}
+
+	# Only enforce role completeness once at least one role is declared. Discom-
+	# internal messages (e.g. buyerDiscom -> its own ledger on_status) carry a
+	# contract with no contractAttributes.roles and no participants; role
+	# completeness is a trade-scope concern and does not apply to them. Mirrors
+	# how N15 self-limits to contracts that carry a participants list.
+	count(roles_present) > 0
 	missing := _allowed_roles - roles_present
 	count(missing) > 0
 	msg := sprintf("missing required role(s) in contractAttributes.roles: %v", [missing])
@@ -200,7 +208,7 @@ _contract_violations contains msg if {
 _contract_violations contains "commitmentAttributes must have @type: TimeSeries" if {
 	ca := _commitment.commitmentAttributes
 	is_object(ca)
-	ca.intervals  # only enforce when timeseries interval data is present
+	ca.intervals # only enforce when timeseries interval data is present
 	ca["@type"] != "TimeSeries"
 }
 

--- a/specification/policies/test/p2p-trading-ies-wave2-networkpolicy-n1_test.rego
+++ b/specification/policies/test/p2p-trading-ies-wave2-networkpolicy-n1_test.rego
@@ -1,0 +1,52 @@
+package deg.policy.p2p_trading_network
+
+import rego.v1
+
+# ----------------------------------------------------------------------------
+# Tests for N1 role-completeness gating: the rule fires only when
+# contractAttributes.roles is non-empty. Discom-internal contracts that carry no
+# roles (and no participants) must pass; a partial roles list must still fail.
+# ----------------------------------------------------------------------------
+
+_all_roles := [
+	{"role": "buyerPlatform"},
+	{"role": "sellerPlatform"},
+	{"role": "buyerDiscom"},
+	{"role": "sellerDiscom"},
+]
+
+_payload(contract) := {
+	"context": {"version": "2.0.0", "networkId": "indiaenergystack.in/test-ies-p2p-trading-network"},
+	"message": {"contract": contract},
+}
+
+_has_missing_roles(pl) if {
+	some msg in violations with input as pl
+	startswith(msg, "missing required role(s)")
+}
+
+# Discom-internal on_status: a contract with no roles and no participants must
+# not trip N1.
+test_n1_skipped_when_no_roles if {
+	pl := _payload({"commitments": [{"status": {"descriptor": {"code": "ACTIVE"}}}]})
+	not _has_missing_roles(pl)
+}
+
+# An explicitly empty roles array is likewise not a trade-scope contract.
+test_n1_skipped_when_roles_empty if {
+	pl := _payload({"contractAttributes": {"roles": []}})
+	not _has_missing_roles(pl)
+}
+
+# A full four-role contract passes N1.
+test_n1_passes_when_all_roles_present if {
+	pl := _payload({"contractAttributes": {"roles": _all_roles}})
+	not _has_missing_roles(pl)
+}
+
+# A partial roles list still fails — completeness is enforced once any role is
+# declared.
+test_n1_fails_when_roles_partial if {
+	pl := _payload({"contractAttributes": {"roles": [{"role": "buyerPlatform"}, {"role": "sellerPlatform"}]}})
+	_has_missing_roles(pl)
+}


### PR DESCRIPTION
## Problem
The wave2 network policy's **N1** rule (\"required roles: buyerPlatform, sellerPlatform, buyerDiscom, sellerDiscom must all be present\") fires on *any* message that carries `message.contract`. Discom-internal messages — e.g. a discom ledger's own `on_status` — carry a contract with **no `contractAttributes.roles` and no participants**, so N1 reported all four roles missing:

```
missing required role(s) in contractAttributes.roles: {"buyerDiscom","buyerPlatform","sellerDiscom","sellerPlatform"}
```

Role completeness is a trade-scope concern and does not apply to these internal messages.

## Fix
Gate the N1 completeness check on a **non-empty `roles` array**, mirroring how N15 already self-limits to contracts that carry a `participants` list. Behaviour:
- No roles / empty roles → **skipped** (discom-internal messages pass).
- Partial roles list → **still fails** (completeness enforced once any role is declared).
- Full four-role contract → **passes**.

The unknown-role check and N2/N3/N12/N15 already self-gate on their inputs, so no other rule needed changing.

## Testing
- New `test/p2p-trading-ies-wave2-networkpolicy-n1_test.rego` (4 cases); full suite `opa test` 9/9.
- All 16 uc1 example payloads now evaluate to no violations — including `buyerdiscom-on-status.json` and `sellerdiscom-on-status.json`, which previously tripped N1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)