### PR TITLE
fix(p2p-wave2): report both intervals in discom on_status examples

### DIFF
--- a/devkits/p2p-trading-ies-wave2/uc1/examples/buyerdiscom-on-status.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/buyerdiscom-on-status.json
@@ -30,7 +30,7 @@
                 "@type": "DatasetItem",
                 "schema:identifier": "ds-actuals-buyer-001",
                 "schema:name": "Buyer-discom meter actuals",
-                "schema:temporalCoverage": "2026-04-26T04:30:00Z/2026-04-26T05:30:00Z",
+                "schema:temporalCoverage": "2026-04-26T04:30:00Z/2026-04-26T06:30:00Z",
                 "dataPayload": {
                   "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
                   "@type": "TimeSeries",
@@ -38,7 +38,8 @@
                   "clientName": "TEST_DISCOM_BUYER",
                   "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "ENERGY_CONSUMPTION", "units": "KWH"}],
-                  "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": [19.2]}]}]
+                  "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": [5.0]}]},
+                  {"id": 1, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": [7.0]}]}]
                 }
               }
             }

--- a/devkits/p2p-trading-ies-wave2/uc1/examples/sellerdiscom-on-status.json
+++ b/devkits/p2p-trading-ies-wave2/uc1/examples/sellerdiscom-on-status.json
@@ -30,7 +30,7 @@
                 "@type": "DatasetItem",
                 "schema:identifier": "ds-actuals-001",
                 "schema:name": "Seller-discom meter actuals",
-                "schema:temporalCoverage": "2026-04-26T04:30:00Z/2026-04-26T05:30:00Z",
+                "schema:temporalCoverage": "2026-04-26T04:30:00Z/2026-04-26T06:30:00Z",
                 "dataPayload": {
                   "@context": "https://schema.nfh.global/BecknTimeSeries/v1.0/context.jsonld",
                   "@type": "TimeSeries",
@@ -38,7 +38,8 @@
                   "clientName": "TEST_DISCOM_SELLER",
                   "intervalPeriod": {"start": "2026-04-26T04:30:00Z", "duration": "PT1H"},
                   "payloadDescriptors": [{"objectType": "REPORT_PAYLOAD_DESCRIPTOR", "payloadType": "ENERGY_CONSUMPTION", "units": "KWH"}],
-                  "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": [-19.2]}]}]
+                  "intervals": [{"id": 0, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": [-10.0]}]},
+                  {"id": 1, "payloads": [{"type": "ENERGY_CONSUMPTION", "values": [-12.0]}]}]
                 }
               }
             }


### PR DESCRIPTION
## What
The seller/buyer discom `on_status` meter-data examples reported `ENERGY_CONSUMPTION` for interval `0` only. Add interval `1` so both delivery slots are reported:

| Example | id 0 | id 1 |
|---|---|---|
| `buyerdiscom-on-status.json` (consumption, +) | `5.0` | `7.0` |
| `sellerdiscom-on-status.json` (injection, −) | `-10.0` | `-12.0` |

Also extended each `schema:temporalCoverage` from `04:30/05:30` (1h) to `04:30/06:30` (2h) so the dataset window spans both `PT1H` intervals.

## Scope
Devkit examples only. Both files re-validated as JSON.