### PR TITLE
chore(p2p-wave2 postman): default ledger vars to the IES ledger

### DIFF
--- a/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.BUYER-DEG.postman_collection.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.BUYER-DEG.postman_collection.json
@@ -219,11 +219,11 @@
     },
     {
       "key": "ledger_host_buyer",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_seller",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_host_url",
@@ -235,11 +235,11 @@
     },
     {
       "key": "ledger_buyer_discom_id",
-      "value": "buyer-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_seller_discom_id",
-      "value": "seller-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_subscriber_id",

--- a/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.BUYERDISCOM-DEG.postman_collection.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.BUYERDISCOM-DEG.postman_collection.json
@@ -81,7 +81,7 @@
     },
     {
       "key": "bap_host_root",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "bpp_host_root",
@@ -93,15 +93,15 @@
     },
     {
       "key": "buyerdiscom_ledger_host_root",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_buyer",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_seller",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_host_url",
@@ -113,11 +113,11 @@
     },
     {
       "key": "ledger_buyer_discom_id",
-      "value": "buyer-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_seller_discom_id",
-      "value": "seller-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_subscriber_id",

--- a/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.BUYERDISCOMLEDGER-DEG.postman_collection.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.BUYERDISCOMLEDGER-DEG.postman_collection.json
@@ -144,7 +144,7 @@
     },
     {
       "key": "bpp_host_root",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_ledger_bpp_caller_url",
@@ -168,11 +168,11 @@
     },
     {
       "key": "ledger_host_buyer",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_seller",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_host_url",
@@ -184,11 +184,11 @@
     },
     {
       "key": "ledger_buyer_discom_id",
-      "value": "buyer-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_seller_discom_id",
-      "value": "seller-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_subscriber_id",

--- a/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.SELLER-DEG.postman_collection.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.SELLER-DEG.postman_collection.json
@@ -338,11 +338,11 @@
     },
     {
       "key": "ledger_host_buyer",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_seller",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_host_url",
@@ -354,11 +354,11 @@
     },
     {
       "key": "ledger_buyer_discom_id",
-      "value": "buyer-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_seller_discom_id",
-      "value": "seller-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_subscriber_id",

--- a/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.SELLERDISCOM-DEG.postman_collection.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.SELLERDISCOM-DEG.postman_collection.json
@@ -81,7 +81,7 @@
     },
     {
       "key": "bap_host_root",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "bpp_host_root",
@@ -93,15 +93,15 @@
     },
     {
       "key": "sellerdiscom_ledger_host_root",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_buyer",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_seller",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_host_url",
@@ -113,11 +113,11 @@
     },
     {
       "key": "ledger_buyer_discom_id",
-      "value": "buyer-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_seller_discom_id",
-      "value": "seller-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_subscriber_id",

--- a/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.SELLERDISCOMLEDGER-DEG.postman_collection.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/postman/p2p-trading-ies-wave2-uc1.SELLERDISCOMLEDGER-DEG.postman_collection.json
@@ -144,7 +144,7 @@
     },
     {
       "key": "bpp_host_root",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "seller_ledger_bpp_caller_url",
@@ -168,11 +168,11 @@
     },
     {
       "key": "ledger_host_buyer",
-      "value": "http://buyer-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_host_seller",
-      "value": "http://seller-discom-ledger.example.com:9000"
+      "value": "https://ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_host_url",
@@ -184,11 +184,11 @@
     },
     {
       "key": "ledger_buyer_discom_id",
-      "value": "buyer-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "ledger_seller_discom_id",
-      "value": "seller-discom-ledger.example.com"
+      "value": "ies-p2p-energy-ledger.beckn.io"
     },
     {
       "key": "buyer_discom_subscriber_id",

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -204,8 +204,8 @@ DEVKIT_CONFIGS = {
         # Ledger TSP base URLs (ledgerUri on DiscomLedgerProvider). Match the
         # local example.com hosts used by uc1 examples / docker-compose; override
         # the Postman variable to point at a shared IES ledger if needed.
-        "ledger_host_buyer": "http://buyer-discom-ledger.example.com:9000",
-        "ledger_host_seller": "http://seller-discom-ledger.example.com:9000",
+        "ledger_host_buyer": "https://ies-p2p-energy-ledger.beckn.io",
+        "ledger_host_seller": "https://ies-p2p-energy-ledger.beckn.io",
         "examples_path": "devkits/p2p-trading-ies-wave2/uc1/examples",
         # Source dirs for the discom-ledger TSP collections. The on_status.json
         # response fixtures here ARE the canonical outbound on_status payloads
@@ -247,8 +247,8 @@ DEVKIT_CONFIGS = {
         # Postman variables in all wave2 collections. seller_discom_ledger_id is
         # also used in substitutions.yaml for context.bppId in
         # seller-initiated-status-to-seller-discom flows.
-        "ledger_buyer_discom_id": "buyer-discom-ledger.example.com",
-        "ledger_seller_discom_id": "seller-discom-ledger.example.com",
+        "ledger_buyer_discom_id": "ies-p2p-energy-ledger.beckn.io",
+        "ledger_seller_discom_id": "ies-p2p-energy-ledger.beckn.io",
         "transaction_id": "2b4d69aa-22e4-4c78-9f56-5a7b9e2b2026",
         "seller_discom_ledger_id": "seller-discom-ledger.example.com",
         "usecase": "uc1",


### PR DESCRIPTION
Sets the postman generator's default values so the collections point at the canonical **IES ledger** instead of the devkit-local example hosts.

| Variable | New default |
|---|---|
| `ledger_buyer_discom_id` | `ies-p2p-energy-ledger.beckn.io` |
| `ledger_seller_discom_id` | `ies-p2p-energy-ledger.beckn.io` |
| `ledger_host_buyer` | `https://ies-p2p-energy-ledger.beckn.io` |
| `ledger_host_seller` | `https://ies-p2p-energy-ledger.beckn.io` |

These feed the `{{…}}` substitutions for each discom participant's `ledgerId` / `ledgerUri`, so the collection payloads now reference the IES ledger by default (users override for local runs).

- Changed the four defaults in `scripts/generate_postman_collection.py` and regenerated all 6 collections.
- Left unrelated vars untouched (`seller_discom_ledger_id`, `*_discom_subscriber_id`, `*_discom_host_url`).
- Verified: all 6 collections are valid JSON with no undefined `{{vars}}`; every collection now carries the IES defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)