### PR TITLE
feat(schema/p2p-wave2): discom id = UPADHI short code, add subscriberId

### DIFF
--- a/specification/schema/DEGContract/v2.0/attributes.yaml
+++ b/specification/schema/DEGContract/v2.0/attributes.yaml
@@ -53,9 +53,10 @@ components:
                 description: >
                   Concrete participant id once bound, matching a
                   Contract.participants[*].id. Platform roles use the platform
-                  subscriber id; discom roles use the DISCOM's own participant id
-                  (its subscriber id / did:web) — NOT the ledger id. The ledger is
-                  carried as an attribute (ledgerId/ledgerUri) on the discom
+                  subscriber id; discom roles use the DISCOM's UPADHI short code
+                  (e.g. "PVVNL") — NOT the ledger id or a subscriber id. The
+                  discom's beckn subscriberId, platform uri, and ledger
+                  (ledgerId/ledgerUri) are carried as attributes on the discom
                   participant. Null at catalog publish for sides not yet bound.
 
         policy:

--- a/specification/schema/DiscomLedgerProvider/README.md
+++ b/specification/schema/DiscomLedgerProvider/README.md
@@ -20,8 +20,9 @@ Identity attributes for a regulated discom ledger Technical Service Provider (TS
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
+| `subscriberId` | `string` | ✓ | The discom node's beckn subscriber id (routing/signing). |
 | `discomUri` | `URI` | ✓ | Base URL of the discom's own Beckn platform (init/cascade + allocation). |
 | `ledgerId` | `string` | ✓ | Subscriber id of the discom's ledger TSP (a distinct party). |
 | `ledgerUri` | `URI` | ✓ | Base URL of the discom ledger TSP endpoint. |
 
-The party's own id is the participant `id` (not repeated here); the human-readable utility alias (e.g. `PVVNL`) is resolved from `ledgerId` in the ledger, not carried on the wire.
+The participant `id` is the discom's UPADHI short code (e.g. `PVVNL`); the beckn routing identity is the `subscriberId` attribute.

--- a/specification/schema/DiscomLedgerProvider/v1.0/README.md
+++ b/specification/schema/DiscomLedgerProvider/v1.0/README.md
@@ -2,7 +2,7 @@
 
 Identity attributes for a discom acting as a `buyerDiscom` / `sellerDiscom` party in a P2P trade. Attached to `Contract.participants[*].participantAttributes` (and to the offer's `participants[]` at catalog publish).
 
-The party's own identity is the participant `id`; it is **not** repeated in these attributes. The attributes carry the discom's platform endpoint (`discomUri`) and its ledger (`ledgerId` + `ledgerUri`). The human-readable utility alias (e.g. `PVVNL`) is intentionally absent — it is resolved from `ledgerId` in the ledger.
+The party's `id` is the discom's **UPADHI short code** (e.g. `PVVNL`, `TPDDL`, `BRPL`) — a stable, regulator-defined identifier — and is not repeated in these attributes. The attributes carry the discom's beckn `subscriberId` (routing/signing identity), its platform endpoint (`discomUri`), and its ledger (`ledgerId` + `ledgerUri`).
 
 Part of the [DEG Schema](../../../specification/schema/) · [DiscomLedgerProvider](../README.md)
 
@@ -18,12 +18,13 @@ Part of the [DEG Schema](../../../specification/schema/) · [DiscomLedgerProvide
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
+| `subscriberId` | `string` | ✅ | The discom node's beckn subscriber id (routing/signing; appears as bppId/bapId on cascade legs) |
 | `discomUri` | `string` (uri) | ✅ | Base URL of the discom's own Beckn platform (init/cascade + unallocated-trade allocation) |
 | `ledgerId` | `string` | ✅ | Subscriber id of the discom's ledger TSP (a distinct party) |
 | `ledgerUri` | `string` (uri) | ✅ | Base URL of the discom ledger TSP where trades are recorded after `on_confirm` |
 
 ## Usage
 
-The party id (the discom's subscriber id / `did:web`) is the participant `id`, referenced from `contractAttributes.roles[role=buyerDiscom|sellerDiscom].participantId`. Two discoms MAY share a `ledgerId`/`ledgerUri` if they use the same TSP; each platform still calls only its own side's discom: BAP → `buyerDiscom`, BPP → `sellerDiscom`.
+The participant `id` is the discom's **UPADHI short code** (e.g. `PVVNL`), referenced from `contractAttributes.roles[role=buyerDiscom|sellerDiscom].participantId`; the beckn routing identity is the `subscriberId` attribute. Two discoms MAY share a `ledgerId`/`ledgerUri` if they use the same TSP; each platform still calls only its own side's discom: BAP → `buyerDiscom`, BPP → `sellerDiscom`.
 
 The `degledgerrecorder` plugin resolves the discom participant via the role→id join and reads `ledgerUri` (where to record) and `discomUri` (where to route allocation).

--- a/specification/schema/DiscomLedgerProvider/v1.0/attributes.yaml
+++ b/specification/schema/DiscomLedgerProvider/v1.0/attributes.yaml
@@ -8,16 +8,20 @@ info:
     the offer's participants[] at catalog publish) for entries whose role is
     buyerDiscom or sellerDiscom.
 
-    The party's own identity is the participant `id` (the discom's subscriber
-    id / did:web) — it is NOT repeated here. These attributes carry the two
-    endpoints a counterpart needs: `discomUri`, the discom's own Beckn platform
-    (target for init/cascade and unallocated-trade allocation), and the discom's
-    ledger, named by `ledgerId` (a distinct TSP participant) and reached at
-    `ledgerUri` (where trade records are written after on_confirm).
+    The party's `id` is the discom's short code as defined in CEA's UPADHI
+    portal list of abbreviations (e.g. "PVVNL", "TPDDL", "BRPL") — a stable,
+    regulator-defined identifier. It is NOT repeated here. These attributes
+    carry the discom's beckn identity and endpoints:
+      - `subscriberId` — the discom node's beckn subscriber id, used for
+        routing and signing (and appearing as bppId/bapId when the discom is
+        the caller/receiver on a cascade leg);
+      - `discomUri` — the discom's own Beckn platform base URL (target for
+        init/cascade and unallocated-trade allocation);
+      - `ledgerId` / `ledgerUri` — the discom's ledger TSP (a distinct party)
+        and the endpoint where trade records are written after on_confirm.
 
-    The human-readable utility alias (e.g. "PVVNL", "TPDDL") is intentionally
-    absent — it is resolved from `ledgerId` in the ledger, keeping the on-wire
-    identity stable and alias-free.
+    UPADHI list of abbreviations:
+    https://upadhi.cea.gov.in/assets/documents/List%20of%20Abbreviations_10%20March'25_UPADHI.pdf
 
     Two discoms MAY share a `ledgerUri`/`ledgerId` if they use the same TSP;
     each platform still calls only its own side's discom (BAP -> buyerDiscom,
@@ -28,7 +32,7 @@ components:
     DiscomLedgerProvider:
       type: object
       additionalProperties: false
-      required: [discomUri, ledgerId, ledgerUri]
+      required: [subscriberId, discomUri, ledgerId, ledgerUri]
       x-tags:
         - p2p-trading
         - discom-ledger
@@ -36,6 +40,17 @@ components:
         "@context": ./context.jsonld
         "@type": DiscomLedgerProvider
       properties:
+
+        subscriberId:
+          type: string
+          description: >
+            The discom node's beckn subscriber id (its routing/signing identity
+            in the network registry). Distinct from the participant `id`, which
+            is the UPADHI short code. Appears as context.bppId / context.bapId
+            when the discom is the caller/receiver on a cascade leg.
+          example: "seller-discom.example.com"
+          x-jsonld:
+            "@id": subscriberId
 
         discomUri:
           type: string
@@ -55,8 +70,7 @@ components:
           description: >
             Subscriber id (or did:web) of the discom's ledger TSP — a party
             distinct from the discom itself. Used to tag and route ledger
-            records, and as the key under which the ledger holds the discom's
-            human-readable alias.
+            records.
           example: "ies-p2p-energy-ledger.beckn.io"
           x-jsonld:
             "@id": ledgerId

--- a/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld
+++ b/specification/schema/DiscomLedgerProvider/v1.0/context.jsonld
@@ -8,6 +8,7 @@
     "beckn": "https://schema.nfh.global/core/v2.0/",
     "deg": "https://schema.nfh.global/deg/DiscomLedgerProvider/v1.0/",
     "DiscomLedgerProvider": "deg:DiscomLedgerProvider",
+    "subscriberId": "deg:subscriberId",
     "discomUri": "deg:discomUri",
     "ledgerId": "deg:ledgerId",
     "ledgerUri": "deg:ledgerUri"

--- a/specification/schema/DiscomLedgerProvider/v1.0/vocab.jsonld
+++ b/specification/schema/DiscomLedgerProvider/v1.0/vocab.jsonld
@@ -13,7 +13,15 @@
       "@id": "deg:DiscomLedgerProvider",
       "@type": "rdfs:Class",
       "rdfs:label": "Discom Ledger Provider",
-      "rdfs:comment": "Identity attributes for a discom acting as a buyerDiscom/sellerDiscom party in a P2P trade, attached to Contract.participants[*].participantAttributes. The party id is the participant id; these attributes carry the discom's platform URI and its ledger (id + uri)."
+      "rdfs:comment": "Identity attributes for a discom acting as a buyerDiscom/sellerDiscom party in a P2P trade, attached to Contract.participants[*].participantAttributes. The participant id is the UPADHI short code; these attributes carry the discom's beckn subscriberId, platform URI, and its ledger (id + uri)."
+    },
+    {
+      "@id": "deg:subscriberId",
+      "@type": "rdf:Property",
+      "rdfs:label": "Subscriber ID",
+      "rdfs:comment": "The discom node's beckn subscriber id (routing/signing identity); distinct from the participant id (the UPADHI short code).",
+      "rdfs:domain": "deg:DiscomLedgerProvider",
+      "rdfs:range": "xsd:string"
     },
     {
       "@id": "deg:discomUri",


### PR DESCRIPTION
Follow-up to #467. Schema-only; versions kept in place.

## Change
Refines how a discom party is identified in `DiscomLedgerProvider`:
- **Participant `id` is now the CEA UPADHI short code** (`PVVNL`, `TPDDL`, `BRPL`) — a stable, regulator-defined identifier — instead of a subscriber id / `did:web`. The allowlist can now key directly on the human-readable code.
- **Add `subscriberId`** — the discom node's beckn subscriber id (routing/signing; appears as `bppId`/`bapId` on cascade legs), distinct from the participant `id`.
- Keep `discomUri`, `ledgerId`, `ledgerUri`. `required` now includes `subscriberId`.
- `DEGContract` doc: a discom role's `participantId` is the UPADHI short code, not the ledger id or a subscriber id.

Result — a discom participant:
```jsonc
"id": "PVVNL",
"participantAttributes": {
  "@type": "DiscomLedgerProvider",
  "subscriberId": "seller-discom.example.com",
  "discomUri":    "https://seller-discom.example.com",
  "ledgerId":     "seller-discom-ledger.example.com",
  "ledgerUri":    "https://seller-discom-ledger.example.com"
}
```

## Consequence (handled in the payload/rego PR, not here)
With the discom `id` = short code, **N15** (`bppId`/`bapId` must match a participant id) will also accept a discom's `subscriberId` on cascade legs. Routing is unaffected (recorder routes on `discomUri`/`ledgerUri`). The allowlist keys on the short-code `id`.

## After merge
Republish **`DiscomLedgerProvider/v1.0`** to `schema.nfh.global` so the devkit's `schemav2validator` (extendedSchema) accepts `subscriberId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)