### PR TITLE
fix(p2p-trading-interdiscom): reject order quantity equal to the offer cap

### DIFF
--- a/specification/policies/p2p-trading-interdiscom.rego
+++ b/specification/policies/p2p-trading-interdiscom.rego
@@ -239,10 +239,10 @@ _order_violations contains msg if {
 	item := input.message.order["beckn:orderItems"][i]
 	qty := item["beckn:quantity"].unitQuantity
 	cap := item["beckn:acceptedOffer"]["beckn:price"].applicableQuantity.unitQuantity
-	qty > cap
+	qty >= cap
 
 	msg := sprintf(
-		"order item [%d]: beckn:quantity.unitQuantity (%v) must not be greater than the applicableQuantity (%v)",
+		"order item [%d]: beckn:quantity.unitQuantity (%v) must be less than the applicableQuantity (%v)",
 		[i, qty, cap],
 	)
 }

--- a/specification/policies/test/p2p-trading-interdiscom_test.rego
+++ b/specification/policies/test/p2p-trading-interdiscom_test.rego
@@ -101,3 +101,39 @@ test_t1_mixed_buyer_utility_fail if {
 	contains(msg, "buyer utilityId")
 	contains(msg, "TEST_DISCOM_BUYER")
 }
+
+# ──────────────────────────────────────────────────────────────────────────────
+# O5 – ordered quantity must be strictly less than the offer cap
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Only the fields Rule 6b reads are populated; the other order rules are not
+# exercised here, so assertions look for the specific message rather than
+# counting the whole violation set.
+_input_with_quantities(qty, cap) := {"message": {"order": {"beckn:orderItems": [{
+	"beckn:quantity": {"unitQuantity": qty},
+	"beckn:acceptedOffer": {"beckn:price": {"applicableQuantity": {"unitQuantity": cap}}},
+}]}}}
+
+_has_cap_violation(msgs) if {
+	some msg in msgs
+	contains(msg, "applicableQuantity")
+}
+
+# Below the cap is the only accepted case.
+test_o5_quantity_below_cap_passes if {
+	msgs := _order_violations with input as _input_with_quantities(9, 10)
+	not _has_cap_violation(msgs)
+}
+
+# Equal to the cap must be rejected: O5 requires strictly less than, so an order
+# consuming the entire published cap is a violation rather than the boundary
+# being inclusive.
+test_o5_quantity_equal_to_cap_fails if {
+	msgs := _order_violations with input as _input_with_quantities(10, 10)
+	_has_cap_violation(msgs)
+}
+
+test_o5_quantity_above_cap_fails if {
+	msgs := _order_violations with input as _input_with_quantities(11, 10)
+	_has_cap_violation(msgs)
+}


### PR DESCRIPTION
Fixes #258.

## The mismatch

Rule 6b blocked only `qty > cap`, so an order for **exactly** the published `applicableQuantity` passed validation. Three places in the repo disagreed about the intended boundary:

| Source | Says |
|---|---|
| **O5**, this policy's header (line 26-27) | quantity "must be >= 0 and **strictly less than** the offer's applicableQuantity.unitQuantity" |
| Rule 6b's own title (line 237) | "Ordered quantity must be **<** applicableQuantity (offer cap)" |
| Implementation + message | `qty > cap` / "must not be greater than" — i.e. **inclusive** |

O5 is the policy's normative statement and the rule title agrees with it, so the implementation and the message were the odd ones out. This changes the predicate to `qty >= cap` and rewords the message to describe O5 rather than the old behaviour.

## Testing

Added boundary tests to `p2p-trading-interdiscom_test.rego`, which previously had no coverage of the order rules at all (only T1 test-consistency):

- `test_o5_quantity_below_cap_passes` — 9 vs 10, no violation
- `test_o5_quantity_equal_to_cap_fails` — 10 vs 10, violation (**fails without this change**)
- `test_o5_quantity_above_cap_fails` — 11 vs 10, violation

`opa test` on the policy plus its tests: **10/10 pass** with the change; without it the equality case fails and the rest are unaffected, so nothing else depends on the old inclusive behaviour.

The tests assert on the specific message rather than the size of `_order_violations`, since that set aggregates 44 rules and a count-based assertion would be brittle.

## Compatibility

I scanned every JSON under the repo for an order item whose `beckn:quantity.unitQuantity` equals its accepted offer's `applicableQuantity.unitQuantity` — the shape that becomes a violation under this change. There are none, so no shipped example, devkit, or Postman collection starts failing.
