### PR TITLE
fix(devkit): add required registry url and schema location to local-simple-bap

### DIFF
--- a/devkits/data-exchange/config/local-simple-bap.yaml
+++ b/devkits/data-exchange/config/local-simple-bap.yaml
@@ -31,6 +31,7 @@ modules:
         registry:
           id: dediregistry
           config:
+            url: https://fabric.nfh.global/registry/dedi
             registryName: subscribers.beckn.one
             allowedNetworkIDs: "nfh.global/testnet-deg,indiaenergystack.in/test-ies-data-sharing-network"
             timeout: 10
@@ -53,6 +54,8 @@ modules:
         schemaValidator:
           id: schemav2validator
           config:
+            type: url
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/tags/core-2.0.0-rc-eos-release/api/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -89,6 +92,7 @@ modules:
         registry:
           id: dediregistry
           config:
+            url: https://fabric.nfh.global/registry/dedi
             registryName: subscribers.beckn.one
             allowedNetworkIDs: "nfh.global/testnet-deg,indiaenergystack.in/test-ies-data-sharing-network"
             timeout: 10
@@ -111,6 +115,8 @@ modules:
         schemaValidator:
           id: schemav2validator
           config:
+            type: url
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/tags/core-2.0.0-rc-eos-release/api/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"


### PR DESCRIPTION
Fixes #418.

## Why the node fails

Both plugins read values from config that this template does not set:

- `schemav2validator/cmd/plugin.go` returns `errors.New("location not configured")` when `location` is absent — the validator never initialises.
- `dediregistry/cmd/plugin.go` reads `config["url"]` with no fallback.

So a node started from `local-simple-bap.yaml` fails at the `validateSign` / `validateSchema` steps rather than coming up, which matches the reported symptom.

## Values

Rather than take the URLs from the issue verbatim, I matched **`devkits/p2p-trading-ies-wave1/config/local-p2p-bap.yaml`**, a working config in this repo that sets all three:

| Key | Value |
|---|---|
| `registry.url` | `https://fabric.nfh.global/registry/dedi` |
| `schemaValidator.type` | `url` |
| `schemaValidator.location` | `…/protocol-specifications-v2/tags/core-2.0.0-rc-eos-release/api/beckn.yaml` |

One deliberate difference from the issue: it proposed the schema at `…/main/api/v2.0.0/beckn.yaml`. Both that and the pinned tag return 200, but I used the **pinned tag** because that is what the working config uses and a `main` ref would drift when upstream moves. Happy to switch if you'd rather track `main`.

I also left `allowedNetworkIDs` untouched — the issue proposed adding `winroom-ies-data-exchange`, but the file has since changed and already carries `test-ies-data-sharing-network`, so that part appears to have been addressed separately.

Applied to both the `bapTxnReceiver` and `bapTxnCaller` modules. YAML validated.

## One thing worth flagging

**No other devkit config sets these keys either** — I checked all of them, and `registry.url`, `schemaValidator.type` and `schemaValidator.location` are absent everywhere except `local-p2p-bap.yaml`. So the other templates likely fail the same way. I kept this PR to the file named in the issue rather than changing configs I haven't been able to run, but it's probably worth a follow-up if you confirm the others are meant to be runnable as-is.
