### PR TITLE
feat(ledger-ui-client): date-range mode for the DISCOM trade report

### DIFF
--- a/devkits/p2p-trading-ies-ledger-ui-client/discom_trade_report.py
+++ b/devkits/p2p-trading-ies-ledger-ui-client/discom_trade_report.py
@@ -2,14 +2,28 @@
 """
 DISCOM Trade Report — WhatsApp-friendly summary of trades per DISCOM.
 
-Queries the DEG Ledger for trades involving configured DISCOMs whose
-delivery start time falls within the last 30 to last 2 days (midnight IST
-boundaries) and reports trade counts, allocation status, and pending
-trades by delivery day.
+Two modes:
+
+  Daily (default) — trades whose delivery start falls within the last 30 to
+  last 2 days (midnight IST boundaries), reported as counts, allocation
+  status, and pending trades by delivery day.
+
+  Range (--from/--to) — an arbitrary delivery window, reported as aligned
+  monospace tables: totals, per-DISCOM buy/sell/pending, per-platform
+  buy/sell/pending, and pending by month.
 
 Usage:
     python3 discom_trade_report.py
     python3 discom_trade_report.py --csv trades.csv
+    python3 discom_trade_report.py --fetch-days 300 --csv trades.csv
+
+    python3 discom_trade_report.py --from 2026-01-01 --to 2026-08-31
+    python3 discom_trade_report.py --from 2026-01-01 --to 2026-08-31 \
+        --pending-detail --csv trades.csv
+    python3 discom_trade_report.py --from 2026-04-01 --to 2026-06-30 \
+        --discoms BRPL,TPDDL --no-mono
+
+Both --from and --to are inclusive calendar dates in IST.
 
 Credentials and LEDGER_URL are read from .env (same as server.py).
 """
@@ -48,11 +62,34 @@ LEDGER_URL = os.environ.get("LEDGER_URL")
 EXPIRY_SECONDS = 300
 PAGE_SIZE = 500
 
-# ── Valid DISCOMs to track ──
+# ── Valid DISCOMs to track (override per run with --discoms) ──
 VALID_DISCOMS = ["PVVNL", "TPDDL", "BRPL"]
 
 # ── Number of top buyer/seller platforms to highlight ──
 TOP_PLATFORMS_N = 3
+
+# ── How far back the daily report fetches (override with --fetch-days) ──
+DEFAULT_FETCH_DAYS = 30
+
+# Short labels for the range-report platform tables. Subscriber IDs are too
+# long to stay aligned on a phone screen; anything not listed here is
+# truncated to PLATFORM_LABEL_WIDTH. Add entries as new platforms appear.
+PLATFORM_LABELS = {
+    "pulseenergy_interstate_p2p_test_bap.com": "PulseEnergy(tst)",
+    "pulseenergy_interstate_p2p_test_bpp.com": "PulseEnergy(tst)",
+    "bap.p2p.ies.kazam.energy": "Kazam",
+    "bpp.p2p.ies.kazam.energy": "Kazam",
+    "p2p-ies-bap-pulseenergy.io": "PulseEnergy",
+    "p2p-ies-bpp-pulseenergy.io": "PulseEnergy",
+    "dev-deg-bap.powerxchange.io": "PowerXchange",
+    "dev-deg-bpp.powerxchange.io": "PowerXchange",
+    "p2p.terrarexenergy.com": "TerrareX",
+    "bap.charzpe.com": "Charzpe",
+    "bpp.charzpe.com": "Charzpe",
+    "clickpower.in": "ClickPower",
+    "iris-cms.com": "Iris",
+}
+PLATFORM_LABEL_WIDTH = 16
 
 # ── IST timezone (UTC+05:30) ──
 IST = timezone(timedelta(hours=5, minutes=30))
@@ -243,30 +280,242 @@ def write_csv(trades, path):
     print(f"CSV written: {path} ({len(trades)} rows)", file=sys.stderr)
 
 
-def generate_report(csv_path=None):
-    """Fetch trades from ledger and print a WhatsApp-friendly DISCOM trade report."""
+def _platform_label(platform):
+    """Short, alignment-friendly label for a subscriber ID."""
+    label = PLATFORM_LABELS.get(platform, platform)
+    if len(label) > PLATFORM_LABEL_WIDTH:
+        label = label[: PLATFORM_LABEL_WIDTH - 1] + "…"
+    return label
+
+
+def _is_test_trade(trade):
+    """True if either side carries a TEST_* DISCOM placeholder."""
+    return (trade.get("discomIdBuyer") or "").startswith("TEST") or \
+           (trade.get("discomIdSeller") or "").startswith("TEST")
+
+
+def _side_pending(trade, discoms, buyer_side):
+    """True if this side's DISCOM is tracked and its allocation is not COMPLETED."""
+    discom_key = "discomIdBuyer" if buyer_side else "discomIdSeller"
+    status_key = "statusBuyerDiscom" if buyer_side else "statusSellerDiscom"
+    if trade.get(discom_key) not in discoms:
+        return False
+    return (trade.get(status_key) or "").upper() != "COMPLETED"
+
+
+def select_valid_trades(all_trades, discoms, start_key, end_key):
+    """Non-TEST trades touching a tracked DISCOM, delivered within [start, end]."""
+    valid = []
+    for trade in all_trades:
+        if _is_test_trade(trade):
+            continue
+        if trade.get("discomIdBuyer") not in discoms and \
+           trade.get("discomIdSeller") not in discoms:
+            continue
+        sort_key, _ = _delivery_date_key(trade)
+        if not (start_key <= sort_key <= end_key):
+            continue
+        valid.append(trade)
+    return valid
+
+
+def build_range_report(all_trades, start, end, discoms=None,
+                       pending_detail=False, monthly=False, mono=True):
+    """Build an aligned monospace trade report for an arbitrary delivery window.
+
+    Each trade is counted once per side whose DISCOM is tracked, so the buy and
+    sell columns sum above the unique trade total whenever both counterparties
+    are tracked DISCOMs.
+    """
+    discoms = list(discoms or VALID_DISCOMS)
+    start_key = start.strftime("%Y-%m-%d")
+    end_key = end.strftime("%Y-%m-%d")
+    valid = select_valid_trades(all_trades, discoms, start_key, end_key)
+
+    discom_stats = {d: {"buy": 0, "sell": 0, "kwh": 0.0, "pend": 0} for d in discoms}
+    buyer_platforms = defaultdict(lambda: {"trades": 0, "kwh": 0.0, "pend": 0})
+    seller_platforms = defaultdict(lambda: {"trades": 0, "kwh": 0.0, "pend": 0})
+    month_totals = defaultdict(lambda: {"trades": 0, "kwh": 0.0})
+    pending_months = defaultdict(int)
+    pending_cross = defaultdict(int)
+
+    total_kwh = 0.0
+    pending_trades = 0
+    pending_kwh = 0.0
+
+    for trade in valid:
+        energy = _get_energy(trade)
+        total_kwh += energy
+        month = _delivery_date_key(trade)[0][:7]
+        month_totals[month]["trades"] += 1
+        month_totals[month]["kwh"] += energy
+
+        buy_pending = _side_pending(trade, discoms, buyer_side=True)
+        sell_pending = _side_pending(trade, discoms, buyer_side=False)
+        if buy_pending or sell_pending:
+            pending_trades += 1
+            pending_kwh += energy
+            pending_months[month] += 1
+
+        buyer_discom = trade.get("discomIdBuyer")
+        if buyer_discom in discom_stats:
+            discom_stats[buyer_discom]["buy"] += 1
+            discom_stats[buyer_discom]["kwh"] += energy
+            discom_stats[buyer_discom]["pend"] += buy_pending
+
+        seller_discom = trade.get("discomIdSeller")
+        if seller_discom in discom_stats:
+            discom_stats[seller_discom]["sell"] += 1
+            discom_stats[seller_discom]["kwh"] += energy
+            discom_stats[seller_discom]["pend"] += sell_pending
+
+        buyer_app = trade.get("platformIdBuyer")
+        if buyer_app:
+            buyer_platforms[buyer_app]["trades"] += 1
+            buyer_platforms[buyer_app]["kwh"] += energy
+            buyer_platforms[buyer_app]["pend"] += buy_pending
+
+        seller_app = trade.get("platformIdSeller")
+        if seller_app:
+            seller_platforms[seller_app]["trades"] += 1
+            seller_platforms[seller_app]["kwh"] += energy
+            seller_platforms[seller_app]["pend"] += sell_pending
+
+        if sell_pending and seller_app:
+            pending_cross[("sell", seller_discom, seller_app)] += 1
+        if buy_pending and buyer_app:
+            pending_cross[("buy", buyer_discom, buyer_app)] += 1
+
+    lines = ["IES P2P TRADE REPORT",
+             f"Delivery: {start.strftime('%d %b %Y')} - {end.strftime('%d %b %Y')}"]
+
+    if valid:
+        first = min(_delivery_date_key(t)[0] for t in valid)
+        last = max(_delivery_date_key(t)[0] for t in valid)
+        if first != start_key or last != end_key:
+            lines.append(f"(first trade {_short_day(first)}, last {_short_day(last)})")
+    lines.append("")
+
+    lines.append(f"TOTAL VALID TRADES : {len(valid)}")
+    lines.append(f"TOTAL ENERGY       : {total_kwh:.0f} kWh")
+    lines.append(f"PENDING TRADES     : {pending_trades} ({pending_kwh:.0f} kWh)")
+
+    lines.append("")
+    lines.append("BY DISCOM")
+    lines.append(f"{'DISCOM':<8}{'Buy':>5}{'Sell':>7}{'kWh':>7}{'Pend':>6}")
+    for d in discoms:
+        s = discom_stats[d]
+        lines.append(f"{d:<8}{s['buy']:>5}{s['sell']:>7}{s['kwh']:>7.0f}{s['pend']:>6}")
+
+    def _platform_table(title, stats):
+        if not stats:
+            return
+        lines.append("")
+        lines.append(title)
+        header = f"{'Platform':<{PLATFORM_LABEL_WIDTH}}{'Trades':>7}{'kWh':>6}{'Pend':>6}"
+        lines.append(header)
+        ordered = sorted(stats.items(),
+                         key=lambda kv: (kv[1]["trades"], kv[1]["kwh"]), reverse=True)
+        for platform, ps in ordered:
+            lines.append(f"{_platform_label(platform):<{PLATFORM_LABEL_WIDTH}}"
+                         f"{ps['trades']:>7}{ps['kwh']:>6.0f}{ps['pend']:>6}")
+
+    _platform_table("SELLER PLATFORMS", seller_platforms)
+    _platform_table("BUYER PLATFORMS", buyer_platforms)
+
+    if monthly:
+        lines.append("")
+        lines.append("BY MONTH")
+        lines.append(f"{'Month':<10}{'Trades':>7}{'kWh':>7}")
+        for month in sorted(month_totals):
+            m = month_totals[month]
+            lines.append(f"{_short_month(month):<10}{m['trades']:>7}{m['kwh']:>7.0f}")
+
+    if pending_months:
+        lines.append("")
+        lines.append("PENDING BY MONTH")
+        for month in sorted(pending_months):
+            lines.append(f"{_short_month(month):<10}{pending_months[month]:>4}")
+
+    if pending_detail and pending_cross:
+        lines.append("")
+        lines.append("PENDING DETAIL (discom x platform)")
+        ordered = sorted(pending_cross.items(), key=lambda kv: -kv[1])
+        for (side, discom, platform), count in ordered:
+            tag = "sells" if side == "sell" else "buys "
+            lines.append(f"{discom:<7}{tag} {_platform_label(platform):<{PLATFORM_LABEL_WIDTH}}{count:>4}")
+
+    lines.append("")
+    lines.append("Note: DISCOM/platform rows count each")
+    lines.append("trade once per side, so columns sum")
+    lines.append(f"above {len(valid)}.")
+
+    report = "\n".join(lines)
+    if mono:
+        report = f"```\n{report}\n```"
+    return report
+
+
+def _short_day(sort_key):
+    """'2026-02-18' -> '18 Feb'."""
+    try:
+        return datetime.strptime(sort_key, "%Y-%m-%d").strftime("%d %b")
+    except ValueError:
+        return sort_key
+
+
+def _short_month(month_key):
+    """'2026-02' -> 'Feb 2026'."""
+    try:
+        return datetime.strptime(month_key, "%Y-%m").strftime("%b %Y")
+    except ValueError:
+        return month_key
+
+
+def _fetch_window(start, end_exclusive):
+    """Fetch every trade delivered in [start, end_exclusive) IST."""
     if not LEDGER_URL:
         print("Error: LEDGER_URL not set in .env or environment", file=sys.stderr)
         sys.exit(1)
 
     api_url = f"{LEDGER_URL.rstrip('/')}/ledger/get"
     private_key = _load_private_key()
+    start_utc = start.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    end_utc = end_exclusive.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
+    print(f"Fetching trades {start.strftime('%d %b %Y')} – "
+          f"{end_exclusive.strftime('%d %b %Y')} IST ...", file=sys.stderr)
+    return _fetch_all_trades(api_url, private_key, start_utc, end_utc)
+
+
+def generate_report(csv_path=None, fetch_days=DEFAULT_FETCH_DAYS):
+    """Fetch trades from ledger and print a WhatsApp-friendly DISCOM trade report."""
     # Date range: fetch covers both the historical report window (T-30 to T-2)
     # and the near-term trend window (T-1 to T+1), all at midnight IST.
     now_ist = datetime.now(IST)
     today_midnight = now_ist.replace(hour=0, minute=0, second=0, microsecond=0)
-    window_start = today_midnight - timedelta(days=30)
-    window_end = today_midnight - timedelta(days=2)  # exclusive
+    window_start = today_midnight - timedelta(days=fetch_days)
     trend_end = today_midnight + timedelta(days=2)   # exclusive; includes all of tomorrow
 
-    start_utc = window_start.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
-    end_utc = trend_end.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
-
-    print(f"Fetching trades {window_start.strftime('%d %b')} – {trend_end.strftime('%d %b %Y')} IST ...", file=sys.stderr)
-    all_trades = _fetch_all_trades(api_url, private_key, start_utc, end_utc)
+    all_trades = _fetch_window(window_start, trend_end)
 
     report = build_report(all_trades, now_ist)
+    print(report)
+
+    if csv_path:
+        write_csv(all_trades, csv_path)
+
+    return report
+
+
+def generate_range_report(start, end, csv_path=None, discoms=None,
+                          pending_detail=False, monthly=False, mono=True):
+    """Fetch and print a report for an arbitrary inclusive IST delivery window."""
+    all_trades = _fetch_window(start, end + timedelta(days=1))
+
+    report = build_range_report(all_trades, start, end, discoms=discoms,
+                                pending_detail=pending_detail,
+                                monthly=monthly, mono=mono)
     print(report)
 
     if csv_path:
@@ -403,8 +652,56 @@ def build_report(all_trades, now_ist):
     return report
 
 
+def _parse_ist_date(value):
+    try:
+        naive = datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected YYYY-MM-DD, got {value!r}")
+    return naive.replace(tzinfo=IST)
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="DISCOM Trade Report")
-    parser.add_argument("--csv", metavar="FILE", help="Optional path to write all trades as a CSV file")
+    parser = argparse.ArgumentParser(
+        description="DISCOM Trade Report",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Without --from/--to, reports the default rolling window "
+               "(delivery T-30 to T-2) as the daily WhatsApp summary.",
+    )
+    parser.add_argument("--csv", metavar="FILE",
+                        help="Also write every fetched trade to this CSV file")
+    parser.add_argument("--from", dest="date_from", metavar="YYYY-MM-DD",
+                        type=_parse_ist_date,
+                        help="Range mode: first delivery date, inclusive (IST)")
+    parser.add_argument("--to", dest="date_to", metavar="YYYY-MM-DD",
+                        type=_parse_ist_date,
+                        help="Range mode: last delivery date, inclusive (IST)")
+    parser.add_argument("--discoms", metavar="A,B,C",
+                        help=f"Comma-separated DISCOMs to track "
+                             f"(default: {','.join(VALID_DISCOMS)})")
+    parser.add_argument("--fetch-days", type=int, default=DEFAULT_FETCH_DAYS,
+                        metavar="N",
+                        help=f"Daily mode: how many days back to fetch, useful "
+                             f"for a wider --csv (default: {DEFAULT_FETCH_DAYS})")
+    parser.add_argument("--monthly", action="store_true",
+                        help="Range mode: add a trades-and-kWh-by-month table")
+    parser.add_argument("--pending-detail", action="store_true",
+                        help="Range mode: add a DISCOM x platform pending breakdown")
+    parser.add_argument("--no-mono", dest="mono", action="store_false",
+                        help="Range mode: omit the ``` fences used for WhatsApp")
     args = parser.parse_args()
-    generate_report(csv_path=args.csv)
+
+    discoms = [d.strip() for d in args.discoms.split(",") if d.strip()] \
+        if args.discoms else None
+
+    if args.date_from or args.date_to:
+        if not (args.date_from and args.date_to):
+            parser.error("--from and --to must be given together")
+        if args.date_to < args.date_from:
+            parser.error("--to must not be earlier than --from")
+        generate_range_report(args.date_from, args.date_to, csv_path=args.csv,
+                              discoms=discoms, pending_detail=args.pending_detail,
+                              monthly=args.monthly, mono=args.mono)
+    else:
+        if discoms:
+            VALID_DISCOMS = discoms
+        generate_report(csv_path=args.csv, fetch_days=args.fetch_days)

--- a/devkits/p2p-trading-ies-ledger-ui-client/discom_trade_report.py
+++ b/devkits/p2p-trading-ies-ledger-ui-client/discom_trade_report.py
@@ -71,16 +71,21 @@ TOP_PLATFORMS_N = 3
 # ── How far back the daily report fetches (override with --fetch-days) ──
 DEFAULT_FETCH_DAYS = 30
 
-# Short labels for the range-report platform tables. Subscriber IDs are too
-# long to stay aligned on a phone screen; anything not listed here is
-# truncated to PLATFORM_LABEL_WIDTH. Add entries as new platforms appear.
+# Display name per subscriber ID for the range-report platform tables.
+# Subscriber IDs sharing a name are summed into a single row, which is how a
+# platform running several subscribers (BAP/BPP pairs, staging and production,
+# rebranded hostnames) is reported as one platform.
+#
+# A subscriber ID that is not listed here is NOT dropped or shortened — it is
+# reported verbatim under its own row, so a newly onboarded platform shows up
+# as itself. Add it here once you know which platform it belongs to.
 PLATFORM_LABELS = {
-    "pulseenergy_interstate_p2p_test_bap.com": "PulseEnergy(tst)",
-    "pulseenergy_interstate_p2p_test_bpp.com": "PulseEnergy(tst)",
-    "bap.p2p.ies.kazam.energy": "Kazam",
-    "bpp.p2p.ies.kazam.energy": "Kazam",
+    "pulseenergy_interstate_p2p_test_bap.com": "PulseEnergy",
+    "pulseenergy_interstate_p2p_test_bpp.com": "PulseEnergy",
     "p2p-ies-bap-pulseenergy.io": "PulseEnergy",
     "p2p-ies-bpp-pulseenergy.io": "PulseEnergy",
+    "bap.p2p.ies.kazam.energy": "Kazam",
+    "bpp.p2p.ies.kazam.energy": "Kazam",
     "dev-deg-bap.powerxchange.io": "PowerXchange",
     "dev-deg-bpp.powerxchange.io": "PowerXchange",
     "p2p.terrarexenergy.com": "TerrareX",
@@ -89,7 +94,6 @@ PLATFORM_LABELS = {
     "clickpower.in": "ClickPower",
     "iris-cms.com": "Iris",
 }
-PLATFORM_LABEL_WIDTH = 16
 
 # ── IST timezone (UTC+05:30) ──
 IST = timezone(timedelta(hours=5, minutes=30))
@@ -281,11 +285,8 @@ def write_csv(trades, path):
 
 
 def _platform_label(platform):
-    """Short, alignment-friendly label for a subscriber ID."""
-    label = PLATFORM_LABELS.get(platform, platform)
-    if len(label) > PLATFORM_LABEL_WIDTH:
-        label = label[: PLATFORM_LABEL_WIDTH - 1] + "…"
-    return label
+    """Display name for a subscriber ID, or the ID verbatim if it has no alias."""
+    return PLATFORM_LABELS.get(platform, platform)
 
 
 def _is_test_trade(trade):
@@ -369,22 +370,26 @@ def build_range_report(all_trades, start, end, discoms=None,
             discom_stats[seller_discom]["kwh"] += energy
             discom_stats[seller_discom]["pend"] += sell_pending
 
+        # Keyed by display name, so a platform trading under several
+        # subscriber IDs is summed into a single row.
         buyer_app = trade.get("platformIdBuyer")
         if buyer_app:
-            buyer_platforms[buyer_app]["trades"] += 1
-            buyer_platforms[buyer_app]["kwh"] += energy
-            buyer_platforms[buyer_app]["pend"] += buy_pending
+            label = _platform_label(buyer_app)
+            buyer_platforms[label]["trades"] += 1
+            buyer_platforms[label]["kwh"] += energy
+            buyer_platforms[label]["pend"] += buy_pending
 
         seller_app = trade.get("platformIdSeller")
         if seller_app:
-            seller_platforms[seller_app]["trades"] += 1
-            seller_platforms[seller_app]["kwh"] += energy
-            seller_platforms[seller_app]["pend"] += sell_pending
+            label = _platform_label(seller_app)
+            seller_platforms[label]["trades"] += 1
+            seller_platforms[label]["kwh"] += energy
+            seller_platforms[label]["pend"] += sell_pending
 
         if sell_pending and seller_app:
-            pending_cross[("sell", seller_discom, seller_app)] += 1
+            pending_cross[("sell", seller_discom, _platform_label(seller_app))] += 1
         if buy_pending and buyer_app:
-            pending_cross[("buy", buyer_discom, buyer_app)] += 1
+            pending_cross[("buy", buyer_discom, _platform_label(buyer_app))] += 1
 
     lines = ["IES P2P TRADE REPORT",
              f"Delivery: {start.strftime('%d %b %Y')} - {end.strftime('%d %b %Y')}"]
@@ -410,14 +415,16 @@ def build_range_report(all_trades, start, end, discoms=None,
     def _platform_table(title, stats):
         if not stats:
             return
+        # Widen to the longest name present, so an un-aliased subscriber ID
+        # prints in full without knocking the columns out of alignment.
+        width = max([len("Platform")] + [len(name) for name in stats])
         lines.append("")
         lines.append(title)
-        header = f"{'Platform':<{PLATFORM_LABEL_WIDTH}}{'Trades':>7}{'kWh':>6}{'Pend':>6}"
-        lines.append(header)
+        lines.append(f"{'Platform':<{width}}{'Trades':>7}{'kWh':>6}{'Pend':>6}")
         ordered = sorted(stats.items(),
                          key=lambda kv: (kv[1]["trades"], kv[1]["kwh"]), reverse=True)
-        for platform, ps in ordered:
-            lines.append(f"{_platform_label(platform):<{PLATFORM_LABEL_WIDTH}}"
+        for name, ps in ordered:
+            lines.append(f"{name:<{width}}"
                          f"{ps['trades']:>7}{ps['kwh']:>6.0f}{ps['pend']:>6}")
 
     _platform_table("SELLER PLATFORMS", seller_platforms)
@@ -441,9 +448,10 @@ def build_range_report(all_trades, start, end, discoms=None,
         lines.append("")
         lines.append("PENDING DETAIL (discom x platform)")
         ordered = sorted(pending_cross.items(), key=lambda kv: -kv[1])
-        for (side, discom, platform), count in ordered:
+        width = max(len(name) for _, _, name in pending_cross)
+        for (side, discom, name), count in ordered:
             tag = "sells" if side == "sell" else "buys "
-            lines.append(f"{discom:<7}{tag} {_platform_label(platform):<{PLATFORM_LABEL_WIDTH}}{count:>4}")
+            lines.append(f"{discom:<7}{tag} {name:<{width}}{count:>4}")
 
     lines.append("")
     lines.append("Note: DISCOM/platform rows count each")


### PR DESCRIPTION
## What

`discom_trade_report.py` only ever covered a rolling T-30 to T-2 delivery window. Answering a question like "how did BRPL / PVVNL / TPDDL trade between January and August" meant editing the lookback constant in place and reading the exported CSV by hand.

This adds a **range mode** behind `--from` / `--to` (inclusive IST calendar dates):

```
python3 discom_trade_report.py --from 2026-01-01 --to 2026-08-31 --monthly --pending-detail
```

```
IES P2P TRADE REPORT
Delivery: 01 Jan 2026 - 31 Aug 2026
(first trade 18 Feb, last 19 Aug)

TOTAL VALID TRADES : 1597
TOTAL ENERGY       : 5772 kWh
PENDING TRADES     : 75 (239 kWh)

BY DISCOM
DISCOM    Buy   Sell    kWh  Pend
PVVNL       7   1197   3618    16
TPDDL     791    218   4553     8
BRPL      782    180   3309    55

SELLER PLATFORMS
Platform         Trades   kWh  Pend
PulseEnergy(tst)    786  2384    11
Kazam               393  2087    49
TerrareX            343   996     0
...
```

Output is fenced for WhatsApp by default, which is where these reports get pasted.

## Options

| Flag | Effect |
|---|---|
| `--from` / `--to` | Range mode; must be given together, `YYYY-MM-DD`, IST, both inclusive |
| `--discoms A,B,C` | Override the tracked DISCOM list (both modes) |
| `--monthly` | Add a trades-and-kWh-by-month table |
| `--pending-detail` | Add a DISCOM × platform pending cross-tab |
| `--no-mono` | Drop the ``` fences, for terminal or email |
| `--fetch-days N` | Daily mode lookback, replacing the hardcoded constant |
| `--csv FILE` | Unchanged |

## Notes for review

- **Daily mode is untouched.** Running with no arguments produces the same summary as before; any existing cron is unaffected. The fetch lookback that had to be edited by hand is now `DEFAULT_FETCH_DAYS` plus `--fetch-days`.
- **Pending is counted two ways, deliberately.** The `Pend` columns are per-side (a leg whose tracked DISCOM is not `COMPLETED`); the headline `PENDING TRADES` counts a trade once if either side is pending. For Jan–Aug that is 79 legs versus 75 unique trades.
- **`PLATFORM_LABELS`** maps each subscriber ID to a display name. IDs sharing a name are summed into one row, which is how a platform running several subscribers (BAP/BPP pairs, staging and production) reports as one platform — all four PulseEnergy IDs now collapse to a single row of 849 seller / 1168 buyer trades. An un-aliased ID is reported **verbatim** under its own row rather than dropped or truncated, so a newly onboarded platform is identifiable; columns size to the longest name present.
- Buy and sell columns sum above the unique trade total whenever both counterparties are tracked DISCOMs (1,578 of 1,597 for Jan–Aug). The report prints a footnote saying so.

## Testing

Run against the live ledger for 1 Jan – 31 Aug 2026:

- Range totals match an independent ad-hoc tally of the same 1,879 fetched records.
- No-argument run byte-for-byte matches the pre-change daily report.
- `--csv` verified in both modes; `--discoms` + `--no-mono` verified on a narrower window.
- Argument validation covered: `--from` without `--to`, `--to` before `--from`, and a malformed date all fail with a clear message.

