### PR TITLE
fix(ledger-ui-client): read trade allocations from validation metrics

### DIFF
--- a/devkits/p2p-trading-ies-ledger-ui-client/discom_trade_report.py
+++ b/devkits/p2p-trading-ies-ledger-ui-client/discom_trade_report.py
@@ -237,6 +237,35 @@ def _duration_hours(start_raw, end_raw):
         return ""
 
 
+def _metric(trade, side_key, metric_type):
+    """Verbatim validationMetricValue of the given type, or None."""
+    for m in trade.get(side_key) or []:
+        if m.get("validationMetricType") == metric_type:
+            return m.get("validationMetricValue")
+    return None
+
+
+def _get_allocation(trade, buyer_side):
+    """A side's allocated quantity, verbatim as the ledger reports it.
+
+    The ledger carries this as a fulfillment validation metric — ACTUAL_PULLED
+    on the buyer side, ACTUAL_PUSHED on the seller side — which is what the
+    dashboard reads. Some records also carry a flat buyerDiscomAllocation /
+    sellerDiscomAllocation mirror of the same number; it is used as a fallback
+    so a record that has only the flat field still reports an allocation.
+    """
+    if buyer_side:
+        side_key, metric_type, flat_key = (
+            "buyerFulfillmentValidationMetrics", "ACTUAL_PULLED", "buyerDiscomAllocation")
+    else:
+        side_key, metric_type, flat_key = (
+            "sellerFulfillmentValidationMetrics", "ACTUAL_PUSHED", "sellerDiscomAllocation")
+    value = _metric(trade, side_key, metric_type)
+    if value is None:
+        value = trade.get(flat_key)
+    return "" if value is None else value
+
+
 CSV_COLUMNS = [
     "Trade Time (IST)",
     "Delivery Start (IST)",
@@ -244,6 +273,7 @@ CSV_COLUMNS = [
     "Qty (KWH)",
     "Buyer Alloc",
     "Seller Alloc",
+    "Final Alloc",
     "Buyer Status",
     "Seller Status",
     "Buyer Discom",
@@ -271,8 +301,9 @@ def write_csv(trades, path):
                 "Delivery Start (IST)": _fmt_ist(start_raw),
                 "Duration (h)": _duration_hours(start_raw, end_raw),
                 "Qty (KWH)": f"{_get_energy(r):.2f}",
-                "Buyer Alloc": r.get("buyerDiscomAllocation", ""),
-                "Seller Alloc": r.get("sellerDiscomAllocation", ""),
+                "Buyer Alloc": _get_allocation(r, buyer_side=True),
+                "Seller Alloc": _get_allocation(r, buyer_side=False),
+                "Final Alloc": r.get("finalAllocation", "") if r.get("finalAllocation") is not None else "",
                 "Buyer Status": r.get("statusBuyerDiscom", ""),
                 "Seller Status": r.get("statusSellerDiscom", ""),
                 "Buyer Discom": r.get("discomIdBuyer", ""),


### PR DESCRIPTION
## Problem

`Buyer Alloc` and `Seller Alloc` were empty on every row of `discom_trade_report.py`'s CSV, even though the dashboard shows allocations for the same trades.

The CSV read them from flat `buyerDiscomAllocation` / `sellerDiscomAllocation` fields. Over a 400-day fetch (1904 records) only 23 records carry those fields — and all 23 are `TEST_DISCOM_BUYER`/`TEST_DISCOM_SELLER` placeholders, which `filter_reportable` drops. So the columns were structurally guaranteed to be blank in the report.

Production records carry the same number as a fulfillment validation metric:

```json
"buyerFulfillmentValidationMetrics":  [{"validationMetricType": "ACTUAL_PULLED", "validationMetricValue": "2.099"}],
"sellerFulfillmentValidationMetrics": [{"validationMetricType": "ACTUAL_PUSHED", "validationMetricValue": "2.099"}]
```

which is what `index.html` (`getBuyerDiscomAllocation` / `getSellerDiscomAllocation`) already reads. On the 23 records that carry both representations, metric and flat field agree exactly — 0 mismatches.

## Change

- `_get_allocation()` reads the side's metric (`ACTUAL_PULLED` / `ACTUAL_PUSHED`) and falls back to the flat field, so a record carrying only one of the two still reports.
- New `Final Alloc` column emits `finalAllocation` verbatim where the record has it, blank otherwise.
- Values are written verbatim — no rounding or reformatting.

## Verification

Against the 1904 records fetched from the live ledger:

| | before | after |
|---|---|---|
| reported rows | 1623 | 1623 |
| rows with Buyer Alloc | 0 | 1578 |
| rows with Seller Alloc | 0 | 1538 |
| rows with Final Alloc | n/a | 0 reported / 22 across the full fetch |

`Final Alloc` is 0 in the report because the only records currently carrying `finalAllocation` are the TEST placeholders that the report excludes; all 22 populate correctly and verbatim when the filter is lifted (`9.6` → `9.6`, `1.745455` → `1.745455`).