### PR TITLE
fix(demand-flex): decouple contractpolicyenforcer injection from enforcement (no outputPath for enforce-only steps)

### DIFF
--- a/devkits/demand-flex/config/local-demand-flex-bap.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bap.yaml
@@ -151,8 +151,22 @@ modules:
             config:
               uuidKeys: transaction_id,message_id
               role: bap
+        steps:
+          # Fail-fast ENFORCEMENT on the requests the BAP EMITS
+          # (select/init/confirm): the BAP rejects its own malformed request
+          # before signing and sending, so errors are caught at the source (the
+          # counterparty BPP receiver enforces the same policy authoritatively).
+          # Pure enforcement — `actions: ""` means nothing is ever injected on
+          # the outbound request; no outputPath/outputMode needed.
+          - id: contractpolicyenforcer
+            config:
+              actions: ""
+              violationActions: "select,init,confirm"
+              debugLogging: "true"
+              allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
       steps:
         - validateSchema
         - checkPolicy
+        - contractpolicyenforcer
         - addRoute
         - sign

--- a/devkits/demand-flex/config/local-demand-flex-bap.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bap.yaml
@@ -74,32 +74,21 @@ modules:
               role: bap
         steps:
           # Enforce the contract policy on INCOMING responses from the BPP,
-          # before the BAP app sees them. Enforcement instance: evaluates
+          # before the BAP app sees them. Pure ENFORCEMENT instance: evaluates
           # <contractAttributes.policy.queryPath>.violations and NACKs when
-          # non-empty (violationActions). Scoped to pre-settlement responses
-          # only — on_status is excluded (settlement checks fire on
-          # intermediate telemetry pushes); structural enforcement at status is
-          # owned by checkPolicy (the network policy). on_select is safe: the
-          # contract rego self-skips when no seller offer is present.
-          #
-          # outputPath/outputMode are REQUIRED by the plugin, but injection is
-          # inert here: the contract rego only exports `revenue_flows` once a
-          # settlement-eligible performance record is present, which never
-          # happens at on_select/on_init/on_confirm, so this instance enforces
-          # without writing any settlement artifact. Config mirrors the caller's
-          # injection instance so it stays well-formed if ever exercised.
+          # non-empty. `actions: ""` clears the injection actions, so this step
+          # NEVER writes to the payload and needs no outputPath/outputMode.
+          # Scoped to pre-settlement responses only; on_status is excluded
+          # (settlement checks fire on intermediate telemetry pushes).
+          # Structural enforcement at status is owned by checkPolicy (the
+          # network policy). on_select is safe: the contract rego self-skips
+          # when no seller offer is present.
           - id: contractpolicyenforcer
             config:
-              actions: "on_select,on_init,on_confirm"
+              actions: ""
               violationActions: "on_select,on_init,on_confirm"
               debugLogging: "true"
               allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
-              outputPath: "message.contract.consideration[id=auto-revenue-flows].considerationAttributes"
-              outputMode: "jsonld"
-              outputType: "RevenueFlow"
-              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
-              outputArrayKey: "revenueFlows"
-              entryDefaults: '{"status":{"code":"SETTLED"}}'
       steps:
         - validateSign
         - checkPolicy

--- a/devkits/demand-flex/config/local-demand-flex-bap.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bap.yaml
@@ -74,19 +74,32 @@ modules:
               role: bap
         steps:
           # Enforce the contract policy on INCOMING responses from the BPP,
-          # before the BAP app sees them. Enforce-only (no output* keys):
-          # evaluates <contractAttributes.policy.queryPath>.violations and
-          # NACKs when non-empty. Scoped to pre-settlement responses only —
-          # on_status is excluded (settlement checks fire on intermediate
-          # telemetry pushes); structural enforcement at status is owned by
-          # checkPolicy (the network policy). on_select is safe: the contract
-          # rego self-skips when no seller offer is present.
+          # before the BAP app sees them. Enforcement instance: evaluates
+          # <contractAttributes.policy.queryPath>.violations and NACKs when
+          # non-empty (violationActions). Scoped to pre-settlement responses
+          # only — on_status is excluded (settlement checks fire on
+          # intermediate telemetry pushes); structural enforcement at status is
+          # owned by checkPolicy (the network policy). on_select is safe: the
+          # contract rego self-skips when no seller offer is present.
+          #
+          # outputPath/outputMode are REQUIRED by the plugin, but injection is
+          # inert here: the contract rego only exports `revenue_flows` once a
+          # settlement-eligible performance record is present, which never
+          # happens at on_select/on_init/on_confirm, so this instance enforces
+          # without writing any settlement artifact. Config mirrors the caller's
+          # injection instance so it stays well-formed if ever exercised.
           - id: contractpolicyenforcer
             config:
               actions: "on_select,on_init,on_confirm"
               violationActions: "on_select,on_init,on_confirm"
               debugLogging: "true"
               allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
+              outputPath: "message.contract.consideration[id=auto-revenue-flows].considerationAttributes"
+              outputMode: "jsonld"
+              outputType: "RevenueFlow"
+              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
+              outputArrayKey: "revenueFlows"
+              entryDefaults: '{"status":{"code":"SETTLED"}}'
       steps:
         - validateSign
         - checkPolicy

--- a/devkits/demand-flex/config/local-demand-flex-bpp.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bpp.yaml
@@ -74,21 +74,34 @@ modules:
               role: bpp
         steps:
           # Enforce the contract policy on INCOMING requests, before the BPP
-          # app sees them. Enforce-only (no output* keys → no injection):
-          # evaluates <contractAttributes.policy.queryPath>.violations and
-          # NACKs when non-empty. Scoped to pre-settlement actions only —
-          # on_status is deliberately excluded because the contract rego's
+          # app sees them. Enforcement instance: evaluates
+          # <contractAttributes.policy.queryPath>.violations and NACKs when
+          # non-empty (violationActions). Scoped to pre-settlement actions only
+          # — on_status is deliberately excluded because the contract rego's
           # settlement checks (missing USAGE / net-zero / no settlement perf)
           # legitimately fire on intermediate baseline / resource-telemetry
           # pushes; structural enforcement at status is owned by checkPolicy
           # (the network policy). select is safe: the contract rego self-skips
           # when no seller offer is present.
+          #
+          # outputPath/outputMode are REQUIRED by the plugin, but injection is
+          # inert here: the contract rego only exports `revenue_flows` once a
+          # settlement-eligible performance record is present, which never
+          # happens at select/init/confirm, so this instance enforces without
+          # writing any settlement artifact. Config mirrors the caller's
+          # injection instance so it stays well-formed if ever exercised.
           - id: contractpolicyenforcer
             config:
               actions: "select,init,confirm"
               violationActions: "select,init,confirm"
               debugLogging: "true"
               allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
+              outputPath: "message.contract.consideration[id=auto-revenue-flows].considerationAttributes"
+              outputMode: "jsonld"
+              outputType: "RevenueFlow"
+              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
+              outputArrayKey: "revenueFlows"
+              entryDefaults: '{"status":{"code":"SETTLED"}}'
       steps:
         - validateSign
         - checkPolicy

--- a/devkits/demand-flex/config/local-demand-flex-bpp.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bpp.yaml
@@ -74,34 +74,23 @@ modules:
               role: bpp
         steps:
           # Enforce the contract policy on INCOMING requests, before the BPP
-          # app sees them. Enforcement instance: evaluates
+          # app sees them. Pure ENFORCEMENT instance: evaluates
           # <contractAttributes.policy.queryPath>.violations and NACKs when
-          # non-empty (violationActions). Scoped to pre-settlement actions only
-          # — on_status is deliberately excluded because the contract rego's
-          # settlement checks (missing USAGE / net-zero / no settlement perf)
-          # legitimately fire on intermediate baseline / resource-telemetry
-          # pushes; structural enforcement at status is owned by checkPolicy
-          # (the network policy). select is safe: the contract rego self-skips
-          # when no seller offer is present.
-          #
-          # outputPath/outputMode are REQUIRED by the plugin, but injection is
-          # inert here: the contract rego only exports `revenue_flows` once a
-          # settlement-eligible performance record is present, which never
-          # happens at select/init/confirm, so this instance enforces without
-          # writing any settlement artifact. Config mirrors the caller's
-          # injection instance so it stays well-formed if ever exercised.
+          # non-empty. `actions: ""` clears the injection actions, so this step
+          # NEVER writes to the payload — nothing is injected before on_status —
+          # and outputPath/outputMode are therefore not required. Scoped to
+          # pre-settlement actions only; on_status is excluded because the
+          # contract rego's settlement checks (missing USAGE / net-zero / no
+          # settlement perf) legitimately fire on intermediate baseline /
+          # resource-telemetry pushes. Structural enforcement at status is owned
+          # by checkPolicy (the network policy). select is safe: the contract
+          # rego self-skips when no seller offer is present.
           - id: contractpolicyenforcer
             config:
-              actions: "select,init,confirm"
+              actions: ""
               violationActions: "select,init,confirm"
               debugLogging: "true"
               allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
-              outputPath: "message.contract.consideration[id=auto-revenue-flows].considerationAttributes"
-              outputMode: "jsonld"
-              outputType: "RevenueFlow"
-              outputContextURL: "https://schema.nfh.global/RevenueFlow/2.0/context.jsonld"
-              outputArrayKey: "revenueFlows"
-              entryDefaults: '{"status":{"code":"SETTLED"}}'
       steps:
         - validateSign
         - checkPolicy

--- a/devkits/demand-flex/config/local-demand-flex-bpp.yaml
+++ b/devkits/demand-flex/config/local-demand-flex-bpp.yaml
@@ -154,13 +154,19 @@ modules:
               uuidKeys: transaction_id,message_id
               role: bpp
         steps:
-          # First step: injects settlement flows so validateSchema sees the
-          # enriched payload and sign signs it.
+          # First step: on on_status it INJECTS settlement flows (so
+          # validateSchema sees the enriched payload and sign signs it); on the
+          # response actions it EMITS (on_select/on_init/on_confirm) it ENFORCES
+          # the contract policy — fail-fast, so the BPP rejects its own
+          # malformed response before signing and sending. Injection and
+          # enforcement are independent: on_select/on_init/on_confirm are not in
+          # `actions`, so nothing is injected there (only violations checked).
+          # on_status stays inject-only (settlement checks legitimately fire on
+          # intermediate telemetry, so it is NOT enforced).
           - id: contractpolicyenforcer
             config:
               actions: "on_status"
-              # Injection-only instance: violations are logged, never NACKed.
-              violationActions: ""
+              violationActions: "on_select,on_init,on_confirm"
               debugLogging: "true"
               allowedPolicyUrlPrefixes: "https://raw.githubusercontent.com/beckn/DEG/"
               # Wave2-style: rego output is wrapped as a Beckn-native

--- a/plugins/contractpolicyenforcer/config.go
+++ b/plugins/contractpolicyenforcer/config.go
@@ -12,25 +12,32 @@ type Config struct {
 	// Enabled controls whether the plugin is active.
 	Enabled bool
 
-	// Actions is the list of beckn actions that trigger settlement flow computation.
-	// Entries match the message action exactly OR the final segment of a
-	// compound action — "publish" matches both "publish" and
-	// "catalog/publish". Default: ["on_status"]
+	// Actions is the list of INJECTION actions — the beckn actions on which
+	// the policy output (settlement / revenue flows) is written into the
+	// message body at OutputPath. Entries match the message action exactly OR
+	// the final segment of a compound action — "publish" matches both
+	// "publish" and "catalog/publish".
+	//
+	// Empty = the step NEVER injects (a pure-enforcement step). OutputPath /
+	// OutputMode are then not required. Set explicitly to "" in YAML to clear
+	// the default. Default: ["on_status"].
 	Actions []string
 
-	// ViolationActions is the subset of Actions on which policy violations
-	// are ENFORCED: if the evaluated policy reports a non-empty `violations`
-	// set for one of these actions, the step returns an error and the
-	// message is NACKed. Enforcement is fail-closed — on these actions a
-	// missing policy reference, a disallowed policy URL, or a fetch/compile/
-	// eval failure also blocks the message (otherwise enforcement could be
-	// bypassed by stripping the policy ref).
+	// ViolationActions is the list of ENFORCEMENT actions: if the evaluated
+	// policy reports a non-empty `violations` set for one of these actions,
+	// the step returns an error and the message is NACKed. Enforcement is
+	// fail-closed — on these actions a missing policy reference, a disallowed
+	// policy URL, or a fetch/compile/eval failure also blocks the message
+	// (otherwise enforcement could be bypassed by stripping the policy ref).
 	//
-	// Actions NOT listed here keep the original soft-failure behavior: the
-	// message passes through unmodified on any problem.
+	// INDEPENDENT of Actions — a step may enforce on actions where it does
+	// NOT inject (e.g. select/init/confirm — check violations only, write
+	// nothing) and inject on others (on_status). Actions NOT listed here keep
+	// soft-failure behavior: the message passes through unmodified on any
+	// problem.
 	//
 	// Comma-separated list in YAML, e.g. "select,init,confirm".
-	// Default: empty (never enforce). Must be a subset of Actions.
+	// Default: empty (never enforce).
 	ViolationActions []string
 
 	// CacheTTL is how long a compiled rego policy is cached before re-fetch.
@@ -163,24 +170,16 @@ func ParseConfig(cfg map[string]string) (*Config, error) {
 		config.Enabled = enabled == "true" || enabled == "1"
 	}
 
-	if actions, ok := cfg["actions"]; ok && actions != "" {
-		list := strings.Split(actions, ",")
-		config.Actions = make([]string, 0, len(list))
-		for _, a := range list {
-			a = strings.TrimSpace(a)
-			if a != "" {
-				config.Actions = append(config.Actions, a)
-			}
-		}
+	// `actions` are the injection actions. When the key is PRESENT (even as
+	// an empty string) it replaces the default — so `actions: ""` explicitly
+	// clears injection for a pure-enforcement step. When absent, the default
+	// (["on_status"]) stands.
+	if actions, ok := cfg["actions"]; ok {
+		config.Actions = splitCSV(actions)
 	}
 
-	if actions, ok := cfg["violationActions"]; ok && actions != "" {
-		for _, a := range strings.Split(actions, ",") {
-			a = strings.TrimSpace(a)
-			if a != "" {
-				config.ViolationActions = append(config.ViolationActions, a)
-			}
-		}
+	if actions, ok := cfg["violationActions"]; ok {
+		config.ViolationActions = splitCSV(actions)
 	}
 
 	if ttl, ok := cfg["cacheTTL"]; ok && ttl != "" {
@@ -256,24 +255,22 @@ func ParseConfig(cfg map[string]string) (*Config, error) {
 		config.EntryDefaults = strings.TrimSpace(d)
 	}
 
-	// Required fields — no code defaults. Each devkit's YAML MUST declare
-	// the destination explicitly so behavior is visible from the config.
-	if config.OutputPath == "" {
-		return nil, fmt.Errorf(
-			"contractpolicyenforcer: outputPath is required (e.g. " +
-				"\"message.contract.contractAttributes.revenueFlows\" or " +
-				"\"message.contract.consideration[id=auto-settlement-flows].considerationAttributes\")")
-	}
-	if config.OutputMode == "" {
-		return nil, fmt.Errorf(
-			"contractpolicyenforcer: outputMode is required (allowed: %q, %q)",
-			OutputModeRaw, OutputModeJSONLD)
-	}
-	for _, va := range config.ViolationActions {
-		if !config.IsActionEnabled(va) {
+	// Output destination is required ONLY when the step injects — i.e. when
+	// `actions` (the injection actions) is non-empty. A pure-enforcement step
+	// (actions empty, violationActions set) writes nothing to the payload and
+	// needs no outputPath/outputMode. Enforcement and injection are
+	// independent, so violationActions need NOT be a subset of actions.
+	if len(config.Actions) > 0 {
+		if config.OutputPath == "" {
 			return nil, fmt.Errorf(
-				"contractpolicyenforcer: violationActions entry %q is not in actions %v — violations can only be enforced on actions the step runs on",
-				va, config.Actions)
+				"contractpolicyenforcer: outputPath is required when actions is non-empty (injection) — e.g. " +
+					"\"message.contract.contractAttributes.revenueFlows\" or " +
+					"\"message.contract.consideration[id=auto-settlement-flows].considerationAttributes\"")
+		}
+		if config.OutputMode == "" {
+			return nil, fmt.Errorf(
+				"contractpolicyenforcer: outputMode is required when actions is non-empty (allowed: %q, %q)",
+				OutputModeRaw, OutputModeJSONLD)
 		}
 	}
 	if config.CacheTTL < MinCacheTTL {
@@ -283,6 +280,18 @@ func ParseConfig(cfg map[string]string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// splitCSV splits a comma-separated config value, trimming whitespace and
+// dropping empty entries. Returns nil for an empty/blank input.
+func splitCSV(s string) []string {
+	var out []string
+	for _, a := range strings.Split(s, ",") {
+		if a = strings.TrimSpace(a); a != "" {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // matchesAction reports whether the action is in the list. A list entry

--- a/plugins/contractpolicyenforcer/contractpolicyenforcer.go
+++ b/plugins/contractpolicyenforcer/contractpolicyenforcer.go
@@ -60,19 +60,24 @@ func (rf *ContractPolicyEnforcer) Run(ctx *model.StepContext) error {
 		return nil
 	}
 
-	// Check action
+	// The step activates when the action either injects (action in Actions)
+	// or enforces (action in ViolationActions). These are independent: a step
+	// may enforce on select/init/confirm (check violations, write nothing) and
+	// inject on on_status.
 	action := ExtractAction(ctx.Request.URL.Path, ctx.Body)
-	if !rf.config.IsActionEnabled(action) {
-		if rf.config.DebugLogging {
-			log.Debugf(ctx, "ContractPolicyEnforcer: action '%s' not enabled, skipping", action)
-		}
-		return nil
-	}
+	inject := rf.config.IsActionEnabled(action)
 
 	// On enforced actions every failure below is fail-closed: the policy
 	// gate must not be bypassable by stripping the policy ref or breaking
 	// the policy fetch.
 	enforced := rf.config.IsViolationEnforced(action)
+
+	if !inject && !enforced {
+		if rf.config.DebugLogging {
+			log.Debugf(ctx, "ContractPolicyEnforcer: action '%s' neither injects nor enforces, skipping", action)
+		}
+		return nil
+	}
 
 	// Collect policy references. Trade-shaped messages carry exactly one at
 	// message.contract.contractAttributes.policy; catalog publishes carry
@@ -166,6 +171,16 @@ func (rf *ContractPolicyEnforcer) Run(ctx *model.StepContext) error {
 		}
 		log.Warnf(ctx, "ContractPolicyEnforcer: %d policy violation(s) on %s (not enforced): %s",
 			len(violations), action, strings.Join(violations, "; "))
+	}
+
+	// Injection happens ONLY on injection actions (Actions). A pure-enforcement
+	// action (in ViolationActions but not Actions — e.g. select/init/confirm)
+	// writes nothing to the payload: nothing is injected before on_status.
+	if !inject {
+		if rf.config.DebugLogging {
+			log.Debugf(ctx, "ContractPolicyEnforcer: action '%s' is enforcement-only, no injection", action)
+		}
+		return nil
 	}
 	if flows == nil {
 		if rf.config.DebugLogging {

--- a/plugins/contractpolicyenforcer/enforce_test.go
+++ b/plugins/contractpolicyenforcer/enforce_test.go
@@ -32,6 +32,21 @@ violations contains msg if {
 }
 `
 
+// enforceAndFlowsPolicy exports BOTH a violation (when blocked) and
+// revenue_flows, so tests can assert that a pure-enforcement step evaluates
+// violations but does NOT inject the flows.
+const enforceAndFlowsPolicy = `package test.policy
+
+import rego.v1
+
+violations contains msg if {
+	input.message.buyerDiscom == "BLOCKED_DISCOM"
+	msg := sprintf("buyer discom %q is not in the allowlist", [input.message.buyerDiscom])
+}
+
+revenue_flows := [{"role": "seller", "value": 100}]
+`
+
 // servePolicy returns an httptest server serving a bare rego policy.
 func servePolicy(t *testing.T, policy string) *httptest.Server {
 	t.Helper()
@@ -109,15 +124,52 @@ func TestParseConfig_ViolationActions(t *testing.T) {
 	}
 }
 
-func TestParseConfig_ViolationActionsMustBeSubsetOfActions(t *testing.T) {
-	_, err := ParseConfig(map[string]string{
+// violationActions need NOT be a subset of actions — enforcement and injection
+// are independent concerns.
+func TestParseConfig_ViolationActionsNeedNotBeSubsetOfActions(t *testing.T) {
+	cfg, err := ParseConfig(map[string]string{
 		"actions":          "on_status",
 		"violationActions": "init",
 		"outputPath":       "x.y",
 		"outputMode":       "raw",
 	})
-	if err == nil {
-		t.Error("expected error when violationActions is not a subset of actions")
+	if err != nil {
+		t.Fatalf("violationActions outside actions must be allowed, got: %v", err)
+	}
+	if !cfg.IsViolationEnforced("init") {
+		t.Error("init should be enforced")
+	}
+	if cfg.IsActionEnabled("init") {
+		t.Error("init should NOT be an injection action")
+	}
+}
+
+// A pure-enforcement step (actions explicitly cleared to "") needs no
+// outputPath/outputMode.
+func TestParseConfig_EnforceOnlyNeedsNoOutput(t *testing.T) {
+	cfg, err := ParseConfig(map[string]string{
+		"actions":          "",
+		"violationActions": "select,init,confirm",
+	})
+	if err != nil {
+		t.Fatalf("enforce-only config must be valid without outputPath, got: %v", err)
+	}
+	if len(cfg.Actions) != 0 {
+		t.Errorf("Actions = %v, want empty", cfg.Actions)
+	}
+	if !cfg.IsViolationEnforced("confirm") {
+		t.Error("confirm should be enforced")
+	}
+}
+
+// outputPath is still required when actions is non-empty (injection configured).
+func TestParseConfig_OutputRequiredWhenInjecting(t *testing.T) {
+	if _, err := ParseConfig(map[string]string{
+		"actions":          "on_status",
+		"violationActions": "on_status",
+		"outputMode":       "raw",
+	}); err == nil {
+		t.Error("expected error: actions non-empty but outputPath missing")
 	}
 }
 
@@ -148,6 +200,37 @@ func TestRun_NoViolationsPasses(t *testing.T) {
 
 	if err := p.Run(stepCtx(t, "init", enforceBody("init", srv.URL, "ALLOWED_DISCOM"))); err != nil {
 		t.Fatalf("expected clean payload to pass, got: %v", err)
+	}
+}
+
+// A pure-enforcement step (actions "", violationActions "confirm") NACKs on a
+// violating payload but NEVER injects — even when the policy exports
+// revenue_flows. This is what keeps confirm/init/select payloads untouched
+// before on_status.
+func TestRun_EnforceOnly_DoesNotInject(t *testing.T) {
+	srv := servePolicy(t, enforceAndFlowsPolicy)
+	p, err := New(map[string]string{
+		"actions":          "",
+		"violationActions": "confirm",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// clean payload → passes AND body is unmodified (no injection)
+	ctx := stepCtx(t, "confirm", enforceBody("confirm", srv.URL, "ALLOWED_DISCOM"))
+	orig := string(ctx.Body)
+	if err := p.Run(ctx); err != nil {
+		t.Fatalf("clean payload must pass, got: %v", err)
+	}
+	if string(ctx.Body) != orig {
+		t.Errorf("enforce-only step must not modify the body\n before=%s\n after =%s", orig, string(ctx.Body))
+	}
+
+	// violating payload → NACK
+	bad := stepCtx(t, "confirm", enforceBody("confirm", srv.URL, "BLOCKED_DISCOM"))
+	if err := p.Run(bad); err == nil {
+		t.Fatal("expected NACK on violation for enforce-only action")
 	}
 }
 

--- a/specification/policies/demand-flex-contractpolicy.rego
+++ b/specification/policies/demand-flex-contractpolicy.rego
@@ -130,12 +130,21 @@ _buyer_desc := sprintf("Net payable across %d flex slots", [_slot_count])
 
 _seller_desc := sprintf("Net receivable across %d flex slots", [_slot_count])
 
-revenue_flows := [
+# internal net flows — always defined (0 when nothing settles yet)
+_revenue_flows := [
 	{"role": "buyer", "value": _buyer_value, "currency": _currency, "description": _buyer_desc},
 	{"role": "seller", "value": total_settlement, "currency": _currency, "description": _seller_desc},
 ]
 
-_revenue_sum := sum([f.value | some f in revenue_flows])
+# Exported for injection ONLY when a settlement-eligible performance record is
+# present. Pre-settlement (select / init / confirm) this rule is UNDEFINED, so a
+# contractpolicyenforcer step still evaluates `violations` (enforcement) but
+# finds no `revenue_flows` and skips injection — no zero-value settlement
+# artifact is written onto a pre-settlement contract. net-zero and _revenue_sum
+# key off the always-defined _revenue_flows, so their semantics are unchanged.
+revenue_flows := _revenue_flows if _settlement_perf
+
+_revenue_sum := sum([f.value | some f in _revenue_flows])
 
 net_zero_ok if _revenue_sum == 0
 

--- a/specification/policies/test/demand-flex-contractpolicy_test.rego
+++ b/specification/policies/test/demand-flex-contractpolicy_test.rego
@@ -173,3 +173,17 @@ test_offer_column_absent_at_select_ok if {
 	vs := violations with input as _std_no_column_at("select")
 	every v in vs { not contains(v, "requires a CAPACITY_OFFERED column") }
 }
+
+# revenue_flows is exported ONLY when a settlement-eligible performance record
+# exists. This is what lets the contractpolicyenforcer step enforce `violations`
+# pre-settlement while skipping injection (no zero-value settlement artifact on a
+# confirm). Without performance the rule must be UNDEFINED.
+test_revenue_flows_undefined_without_performance if {
+	no_perf := json.patch(_std, [{"op": "remove", "path": "/message/contract/performance"}])
+	not revenue_flows with input as no_perf
+}
+
+# with settlement performance present, revenue_flows is exported for injection
+test_revenue_flows_defined_with_performance if {
+	count(revenue_flows) == 2 with input as _std
+}


### PR DESCRIPTION
## Background

#482 wired enforce-only `contractpolicyenforcer` instances on the BAP/BPP receivers with no `outputPath`, and onix crashed at startup:

```
contractpolicyenforcer: config: contractpolicyenforcer: outputPath is required
```

Root cause: the plugin coupled **injection** and **enforcement** — every step that ran had to declare an injection destination, and `violationActions` had to be a subset of `actions`. So there was no way to say "enforce here, inject nothing."

## Fix — decouple the two concerns (plugin change)

`plugins/contractpolicyenforcer/` (builds the v2 onix-deg-adapter image):

- **`actions` = injection actions** — where policy output (revenue flows) is written to `outputPath`. Empty ⇒ the step never injects. `actions: ""` explicitly clears the default.
- **`violationActions` = enforcement actions** — where a non-empty `violations` set NACKs. **No longer required to be a subset of `actions`.** A step may enforce on select/init/confirm and inject only on on_status.
- **`outputPath`/`outputMode` required only when `actions` is non-empty.** Pure-enforcement steps need neither.
- **Injection is gated on `actions` membership** in `Run` (not merely on whether the rego returned flows), so a pure-enforcement action writes **nothing** to the payload — *nothing is injected before on_status*.

## Devkit wiring

`config/local-demand-flex-{bap,bpp}.yaml` — receiver enforcement instances now:

```yaml
actions: ""                                 # no injection
violationActions: "select,init,confirm"     # BPP receiver
# (BAP receiver: on_select,on_init,on_confirm)
```

no `outputPath`. The BPP-caller `on_status` injection instance is unchanged.

## Behaviour

| Instance | actions (inject) | violationActions (NACK) | writes payload? |
|---|---|---|---|
| BPP receiver | — | select,init,confirm | never |
| BAP receiver | — | on_select,on_init,on_confirm | never |
| BPP caller | on_status | — | on_status only |

Also retained: the contract rego exports `revenue_flows` only when a settlement-eligible performance record exists (defense-in-depth + semantic correctness).

## Verification
- `go test ./...` green. New tests: `violationActions` need not be a subset of `actions`; enforce-only config (`actions: ""`) validates **without** `outputPath`; a Run-level test proves an enforce-only step **NACKs on violation but never mutates the body** even when the policy exports `revenue_flows`.
- Confirmed `yaml.v3` preserves the quoted empty-string `actions: ""` (the exact drop that would re-trigger the fatal — it does not drop).
- Dropped-CAPACITY_OFFERED confirm still NACKs; rego network 23, contract 17; `opa fmt` clean.

**Requires the v2 onix-deg-adapter image to be rebuilt from this plugin.**