### PR TITLE
fix(devkits): raise onix responseHeaderTimeout 5s→30s to unblock cold-cache schema resolution

### DIFF
--- a/devkits/data-exchange/config/local-simple-bap.yaml
+++ b/devkits/data-exchange/config/local-simple-bap.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -84,7 +84,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/data-exchange/config/local-simple-bpp.yaml
+++ b/devkits/data-exchange/config/local-simple-bpp.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -108,7 +108,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/demand-flex/config/local-demand-flex-bap.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bap.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -87,7 +87,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/demand-flex/config/local-demand-flex-bpp.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bpp.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -87,7 +87,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/ev-charging-migration-kit/config/local-beckn-one-bap.yaml
+++ b/devkits/ev-charging-migration-kit/config/local-beckn-one-bap.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -86,7 +86,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/ev-charging-migration-kit/config/local-beckn-one-bpp.yaml
+++ b/devkits/ev-charging-migration-kit/config/local-beckn-one-bpp.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -86,7 +86,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/ev-charging/config/local-ev-bap.yaml
+++ b/devkits/ev-charging/config/local-ev-bap.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -80,7 +80,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/ev-charging/config/local-ev-bpp.yaml
+++ b/devkits/ev-charging/config/local-ev-bpp.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -75,7 +75,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/p2p-enrollment/config/local-enrollment-bap.yaml
+++ b/devkits/p2p-enrollment/config/local-enrollment-bap.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -81,7 +81,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/p2p-enrollment/config/local-enrollment-bpp.yaml
+++ b/devkits/p2p-enrollment/config/local-enrollment-bpp.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -76,7 +76,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/p2p-trading-ies-wave1/config/local-p2p-bap.yaml
+++ b/devkits/p2p-trading-ies-wave1/config/local-p2p-bap.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -110,7 +110,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry

--- a/devkits/p2p-trading-ies-wave1/config/local-p2p-bpp.yaml
+++ b/devkits/p2p-trading-ies-wave1/config/local-p2p-bpp.yaml
@@ -26,7 +26,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry
@@ -86,7 +86,7 @@ modules:
         maxIdleConns: 1000
         maxIdleConnsPerHost: 200
         idleConnTimeout: 300s
-        responseHeaderTimeout: 5s
+        responseHeaderTimeout: 30s
       plugins:
         registry:
           id: dediregistry


### PR DESCRIPTION
## Symptom

On a fresh stack, demand-flex arazzo `select`/`init`/`confirm`/`update` failed with HTTP 502; onix-bpp logged `context canceled` while fetching `https://schema.nfh.global/EnergyResourceCommon/v1.0` — even though every schema URL returns 200 from the host. `publish`/`discover` passed. It never self-healed across retries.

## Root cause

The BAP/BPP caller module's HTTP client had `responseHeaderTimeout: 5s`. Validating `offerAttributes` (`@type: DemandFlexBuyOffer`) on a **cold cache** requires resolving a 4-deep remote `$ref` chain — `DemandFlexBuyOffer → EnergyResource → EnergyResourceStorage → EnergyResourceCommon` — i.e. four sequential HTTPS GETs to `schema.nfh.global` from inside the container, which takes longer than 5s.

1. The calling onix waits ≤5s for the receiver's response headers.
2. The receiver is still resolving the cold `$ref` chain at 5s.
3. The caller disconnects → the receiver's request context (which the schema resolver runs under) is **canceled** → the in-flight GET returns `context canceled` (parent-canceled, not a deadline) → `validateSchema` NACKs → 502.

onix caches a schema only after a **successful** top-level load, so the aborted load cached nothing and every request failed identically — a timeout deadlock (5s caller budget vs >5s cold resolution).

## Fix

Raise `responseHeaderTimeout` `5s → 30s` on the caller modules, matching `extendedSchema_downloadTimeout: 30` and the value **p2p-trading-ies-wave2 already uses**. The first cold request now finishes resolving and populates the cache (`extendedSchema_cacheTTL: 86400`); subsequent calls are fast.

Applied to the six devkits still on 5s: `data-exchange`, `demand-flex`, `ev-charging`, `ev-charging-migration-kit`, `p2p-enrollment`, `p2p-trading-ies-wave1` (12 files, 24 occurrences). `p2p-trading-ies-wave2` was already 30s. Diff is the timeout value only.

## Verification

Restarted the demand-flex stack with the new config and ran both suites end-to-end:
- **uc1** — 4/4 workflows, 10/10 steps, **30/30 checks**, all ACK (previously `select`/`init`/`confirm`/`update` 502'd).
- **uc2** — 3/3 workflows, 8/8 steps, **24/24 checks**, all ACK.

This also confirms the merged network-rego formation checks (#478) run clean through the full flow.