### PR TITLE
fix(demand-flex): enforce CAPACITY_OFFERED at select/init/confirm; catch dropped column early

### DIFF
--- a/devkits/demand-flex/config/local-demand-flex-bap.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bap.yaml
@@ -72,9 +72,25 @@ modules:
             config:
               uuidKeys: transaction_id,message_id
               role: bap
+        steps:
+          # Enforce the contract policy on INCOMING responses from the BPP,
+          # before the BAP app sees them. Enforce-only (no output* keys):
+          # evaluates <contractAttributes.policy.queryPath>.violations and
+          # NACKs when non-empty. Scoped to pre-settlement responses only —
+          # on_status is excluded (settlement checks fire on intermediate
+          # telemetry pushes); structural enforcement at status is owned by
+          # checkPolicy (the network policy). on_select is safe: the contract
+          # rego self-skips when no seller offer is present.
+          - id: contractpolicyenforcer
+            config:
+              actions: "on_select,on_init,on_confirm"
+              violationActions: "on_select,on_init,on_confirm"
+              debugLogging: "true"
+              allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
       steps:
         - validateSign
         - checkPolicy
+        - contractpolicyenforcer
         - addRoute
         - validateSchema
 

--- a/devkits/demand-flex/config/local-demand-flex-bpp.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bpp.yaml
@@ -72,9 +72,27 @@ modules:
             config:
               uuidKeys: transaction_id,message_id
               role: bpp
+        steps:
+          # Enforce the contract policy on INCOMING requests, before the BPP
+          # app sees them. Enforce-only (no output* keys → no injection):
+          # evaluates <contractAttributes.policy.queryPath>.violations and
+          # NACKs when non-empty. Scoped to pre-settlement actions only —
+          # on_status is deliberately excluded because the contract rego's
+          # settlement checks (missing USAGE / net-zero / no settlement perf)
+          # legitimately fire on intermediate baseline / resource-telemetry
+          # pushes; structural enforcement at status is owned by checkPolicy
+          # (the network policy). select is safe: the contract rego self-skips
+          # when no seller offer is present.
+          - id: contractpolicyenforcer
+            config:
+              actions: "select,init,confirm"
+              violationActions: "select,init,confirm"
+              debugLogging: "true"
+              allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
       steps:
         - validateSign
         - checkPolicy
+        - contractpolicyenforcer
         - addRoute
         - validateSchema
 

--- a/specification/policies/demand-flex-contractpolicy.rego
+++ b/specification/policies/demand-flex-contractpolicy.rego
@@ -142,7 +142,33 @@ net_zero_ok if _revenue_sum == 0
 # --------------------------------------------------------------------------
 # Violations
 # --------------------------------------------------------------------------
+#
+# `violations` is the NACK gate. Two families of rule live here, each
+# self-skipping when its data is absent so the same set is safe to evaluate
+# at every stage the contract enforcer runs (select → init → confirm; and
+# the settlement family additionally at the final settled status):
+#
+#   Formation (safe from init/confirm onward):
+#     V1  seller/buyer roles present
+#     V2  DemandFlexNeed columns == {CAPACITY_REQUESTED, PRICE, SHORTFALL_PENALTY}
+#     V3  commitment column == {CAPACITY_OFFERED}
+#     V3a CAPACITY_OFFERED column PRESENT (stage-gated) — backstop for the
+#         network policy's rule 3a; catches a fully-dropped commitmentAttributes
+#     V4  CAPACITY_OFFERED grid == need grid
+#     V5  every need slot carries a CAPACITY_OFFERED value
+#   Settlement (only meaningful once telemetry has arrived):
+#     V6  a settlement-eligible performance record exists
+#     V7  each meter's telemetry grid == need grid
+#     V8  every meter carries USAGE on every settled slot
+#     V9  revenue flows net to zero
+#
+# NOTE: V6/V8/V9 legitimately fire on an intermediate on_status (baseline-only
+# or resource-telemetry push), so the contract policy is NOT enforced on
+# on_status — the network policy owns structural enforcement at status; the
+# contract policy is enforced only where settlement is not yet claimed
+# (select/init/confirm) plus injected/validated on the final settled status.
 
+# V6 — a settlement-eligible performance record exists
 violations contains msg if {
 	count(input.message.contract.performance) > 0
 	not _settlement_perf
@@ -150,6 +176,7 @@ violations contains msg if {
 	msg := sprintf("no settlement-eligible performance record found — all records are non-settlement (methodologies: %v)", [ms])
 }
 
+# V1 — participant roles present
 violations contains msg if {
 	not "buyer" in _roles
 	msg := "no participant with role 'buyer' found"
@@ -160,8 +187,9 @@ violations contains msg if {
 	msg := "no participant with role 'seller' found"
 }
 
-# column const (uc1 demand_flex profile) — the schema leaves columns open;
-# this rego is the hard lock. Self-skips when the series is absent.
+# V2 — DemandFlexNeed column constant (uc1 demand_flex profile). The schema
+# leaves columns open; this rego is the hard lock. Self-skips when the series
+# is absent.
 violations contains msg if {
 	descs := _need.payloadDescriptors
 	cols := {d.payloadType | some d in descs}
@@ -169,6 +197,8 @@ violations contains msg if {
 	msg := sprintf("DemandFlexNeed columns must be exactly {CAPACITY_REQUESTED, PRICE, SHORTFALL_PENALTY}, got %v", [cols])
 }
 
+# V3 — commitment column constant. Self-skips when commitmentAttributes is
+# absent (a dropped column is caught by V3a below, not here).
 violations contains msg if {
 	descs := _offered.payloadDescriptors
 	cols := {d.payloadType | some d in descs}
@@ -176,27 +206,49 @@ violations contains msg if {
 	msg := sprintf("commitment column must be exactly {CAPACITY_OFFERED}, got %v", [cols])
 }
 
-# shared intervalPeriod grid — CAPACITY_OFFERED series
+# V3a — CAPACITY_OFFERED column PRESENCE (stage-gated). Settlement backstop
+# for the network policy's rule 3a: from init onward every committed
+# DemandFlexNeed MUST carry a CAPACITY_OFFERED column. V3/V4/V5 all key off
+# _offered and self-skip when commitmentAttributes is dropped wholesale;
+# reading the column straight off the commitment (via object.get) closes that
+# hole. `select`/`on_select` are excluded — no seller offer exists yet.
+_offer_required_actions := {
+	"init", "on_init",
+	"confirm", "on_confirm",
+	"status", "on_status",
+	"update", "on_update",
+}
+
+violations contains msg if {
+	input.context.action in _offer_required_actions
+	_need.intervals # a DemandFlexNeed is present
+	ca := object.get(_commitment, "commitmentAttributes", {})
+	declared := {d.payloadType | some d in object.get(ca, "payloadDescriptors", [])}
+	not "CAPACITY_OFFERED" in declared
+	msg := sprintf("action %q requires a CAPACITY_OFFERED column on commitmentAttributes, but none is declared", [input.context.action])
+}
+
+# V4 — shared intervalPeriod grid, CAPACITY_OFFERED series
 violations contains msg if {
 	_offered.intervalPeriod != _need.intervalPeriod
 	msg := "CAPACITY_OFFERED series intervalPeriod does not match the DemandFlexNeed grid"
 }
 
-# shared intervalPeriod grid — each meter's telemetry
+# V7 — shared intervalPeriod grid, each meter's telemetry
 violations contains msg if {
 	some m in _meters
 	m.telemetry.intervalPeriod != _need.intervalPeriod
 	msg := sprintf("meter %s: telemetry intervalPeriod does not match the DemandFlexNeed grid", [m.meterId])
 }
 
-# every slot needs a seller CAPACITY_OFFERED
+# V5 — every need slot carries a seller CAPACITY_OFFERED value
 violations contains msg if {
 	some iv in _need.intervals
 	not _val(_offered.intervals, iv.id, "CAPACITY_OFFERED")
 	msg := sprintf("interval %d: missing CAPACITY_OFFERED", [iv.id])
 }
 
-# every meter needs USAGE on every settled slot
+# V8 — every meter needs USAGE on every settled slot
 violations contains msg if {
 	some iv in _need.intervals
 	some m in _meters
@@ -204,6 +256,7 @@ violations contains msg if {
 	msg := sprintf("meter %s: missing USAGE at interval %d — cannot settle", [m.meterId, iv.id])
 }
 
+# V9 — buyer/seller revenue flows must net to zero
 violations contains msg if {
 	not net_zero_ok
 	msg := sprintf("net-zero failed: revenue sum = %g (expected 0)", [_revenue_sum])

--- a/specification/policies/demand-flex-networkpolicy.rego
+++ b/specification/policies/demand-flex-networkpolicy.rego
@@ -1,7 +1,22 @@
 # DEG Network Policy — Demand Flex
 #
-# Network-level gate evaluated by the BPP's `checkPolicy` step.
-# Fires NACK when `violations` is non-empty.
+# Network-level gate evaluated by the `checkPolicy` step on EVERY module
+# (BAP + BPP, caller + receiver), so it runs on every action in both
+# directions. Fires NACK when `violations` is non-empty.
+#
+# Design: this policy owns all STRUCTURAL / FORMATION checks and is the
+# early-catch layer for the whole flow. Each rule self-skips when the data
+# it inspects is not on the wire, so one rule set safely spans
+# select → init → confirm → status without false positives. The
+# settlement-math (net-zero, per-meter payout) lives in the contract rego,
+# which only makes sense once telemetry has arrived.
+#
+# Stage legend (which rule is live when):
+#   discover / catalog … 1b, 4          (need series only)
+#   select / on_select … 1b, 4          (buyer need; no seller offer yet)
+#   init / on_init …… 1b, 3, 3a, 4      (seller must now commit CAPACITY_OFFERED)
+#   confirm/on_confirm  1b, 3, 3a, 4     (same commitment rules re-checked)
+#   status / on_status  1, 1b, 2, 3, 3a, 4  (+ per-meter telemetry checks)
 #
 # The `violations` rule combines these checks:
 #
@@ -39,6 +54,16 @@
 #      The contract rego keeps the equivalent rules as a settlement-time
 #      backstop. Self-skips on messages with no offered series (bare
 #      select / on_select, status-id round-trips).
+#
+#   3a. CAPACITY_OFFERED column presence (stage-gated). Rule 3 above can
+#      only check a column the seller actually declared — drop the whole
+#      `commitmentAttributes` block and rule 3 silently self-skips. This
+#      rule closes that gap: from `init` onward (init, on_init, confirm,
+#      on_confirm, status, on_status, update, on_update — see
+#      `_offer_required_actions`), any commitment carrying a DemandFlexNeed
+#      MUST also declare a CAPACITY_OFFERED column. `select` / `on_select`
+#      are excluded because the seller has not committed capacity yet.
+#      This is the rule that catches a dropped CAPACITY_OFFERED at confirm.
 #
 #   4. BecknTimeSeries interval id sequence. Every series' `intervals[*].id`
 #      MUST be 0,1,2,… — start at 0 and increase by 1, with no gaps,
@@ -213,6 +238,35 @@ violations contains msg if {
 	some p in _offered_pairs
 	p.offered.intervalPeriod != p.need.intervalPeriod
 	msg := sprintf("commitment %s: CAPACITY_OFFERED intervalPeriod does not match the DemandFlexNeed grid", [p.cid])
+}
+
+# ----- 3a) CAPACITY_OFFERED column presence (stage-gated) -------------
+# Actions at which the seller must ALREADY have committed a CAPACITY_OFFERED
+# column against the buyer's DemandFlexNeed — everything from init onward.
+# `select` / `on_select` are deliberately absent: the seller has not offered
+# capacity yet, so a bare need with no commitment column is valid there.
+_offer_required_actions := {
+	"init", "on_init",
+	"confirm", "on_confirm",
+	"status", "on_status",
+	"update", "on_update",
+}
+
+# Unlike rule 3 (which keys off the CAPACITY_OFFERED descriptor and therefore
+# self-skips when the whole column is dropped), this reads the column presence
+# directly from the commitment, so dropping `commitmentAttributes` entirely is
+# caught. `object.get` keeps the reference defined even when the block is absent.
+violations contains msg if {
+	input.context.action in _offer_required_actions
+	some c in input.message.contract.commitments
+	c.resources[0].resourceAttributes.intervals # a DemandFlexNeed is present
+	ca := object.get(c, "commitmentAttributes", {})
+	declared := {d.payloadType | some d in object.get(ca, "payloadDescriptors", [])}
+	not "CAPACITY_OFFERED" in declared
+	msg := sprintf(
+		"commitment %s: action %q requires a CAPACITY_OFFERED column on commitmentAttributes, but none is declared",
+		[object.get(c, "id", "?"), input.context.action],
+	)
 }
 
 # ----- 4) BecknTimeSeries interval id sequence ------------------------

--- a/specification/policies/test/demand-flex-contractpolicy_test.rego
+++ b/specification/policies/test/demand-flex-contractpolicy_test.rego
@@ -146,3 +146,30 @@ test_std_no_column_violation if {
 	vs := violations with input as _std
 	every v in vs { not contains(v, "columns must be") }
 }
+
+# V3a — CAPACITY_OFFERED column presence (stage-gated).
+# Drop commitmentAttributes entirely and stamp a context.action.
+_std_no_column_at(action) := inp if {
+	dropped := json.patch(_std, [{"op": "remove", "path": "/message/contract/commitments/0/commitmentAttributes"}])
+	inp := object.union(dropped, {"context": {"action": action}})
+}
+
+# whole column dropped at confirm → presence violation (the reported bug)
+test_offer_column_dropped_at_confirm if {
+	vs := violations with input as _std_no_column_at("confirm")
+	some v in vs
+	contains(v, "requires a CAPACITY_OFFERED column")
+}
+
+# same drop at on_status → presence violation
+test_offer_column_dropped_at_status if {
+	vs := violations with input as _std_no_column_at("on_status")
+	some v in vs
+	contains(v, "requires a CAPACITY_OFFERED column")
+}
+
+# select carries no seller offer yet → presence rule self-skips
+test_offer_column_absent_at_select_ok if {
+	vs := violations with input as _std_no_column_at("select")
+	every v in vs { not contains(v, "requires a CAPACITY_OFFERED column") }
+}

--- a/specification/policies/test/demand-flex-networkpolicy_test.rego
+++ b/specification/policies/test/demand-flex-networkpolicy_test.rego
@@ -210,6 +210,50 @@ test_no_offer_yet_self_skips if {
 }
 
 # ---------------------------------------------------------------------------
+# 3a) CAPACITY_OFFERED column presence (stage-gated)
+# ---------------------------------------------------------------------------
+
+# commitment carrying a need but no commitmentAttributes at all, at a
+# post-commitment action, adds the action + context envelope.
+_need_only_at(action) := {"context": {"action": action}, "message": {"contract": {"commitments": [{
+	"id": "cmt-1",
+	"resources": [{"resourceAttributes": _need2}],
+}]}}}
+
+# whole CAPACITY_OFFERED column dropped at confirm → violation (the reported bug)
+test_offer_column_dropped_at_confirm if {
+	vs := violations with input as _need_only_at("confirm")
+	some v in vs
+	contains(v, "requires a CAPACITY_OFFERED column")
+	contains(v, "confirm")
+}
+
+# same drop at init → violation
+test_offer_column_dropped_at_init if {
+	vs := violations with input as _need_only_at("init")
+	some v in vs
+	contains(v, "requires a CAPACITY_OFFERED column")
+}
+
+# same drop at on_status → violation
+test_offer_column_dropped_at_status if {
+	vs := violations with input as _need_only_at("on_status")
+	some v in vs
+	contains(v, "requires a CAPACITY_OFFERED column")
+}
+
+# select carries a bare need with no seller offer yet → must NOT flag
+test_offer_column_absent_at_select_ok if {
+	count(violations) == 0 with input as _need_only_at("select")
+}
+
+# full column present at confirm → no presence violation
+test_offer_column_present_at_confirm_ok if {
+	inp := object.union(_commit_input(_need2, _offered2), {"context": {"action": "confirm"}})
+	count(violations) == 0 with input as inp
+}
+
+# ---------------------------------------------------------------------------
 # 4) BecknTimeSeries interval id sequence
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Dropping the `CAPACITY_OFFERED` payload in a `confirm` did **not** trigger a contract-policy violation. Two root causes:

1. **Contract policy was never on the confirm path.** The only `contractpolicyenforcer` instance was on the BPP **caller**, scoped to `actions: on_status` and injection-only (`violationActions: ""`) — it can never NACK, and never runs on confirm. Confirm's only OPA gate was `checkPolicy` (the network policy).
2. **Both regos self-skip a fully-dropped column.** Network rule 3 and contract V3/V5 key off the `CAPACITY_OFFERED` payload **descriptor**; drop the whole `commitmentAttributes` block and there is nothing to iterate, so `violations` stays empty. (Dropping only the *values* while keeping the descriptor *was* already caught.)

## Changes

### Network policy — `demand-flex-networkpolicy.rego`
- **New rule 3a — CAPACITY_OFFERED column presence (stage-gated).** From `init` onward (`_offer_required_actions` = init/on_init, confirm/on_confirm, status/on_status, update/on_update) any commitment carrying a DemandFlexNeed **must** declare a `CAPACITY_OFFERED` column. Reads presence directly off the commitment via `object.get`, so a wholesale-dropped column is caught. `select`/`on_select` excluded (seller has not offered capacity yet). This rule runs on **every module** via `checkPolicy`, so it catches the drop as early as `init`, in both directions.

### Contract policy — `demand-flex-contractpolicy.rego`
- **New V3a** — same presence check, same gating, as the settlement-time backstop.
- Header rewritten into a **per-rule index (V1..V9) with a stage legend**; per-rule one-line comments added to both regos for readability.

### Devkit wiring — `config/local-demand-flex-{bap,bpp}.yaml`
- Added **enforce-only** `contractpolicyenforcer` (no `output*` keys) on:
  - `bppTxnReceiver` → `actions: select,init,confirm`
  - `bapTxnReceiver` → `actions: on_select,on_init,on_confirm`
- **`on_status` is deliberately excluded** from contract enforcement: the contract rego's settlement checks (missing USAGE / net-zero / no settlement-eligible perf) legitimately fire on intermediate baseline-only and resource-telemetry pushes. Structural enforcement at `status` remains with the network policy (which self-skips correctly). Enforcing the contract rego blanket at `on_status` would NACK legitimate telemetry.

## Enforcement matrix (after)

| Stage | Network policy | Contract policy |
|---|---|---|
| select / on_select | ✅ structural (3a skips) | ✅ (self-skips, no offer) |
| init / on_init | ✅ + 3a | ✅ + V3a |
| confirm / on_confirm | ✅ + 3a | ✅ + V3a |
| status / on_status | ✅ + 3a + telemetry | inject-only (settlement) |

## Testing
- Rego unit tests: network **18 → 23**, contract **12 → 15** (new cases cover drop-at-confirm/init/status and select self-skip).
- Verified against **all** `uc1-bdr-w-baselining` example payloads: violation counts unchanged for every legitimate message (select, on_status baselines/telemetry) — no new false positives.
- `opa fmt` clean; both devkit YAMLs parse.

> Note: the enforce-only `contractpolicyenforcer` wiring assumes it evaluates `<contractAttributes.policy.queryPath>.violations` and NACKs per `violationActions` (same knobs as the existing injection instance). The plugin ships in the `w-deg-plugins-v2` image, not this repo — worth a smoke test on that image. The **network-policy 3a rule works with the current stack today** and is the primary fix.