### PR TITLE
feat(schema/p2p-wave2): identity-clean discom + offer participants[]

### DIFF
--- a/specification/schema/DEGContract/v2.0/attributes.yaml
+++ b/specification/schema/DEGContract/v2.0/attributes.yaml
@@ -32,12 +32,13 @@ components:
         roles:
           type: array
           description: >
-            Contract roles. The participantId key is required on every role
-            entry, but its value MAY be null in the catalog/offer (buyer
-            and buyerDiscom unknown until select/init) and is bound to a
-            concrete participant id at select/init. Identity attributes
-            (meter, utility, utilityCustomerId) for each bound role live
-            at Contract.participants[*].participantAttributes.
+            Contract roles — the role -> participantId map. The participantId
+            key is required on every role entry, but its value MAY be null in
+            the catalog/offer (buyer and buyerDiscom unknown until select/init)
+            and is bound to a concrete participant id at select/init. Roles
+            carry NO identity attributes; each party's attributes live at
+            Contract.participants[*] (Beckn-native, role-less), joined on
+            `participants[].id == roles[].participantId`.
           items:
             type: object
             additionalProperties: false
@@ -50,10 +51,12 @@ components:
                   - string
                   - "null"
                 description: >
-                  Concrete participant id once bound (buyerPlatform/sellerPlatform
-                  use the utilityId-meter compound id, e.g. "TPDDL-DL-seller-001";
-                  discom roles use the discom-ledger participant id).
-                  Null at catalog publish for sides not yet bound.
+                  Concrete participant id once bound, matching a
+                  Contract.participants[*].id. Platform roles use the platform
+                  subscriber id; discom roles use the DISCOM's own participant id
+                  (its subscriber id / did:web) — NOT the ledger id. The ledger is
+                  carried as an attribute (ledgerId/ledgerUri) on the discom
+                  participant. Null at catalog publish for sides not yet bound.
 
         policy:
           type: object

--- a/specification/schema/DiscomLedgerProvider/README.md
+++ b/specification/schema/DiscomLedgerProvider/README.md
@@ -20,5 +20,8 @@ Identity attributes for a regulated discom ledger Technical Service Provider (TS
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `utilityId` | `string` | ✓ | Utility / DISCOM identifier the ledger TSP serves (e.g. `BRPL-DL`). |
+| `discomUri` | `URI` | ✓ | Base URL of the discom's own Beckn platform (init/cascade + allocation). |
+| `ledgerId` | `string` | ✓ | Subscriber id of the discom's ledger TSP (a distinct party). |
 | `ledgerUri` | `URI` | ✓ | Base URL of the discom ledger TSP endpoint. |
+
+The party's own id is the participant `id` (not repeated here); the human-readable utility alias (e.g. `PVVNL`) is resolved from `ledgerId` in the ledger, not carried on the wire.

--- a/specification/schema/DiscomLedgerProvider/v1.0/README.md
+++ b/specification/schema/DiscomLedgerProvider/v1.0/README.md
@@ -1,6 +1,8 @@
 # DiscomLedgerProvider — v1.0
 
-Identity attributes for a regulated discom ledger Technical Service Provider (TSP). Attached to `Contract.participants[*].participantAttributes` for entries with role `buyerDiscom` or `sellerDiscom`, and carries the `ledgerUri` that platforms use to write trade records after `on_confirm`.
+Identity attributes for a discom acting as a `buyerDiscom` / `sellerDiscom` party in a P2P trade. Attached to `Contract.participants[*].participantAttributes` (and to the offer's `participants[]` at catalog publish).
+
+The party's own identity is the participant `id`; it is **not** repeated in these attributes. The attributes carry the discom's platform endpoint (`discomUri`) and its ledger (`ledgerId` + `ledgerUri`). The human-readable utility alias (e.g. `PVVNL`) is intentionally absent — it is resolved from `ledgerId` in the ledger.
 
 Part of the [DEG Schema](../../../specification/schema/) · [DiscomLedgerProvider](../README.md)
 
@@ -16,11 +18,12 @@ Part of the [DEG Schema](../../../specification/schema/) · [DiscomLedgerProvide
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `ledgerUri` | `string` (uri) | ✅ | Base URL of the discom ledger TSP |
-| `utilityId` | `string` | | Utility/DISCOM identifier the TSP serves (e.g., `BRPL-DL`) |
+| `discomUri` | `string` (uri) | ✅ | Base URL of the discom's own Beckn platform (init/cascade + unallocated-trade allocation) |
+| `ledgerId` | `string` | ✅ | Subscriber id of the discom's ledger TSP (a distinct party) |
+| `ledgerUri` | `string` (uri) | ✅ | Base URL of the discom ledger TSP where trades are recorded after `on_confirm` |
 
 ## Usage
 
-Two discoms MAY point at the same `ledgerUri` if they share a TSP. Each platform still calls only its own side's discom URI: BAP → `buyerDiscom.ledgerUri`, BPP → `sellerDiscom.ledgerUri`.
+The party id (the discom's subscriber id / `did:web`) is the participant `id`, referenced from `contractAttributes.roles[role=buyerDiscom|sellerDiscom].participantId`. Two discoms MAY share a `ledgerId`/`ledgerUri` if they use the same TSP; each platform still calls only its own side's discom: BAP → `buyerDiscom`, BPP → `sellerDiscom`.
 
-The `degledgerrecorder` plugin reads `ledgerUri` from the payload when configured with `ledgerUriSource: payload`.
+The `degledgerrecorder` plugin resolves the discom participant via the role→id join and reads `ledgerUri` (where to record) and `discomUri` (where to route allocation).

--- a/specification/schema/DiscomLedgerProvider/v1.0/attributes.yaml
+++ b/specification/schema/DiscomLedgerProvider/v1.0/attributes.yaml
@@ -3,15 +3,24 @@ info:
   title: DiscomLedgerProvider — Discom Ledger TSP Attributes (v1.0)
   version: 1.0.0
   description: >
-    Identity attributes for a regulated discom ledger Technical Service
-    Provider (TSP). Attached to Contract.participants[*].participantAttributes
-    for entries with role buyerDiscom or sellerDiscom. Carries the `ledgerUrl`
-    that platforms use to write trade records to that discom's ledger after
-    on_confirm, and `platformUrl` used to request allocation of unallocated
-    trades to this discom.
+    Identity attributes for a regulated discom acting as a party in a P2P
+    trade. Attached to Contract.participants[*].participantAttributes (and to
+    the offer's participants[] at catalog publish) for entries whose role is
+    buyerDiscom or sellerDiscom.
 
-    Two discoms MAY point at the same `ledgerUrl` if they share a TSP; each
-    platform still calls only its own side's discom URI (BAP -> buyerDiscom,
+    The party's own identity is the participant `id` (the discom's subscriber
+    id / did:web) — it is NOT repeated here. These attributes carry the two
+    endpoints a counterpart needs: `discomUri`, the discom's own Beckn platform
+    (target for init/cascade and unallocated-trade allocation), and the discom's
+    ledger, named by `ledgerId` (a distinct TSP participant) and reached at
+    `ledgerUri` (where trade records are written after on_confirm).
+
+    The human-readable utility alias (e.g. "PVVNL", "TPDDL") is intentionally
+    absent — it is resolved from `ledgerId` in the ledger, keeping the on-wire
+    identity stable and alias-free.
+
+    Two discoms MAY share a `ledgerUri`/`ledgerId` if they use the same TSP;
+    each platform still calls only its own side's discom (BAP -> buyerDiscom,
     BPP -> sellerDiscom).
 
 components:
@@ -19,7 +28,7 @@ components:
     DiscomLedgerProvider:
       type: object
       additionalProperties: false
-      required: [ledgerUrl, platformUrl]
+      required: [discomUri, ledgerId, ledgerUri]
       x-tags:
         - p2p-trading
         - discom-ledger
@@ -28,17 +37,31 @@ components:
         "@type": DiscomLedgerProvider
       properties:
 
-        utilityId:
+        discomUri:
+          type: string
+          format: uri
+          description: >
+            Base URL (scheme + host[:port], no path) of the discom's own Beckn
+            platform. Target for init/cascade routing and for requesting
+            allocation of unallocated trades to this discom. The platform
+            exposes the standard Beckn paths under this base:
+            `/bap/caller`, `/bap/receiver`, `/bpp/caller`, `/bpp/receiver`.
+          example: "https://ies-p2p-energy-discom.beckn.io"
+          x-jsonld:
+            "@id": discomUri
+
+        ledgerId:
           type: string
           description: >
-            Utility/DISCOM identifier the ledger TSP serves (e.g.,
-            "TPDDL-DL", "BRPL-DL"). Mirrors EnergyCustomer.utilityId on
-            buyer/seller participants for cross-reference.
-          example: "BRPL-DL"
+            Subscriber id (or did:web) of the discom's ledger TSP — a party
+            distinct from the discom itself. Used to tag and route ledger
+            records, and as the key under which the ledger holds the discom's
+            human-readable alias.
+          example: "ies-p2p-energy-ledger.beckn.io"
           x-jsonld:
-            "@id": utilityId
+            "@id": ledgerId
 
-        ledgerUrl:
+        ledgerUri:
           type: string
           format: uri
           description: >
@@ -46,30 +69,18 @@ components:
             TSP. The ledger acts as a Beckn node and exposes the standard
             paths under this base:
 
-              `<ledgerUrl>/bap/receiver/<action>`  — inbound endpoint where
+              `<ledgerUri>/bap/receiver/<action>`  — inbound endpoint where
                   buyer/seller platforms cascade on_confirm and status to
                   this ledger. The ledger is BAP-receiver on this leg.
-              `<ledgerUrl>/bpp/caller/<action>`    — outbound endpoint from
+              `<ledgerUri>/bpp/caller/<action>`    — outbound endpoint from
                   which the ledger initiates on_status callbacks back to
                   buyer/seller platforms. The ledger is BPP-caller on that
                   leg.
-              `<ledgerUrl>/ledger/put`             — legacy_ledger mode PUT
+              `<ledgerUri>/ledger/put`             — legacy_ledger mode PUT
                   for non-beckn writes; kept for backward compatibility.
 
             The path is appended by the caller per the action being
-            invoked; `ledgerUrl` itself MUST NOT include a path component.
+            invoked; `ledgerUri` itself MUST NOT include a path component.
           example: "https://ies-p2p-energy-ledger.beckn.io"
           x-jsonld:
-            "@id": ledgerUrl
-
-        platformUrl:
-          type: string
-          format: uri
-          description: >
-            Base URL (scheme + host[:port]) of the discom's Beckn platform.
-            Used to request allocation of unallocated trades to this discom.
-            The platform exposes standard Beckn paths under this base:
-            `/bap/caller`, `/bap/receiver`, `/bpp/caller`, `/bpp/receiver`.
-          example: "https://ies-p2p-energy-discom.beckn.io"
-          x-jsonld:
-            "@id": platformUrl
+            "@id": ledgerUri

--- a/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld
+++ b/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld
@@ -8,7 +8,8 @@
     "beckn": "https://schema.nfh.global/core/v2.0/",
     "deg": "https://schema.nfh.global/deg/DiscomLedgerProvider/v1.0/",
     "DiscomLedgerProvider": "deg:DiscomLedgerProvider",
-    "utilityId": "deg:utilityId",
+    "discomUri": "deg:discomUri",
+    "ledgerId": "deg:ledgerId",
     "ledgerUri": "deg:ledgerUri"
   },
   "@graph": []

--- a/specification/schema/DiscomLedgerProvider/v1.0/vocab.jsonld
+++ b/specification/schema/DiscomLedgerProvider/v1.0/vocab.jsonld
@@ -13,13 +13,21 @@
       "@id": "deg:DiscomLedgerProvider",
       "@type": "rdfs:Class",
       "rdfs:label": "Discom Ledger Provider",
-      "rdfs:comment": "Identity attributes for a regulated discom ledger Technical Service Provider (TSP), attached to Contract.participants[*].participantAttributes for buyerDiscom/sellerDiscom roles."
+      "rdfs:comment": "Identity attributes for a discom acting as a buyerDiscom/sellerDiscom party in a P2P trade, attached to Contract.participants[*].participantAttributes. The party id is the participant id; these attributes carry the discom's platform URI and its ledger (id + uri)."
     },
     {
-      "@id": "deg:utilityId",
+      "@id": "deg:discomUri",
       "@type": "rdf:Property",
-      "rdfs:label": "Utility ID",
-      "rdfs:comment": "Utility/DISCOM identifier the ledger TSP serves.",
+      "rdfs:label": "Discom URI",
+      "rdfs:comment": "Base URL of the discom's own Beckn platform; target for init/cascade and unallocated-trade allocation.",
+      "rdfs:domain": "deg:DiscomLedgerProvider",
+      "rdfs:range": "xsd:anyURI"
+    },
+    {
+      "@id": "deg:ledgerId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Ledger ID",
+      "rdfs:comment": "Subscriber id of the discom's ledger TSP (a distinct party); key under which the ledger holds the discom's human-readable alias.",
       "rdfs:domain": "deg:DiscomLedgerProvider",
       "rdfs:range": "xsd:string"
     },
@@ -27,7 +35,7 @@
       "@id": "deg:ledgerUri",
       "@type": "rdf:Property",
       "rdfs:label": "Ledger URI",
-      "rdfs:comment": "Base URL of the discom ledger TSP.",
+      "rdfs:comment": "Base URL of the discom ledger TSP where trade records are written after on_confirm.",
       "rdfs:domain": "deg:DiscomLedgerProvider",
       "rdfs:range": "xsd:anyURI"
     }

--- a/specification/schema/EnergyTradeOffer/v2.0/README.md
+++ b/specification/schema/EnergyTradeOffer/v2.0/README.md
@@ -30,7 +30,8 @@ All interval data (price, quantities, allocations) lives in two BecknTimeSeries:
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `validityWindow` | `TimePeriod` | | Window during which the offer can be selected/accepted. Present at catalog publish. |
-| `contractAttributes` | `object` (JSON-LD) | | DEGContract terms at catalog publish. Only parties with known `participantId` are included — unknown parties (null) are omitted. Mirrors `Contract.contractAttributes` — NPs promote this field verbatim at init. |
+| `contractAttributes` | `object` (JSON-LD) | | DEGContract terms at catalog publish: the role → participantId map (buyer-side null until discover) + policy ref. Mirrors `Contract.contractAttributes` — NPs promote this field verbatim at init. |
+| `participants` | `array` | | Seller-declared parties (identity-only: `id` + `participantAttributes`, no role). Joined from `contractAttributes.roles[].participantId`. Carries the seller discom's `discomUri` + `ledgerUri` so the buyer can construct `init`. |
 | `commitmentAttributes` | `TimeSeries` (JSON-LD) | ✓ | Seller's offer declaration: full payloadDescriptor schema with `insertedBy` + seller's initial intervals. Immutable after publish. |
 
 ## commitmentAttributes.payloadDescriptors

--- a/specification/schema/EnergyTradeOffer/v2.0/attributes.yaml
+++ b/specification/schema/EnergyTradeOffer/v2.0/attributes.yaml
@@ -57,9 +57,12 @@ components:
             Buyer-side roles (buyerPlatform, buyerDiscom) are declared with
             participantId: null at publish — the buyer is unknown to the seller
             until it engages after discover. Seller-side roles carry their known
-            participantIds. MUST carry @context and @type (typically DEGContract).
-            Present in catalog publish; omitted in downstream messages where
-            Contract.contractAttributes carries the full party list.
+            participantIds. Roles carry only role -> participantId; each party's
+            identity attributes live in the sibling `participants[]`, joined on
+            `id == roles[].participantId`. MUST carry @context and @type
+            (typically DEGContract). Present in catalog publish; omitted in
+            downstream messages where Contract.contractAttributes carries the
+            full party list.
           required: ["@context", "@type"]
           properties:
             "@context":
@@ -69,6 +72,39 @@ components:
               type: string
           x-jsonld:
             "@id": contractAttributes
+
+        participants:
+          type: array
+          description: >
+            Seller-declared trade parties at catalog publish, mirroring
+            Contract.participants[] in trade messages. Each entry is
+            identity-only: a Beckn-native `id` plus `participantAttributes`
+            (e.g. EnergyCustomer for sellerPlatform, DiscomLedgerProvider for
+            sellerDiscom). The party's role is NOT carried here — it is given by
+            contractAttributes.roles[], joined on `id == roles[].participantId`.
+
+            Only the seller-side parties (sellerPlatform, sellerDiscom) are
+            declared at publish; buyer-side parties are unknown until after
+            discover. This is where the seller publishes its discom's
+            `discomUri` + `ledgerUri`, so the buyer can construct `init` and
+            downstream cascades can route to the discom and its ledger.
+          items:
+            type: object
+            additionalProperties: true
+            required: [id]
+            properties:
+              id:
+                type: string
+                description: Party subscriber id / did:web; joined from contractAttributes.roles[].participantId.
+              descriptor:
+                type: object
+                additionalProperties: true
+              participantAttributes:
+                type: object
+                additionalProperties: true
+                description: Domain identity attributes (EnergyCustomer or DiscomLedgerProvider). MUST carry @context and @type.
+          x-jsonld:
+            "@id": participants
 
         commitmentAttributes:
           type: object

--- a/specification/schema/EnergyTradeOffer/v2.0/context.jsonld
+++ b/specification/schema/EnergyTradeOffer/v2.0/context.jsonld
@@ -12,6 +12,7 @@
     "EnergyTradeOffer": "deg:EnergyTradeOffer",
     "validityWindow": "deg:validityWindow",
     "contractAttributes": "deg:contractAttributes",
+    "participants": "deg:participants",
     "commitmentAttributes": "deg:commitmentAttributes",
     "insertedBy": "deg:insertedBy"
   },


### PR DESCRIPTION
Schema-first step of the wave2 roles/participants refactor. **Schemas only — no payloads/plugins/regos change here**, so nothing at runtime is affected yet (payloads follow in a separate PR). Versions kept in place per direction (not yet widely used).

## Why
Two problems in the current model:
1. `contractAttributes.roles[]` and `Contract.participants[]` **both** carry `role`+`participantId` — redundant, and `role`/`participantId` aren't even Beckn-core `Participant` fields (they only pass because `Participant` is open).
2. At publish, the `sellerDiscom` is exposed **only** as its ledger host; the discom's own platform URI is missing, so the buyer can't construct `init`.

## Changes
**`DiscomLedgerProvider/v1.0`** — identity-clean:
- Drop `utilityId` (the human alias `PVVNL`/`TEST_DISCOM_*` lives in the ledger, keyed by `ledgerId`).
- `platformUrl → discomUri`, `ledgerUrl → ledgerUri`; add `ledgerId`.
- The discom's own id is the participant `id` (not repeated); the ledger is a **distinct** party (`ledgerId` + `ledgerUri`).

**`EnergyTradeOffer/v2.0`** — add optional offer-level `participants[]` (identity-only: `id` + `participantAttributes`, no `role`), mirroring `Contract.participants[]`. Lets the seller publish its discom's `discomUri` + `ledgerUri` at catalog time; role is joined from `contractAttributes.roles[].participantId`. **This is what unblocks `init`.**

**`DEGContract/v2.0`** — doc only: `roles[]` is the role→participantId map; identity lives in role-less `participants[]` joined on `id`; discom roles use the DISCOM's id, **not** the ledger id.

`EnergyCustomer` deliberately untouched (used across ~15 credential/enrollment families); platform participants simply stop populating `utilityId` in payloads.

## Follow-up (separate PR)
Payloads (publish-catalog + trade examples restructured to the new shape), `substitutions.yaml`/postman, `degledgerrecorder` (role→id join; read `ledgerUri`/`discomUri`; send `discomId`), and both rego policies (network + DeDi-published contract policy). The recorder currently sends `participantAttributes.utilityId` as the ledger's `discomId` and routes on `ledgerUrl` — both move there, so the ledger service is unaffected until that PR.

## Testing
YAML/JSON well-formed; no `schema.json` bundles touched (these are leaf attribute schemas); no other schema references the removed discom fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)