### PR TITLE
feat(demand-flex): fail-fast commitment-formation + interval-id checks in network rego

### DIFF
--- a/specification/policies/demand-flex-networkpolicy.rego
+++ b/specification/policies/demand-flex-networkpolicy.rego
@@ -29,6 +29,24 @@
 #      rule transparently passes traffic that lacks a seller
 #      `reportDescriptors` declaration.
 #
+#   3. Commitment formation completeness (fail fast). Once the seller
+#      has presented a CAPACITY_OFFERED column
+#      (`commitments[*].commitmentAttributes` declaring CAPACITY_OFFERED —
+#      first on the wire at init), every DemandFlexNeed interval MUST
+#      carry a seller CAPACITY_OFFERED value, and the offered series'
+#      `intervalPeriod` MUST match the need grid. This surfaces a
+#      malformed commitment at init/confirm rather than at settlement.
+#      The contract rego keeps the equivalent rules as a settlement-time
+#      backstop. Self-skips on messages with no offered series (bare
+#      select / on_select, status-id round-trips).
+#
+#   4. BecknTimeSeries interval id sequence. Every series' `intervals[*].id`
+#      MUST be 0,1,2,… — start at 0 and increase by 1, with no gaps,
+#      duplicates, or out-of-order ids. Applied to the DemandFlexNeed
+#      series, the CAPACITY_OFFERED series, and each meter's telemetry.
+#      A series that declares no ids at all self-skips (partial/legacy
+#      payloads).
+#
 # Canonical source: specification/policies/demand-flex-networkpolicy.rego
 
 package deg.policy.demand_flex_network
@@ -62,7 +80,7 @@ _per_event_types := {d.payloadType |
 
 _per_interval_types := {d.payloadType |
 	some d in _seller_descriptors
-	d.cardinality != "PER_EVENT"   # default == PER_INTERVAL
+	d.cardinality != "PER_EVENT" # default == PER_INTERVAL
 }
 
 _count_payloads(meter, ptype) := n if {
@@ -128,13 +146,16 @@ violations contains msg if {
 	some ptype in _per_event_types
 	n := _count_payloads(meter, ptype)
 	n != 1
+
 	# Tolerate completely-absent telemetry types (e.g. a grid-meter-only
 	# baselines push) by skipping when the meter doesn't declare ptype in
 	# its own payloadDescriptors.
 	declared := {d.payloadType | some d in meter.telemetry.payloadDescriptors}
 	ptype in declared
-	msg := sprintf("device %s: PER_EVENT payload '%s' must appear in exactly 1 interval (found %d)",
-		[meter.meterId, ptype, n])
+	msg := sprintf(
+		"device %s: PER_EVENT payload '%s' must appear in exactly 1 interval (found %d)",
+		[meter.meterId, ptype, n],
+	)
 }
 
 # ----- 2b) PER_INTERVAL — present in every interval -------------------
@@ -148,6 +169,92 @@ violations contains msg if {
 	total := count(meter.telemetry.intervals)
 	hits := _count_payloads(meter, ptype)
 	hits != total
-	msg := sprintf("device %s: PER_INTERVAL payload '%s' must appear in every interval (found %d of %d)",
-		[meter.meterId, ptype, hits, total])
+	msg := sprintf(
+		"device %s: PER_INTERVAL payload '%s' must appear in every interval (found %d of %d)",
+		[meter.meterId, ptype, hits, total],
+	)
+}
+
+# ----- 3) commitment formation completeness (fail fast) ---------------
+# Pair each commitment's buyer DemandFlexNeed with the seller's
+# CAPACITY_OFFERED series. A pair forms only once the seller has presented
+# a CAPACITY_OFFERED column (commitmentAttributes declaring it); bare
+# select / on_select and status-id round-trips carry no offered series and
+# self-skip. The contract rego keeps equivalent rules as a settlement-time
+# backstop.
+
+_offered_pairs contains pair if {
+	some c in input.message.contract.commitments
+	need := c.resources[0].resourceAttributes
+	need.intervals
+	ca := c.commitmentAttributes
+	"CAPACITY_OFFERED" in {d.payloadType | some d in ca.payloadDescriptors}
+	pair := {"cid": object.get(c, "id", "?"), "need": need, "offered": ca}
+}
+
+_offered_val(intervals, ivid) := v if {
+	some iv in intervals
+	iv.id == ivid
+	some pl in iv.payloads
+	pl.type == "CAPACITY_OFFERED"
+	v := pl.values[0]
+}
+
+# every requested slot must carry a seller CAPACITY_OFFERED value
+violations contains msg if {
+	some p in _offered_pairs
+	some iv in p.need.intervals
+	not _offered_val(p.offered.intervals, iv.id)
+	msg := sprintf("commitment %s, interval %v: missing CAPACITY_OFFERED", [p.cid, iv.id])
+}
+
+# the CAPACITY_OFFERED grid must match the DemandFlexNeed grid
+violations contains msg if {
+	some p in _offered_pairs
+	p.offered.intervalPeriod != p.need.intervalPeriod
+	msg := sprintf("commitment %s: CAPACITY_OFFERED intervalPeriod does not match the DemandFlexNeed grid", [p.cid])
+}
+
+# ----- 4) BecknTimeSeries interval id sequence ------------------------
+# Every series' intervals[*].id MUST be 0,1,2,… (start at 0, +1 each, no
+# gaps/dups/out-of-order). Applied to the need series, the CAPACITY_OFFERED
+# series, and each meter's telemetry. A series declaring no ids self-skips.
+
+_id_series contains s if {
+	some ra in _demand_flex_needs
+	s := {"label": "DemandFlexNeed", "intervals": ra.intervals}
+}
+
+_id_series contains s if {
+	some c in input.message.contract.commitments
+	ca := c.commitmentAttributes
+	ca.intervals
+	s := {"label": sprintf("commitment %s CAPACITY_OFFERED series", [object.get(c, "id", "?")]), "intervals": ca.intervals}
+}
+
+_id_series contains s if {
+	some perf in input.message.contract.performance
+	some m in perf.performanceAttributes.meters
+	m.telemetry.intervals
+	s := {"label": sprintf("meter %s telemetry", [m.meterId]), "intervals": m.telemetry.intervals}
+}
+
+_ids(intervals) := [iv.id | some iv in intervals]
+
+# no ids declared anywhere → out of scope for this check
+_ids_ok(intervals) if count(_ids(intervals)) == 0
+
+# every interval carries an id and they are 0,1,2,… in order
+_ids_ok(intervals) if {
+	ids := _ids(intervals)
+	count(ids) == count(intervals)
+	every i, id in ids {
+		id == i
+	}
+}
+
+violations contains msg if {
+	some s in _id_series
+	not _ids_ok(s.intervals)
+	msg := sprintf("%s: interval ids must start at 0 and increase by 1, got %v", [s.label, _ids(s.intervals)])
 }

--- a/specification/policies/test/demand-flex-networkpolicy_test.rego
+++ b/specification/policies/test/demand-flex-networkpolicy_test.rego
@@ -7,9 +7,7 @@ package deg.policy.demand_flex_network
 import rego.v1
 
 # Helper: minimal on_status payload with one meter
-_payload(meter) := {"message": {"contract": {"performance": [
-	{"performanceAttributes": {"meters": [meter]}},
-]}}}
+_payload(meter) := {"message": {"contract": {"performance": [{"performanceAttributes": {"meters": [meter]}}]}}}
 
 # Test: clean payload (every used type declared) → no violations
 test_clean_payload if {
@@ -60,9 +58,7 @@ test_declared_but_unused_is_allowed if {
 				{"payloadType": "BASELINE"},
 				{"payloadType": "USAGE"},
 			],
-			"intervals": [{"payloads": [
-				{"type": "BASELINE", "values": [46.0]},
-			]}],
+			"intervals": [{"payloads": [{"type": "BASELINE", "values": [46.0]}]}],
 		},
 	}
 	count(violations) == 0 with input as _payload(meter)
@@ -90,9 +86,7 @@ test_typo_isolated_to_one_meter if {
 			"intervals": [{"payloads": [{"type": "BASLN", "values": [46.0]}]}],
 		},
 	}
-	inp := {"message": {"contract": {"performance": [
-		{"performanceAttributes": {"meters": [good, bad]}},
-	]}}}
+	inp := {"message": {"contract": {"performance": [{"performanceAttributes": {"meters": [good, bad]}}]}}}
 	vs := violations with input as inp
 	count(vs) == 1
 	some v in vs
@@ -111,9 +105,7 @@ _valid_need := {
 		{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "PRICE"},
 		{"objectType": "EVENT_PAYLOAD_DESCRIPTOR", "payloadType": "SHORTFALL_PENALTY"},
 	],
-	"intervals": [
-		{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
-	],
+	"intervals": [{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]}],
 }
 
 _need_input(ra) := {"message": {"contract": {"commitments": [{"resources": [{"resourceAttributes": ra}]}]}}}
@@ -147,4 +139,114 @@ test_need_type_coverage_catalog if {
 	vs := violations with input as inp
 	some v in vs
 	contains(v, "MYSTERY")
+}
+
+# ---------------------------------------------------------------------------
+# 3) commitment formation completeness (fail fast at init/confirm)
+# ---------------------------------------------------------------------------
+
+# two-slot need + matching-grid CAPACITY_OFFERED series
+_need2 := {
+	"intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
+	"payloadDescriptors": [
+		{"payloadType": "CAPACITY_REQUESTED"},
+		{"payloadType": "PRICE"},
+		{"payloadType": "SHORTFALL_PENALTY"},
+	],
+	"intervals": [
+		{"id": 0, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [150]}, {"type": "PRICE", "values": [3.5]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+		{"id": 1, "payloads": [{"type": "CAPACITY_REQUESTED", "values": [200]}, {"type": "PRICE", "values": [4.0]}, {"type": "SHORTFALL_PENALTY", "values": [1.5]}]},
+	],
+}
+
+_offered2 := {
+	"@type": "TimeSeries",
+	"intervalPeriod": {"start": "2026-04-01T08:30:00Z", "duration": "PT30M"},
+	"payloadDescriptors": [{"payloadType": "CAPACITY_OFFERED"}],
+	"intervals": [
+		{"id": 0, "payloads": [{"type": "CAPACITY_OFFERED", "values": [150]}]},
+		{"id": 1, "payloads": [{"type": "CAPACITY_OFFERED", "values": [120]}]},
+	],
+}
+
+_commit_input(need, ca) := {"message": {"contract": {"commitments": [{
+	"id": "cmt-1",
+	"resources": [{"resourceAttributes": need}],
+	"commitmentAttributes": ca,
+}]}}}
+
+# complete offer against every slot, matching grid → no violation
+test_capacity_offered_complete_ok if {
+	count(violations) == 0 with input as _commit_input(_need2, _offered2)
+}
+
+# offered series missing a slot → violation naming the missing interval
+test_capacity_offered_missing_slot if {
+	partial := json.patch(_offered2, [{"op": "remove", "path": "/intervals/1"}])
+	vs := violations with input as _commit_input(_need2, partial)
+	count(vs) == 1
+	some v in vs
+	contains(v, "missing CAPACITY_OFFERED")
+	contains(v, "interval 1")
+}
+
+# offered grid does not match the need grid → violation
+test_capacity_offered_grid_mismatch if {
+	mism := json.patch(_offered2, [{"op": "replace", "path": "/intervalPeriod/duration", "value": "PT60M"}])
+	vs := violations with input as _commit_input(_need2, mism)
+	count(vs) == 1
+	some v in vs
+	contains(v, "does not match the DemandFlexNeed grid")
+}
+
+# no offered series yet (e.g. on_select) → formation checks self-skip
+test_no_offer_yet_self_skips if {
+	inp := {"message": {"contract": {"commitments": [{
+		"id": "cmt-1",
+		"resources": [{"resourceAttributes": _need2}],
+		"status": {"descriptor": {"code": "ACTIVE"}},
+	}]}}}
+	count(violations) == 0 with input as inp
+}
+
+# ---------------------------------------------------------------------------
+# 4) BecknTimeSeries interval id sequence
+# ---------------------------------------------------------------------------
+
+# ids 0,1 → no violation
+test_interval_ids_ok if {
+	count(violations) == 0 with input as _need_input(_need2)
+}
+
+# ids do not start at 0 → violation
+test_interval_ids_must_start_at_zero if {
+	bad := json.patch(_valid_need, [{"op": "replace", "path": "/intervals/0/id", "value": 1}])
+	vs := violations with input as _need_input(bad)
+	some v in vs
+	contains(v, "DemandFlexNeed")
+	contains(v, "start at 0")
+}
+
+# gap in ids (0,2) → violation
+test_interval_ids_gap if {
+	bad := json.patch(_need2, [{"op": "replace", "path": "/intervals/1/id", "value": 2}])
+	vs := violations with input as _need_input(bad)
+	some v in vs
+	contains(v, "start at 0 and increase by 1")
+}
+
+# some intervals carry no id → violation (partial id declaration)
+test_interval_ids_partial_missing if {
+	bad := json.patch(_need2, [{"op": "remove", "path": "/intervals/1/id"}])
+	vs := violations with input as _need_input(bad)
+	some v in vs
+	contains(v, "increase by 1")
+}
+
+# the id check also applies to the CAPACITY_OFFERED series
+test_interval_ids_on_offered_series if {
+	bad := json.patch(_offered2, [{"op": "replace", "path": "/intervals/0/id", "value": 5}])
+	vs := violations with input as _commit_input(_need2, bad)
+	some v in vs
+	contains(v, "CAPACITY_OFFERED series")
 }


### PR DESCRIPTION
## Why

A malformed commitment currently surfaces only at **settlement** — e.g. `SETTLEMENT_VIOLATIONS: "interval 0: missing CAPACITY_OFFERED; no settlement-eligible interval data found"` on `on_status`, after the event has already run. The check behind it ([`demand-flex-contractpolicy.rego:193`](specification/policies/demand-flex-contractpolicy.rego#L193)) depends only on the buyer's `DemandFlexNeed` and the seller's `CAPACITY_OFFERED` series — both present from **init** onward — so it can fail fast.

## Approach — no contract-rego refactor

These are structural completeness invariants, the same character as the network rego's existing type-coverage / cardinality checks, so they move to **`demand-flex-networkpolicy.rego`** (evaluated at the BPP `checkPolicy` step, across the lifecycle). The contract rego is left untouched — its rules stay as a **settlement-time backstop**.

## Checks added

**3. Commitment formation completeness (fail fast)** — once the seller has presented a `CAPACITY_OFFERED` column (`commitmentAttributes` declaring it; first on the wire at init):
- every `DemandFlexNeed` interval must carry a seller `CAPACITY_OFFERED` value;
- the `CAPACITY_OFFERED` grid (`intervalPeriod`) must match the need grid.

Self-skips on messages with no offered series (bare `select`/`on_select`, status-id round-trips), so no false NACKs.

**4. BecknTimeSeries interval-id sequence** — every series' `intervals[*].id` must be `0,1,2,…` (start at 0, +1 each, no gaps/dups/out-of-order). Applied to the need series, the `CAPACITY_OFFERED` series, and each meter's telemetry. A series declaring no ids self-skips.

### Where the interval-id check lives
In the **network rego**, not the contract rego: it's a domain-structural `BecknTimeSeries` invariant (like the existing checks 1/1b/2), applies uniformly to all three series types, and is not a contract-commercial term.

## Verification

- `opa test`: **18/18** network-rego unit tests pass (9 new covering complete/missing-slot/grid-mismatch/no-offer-skip and id start-at-0/gap/partial-missing/offered-series).
- `opa fmt`: clean.
- Evaluated `violations` against **every** uc1 + uc2 example payload → **zero** violations (no false NACKs), with `_offered_pairs`/`_id_series` confirmed populated so the rules are live: formation check engages from `init-request` (offered_pairs=1), correctly skips `on-select`/`publish` (offered_pairs=0), and the id check covers need + offered + all meter telemetry on `on-status`.

Fail-fast point: **init** (earliest message carrying `CAPACITY_OFFERED`), vs. settlement previously.