### PR TITLE
fix: add missing attributes.yaml to $ref fragment URLs

### DIFF
--- a/specification/schema/BecknPageInfo/v1.0/README.md
+++ b/specification/schema/BecknPageInfo/v1.0/README.md
@@ -50,7 +50,7 @@ properties:
     type: array
     items: { ... }
   pageInfo:
-    $ref: "https://schema.nfh.global/BecknPageInfo/v1.0#/components/schemas/BecknPageInfo"
+    $ref: "https://schema.nfh.global/BecknPageInfo/v1.0/attributes.yaml#/components/schemas/BecknPageInfo"
     description: Optional. Present only when the collection is paged.
 ```
 

--- a/specification/schema/BecknReportDescriptors/v1.0/attributes.yaml
+++ b/specification/schema/BecknReportDescriptors/v1.0/attributes.yaml
@@ -34,7 +34,7 @@ components:
         OpenADR3 `reportPayloadDescriptor` augmented with a `cardinality`
         field. Required fields and value enums otherwise match OpenADR3.
       allOf:
-        - $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/reportPayloadDescriptor"
+        - $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/reportPayloadDescriptor"
         - type: object
           properties:
             cardinality:

--- a/specification/schema/BecknResourceRef/v1.0/README.md
+++ b/specification/schema/BecknResourceRef/v1.0/README.md
@@ -62,7 +62,7 @@ properties:
     type: array
     items: { type: string }
   participatingMetersRef:
-    $ref: "https://schema.nfh.global/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+    $ref: "https://schema.nfh.global/BecknResourceRef/v1.0/attributes.yaml#/components/schemas/BecknResourceRef"
 ```
 
 ## Minimal example — bulk meter enrollment at confirm

--- a/specification/schema/BecknTimeSeries/v1.0/README.md
+++ b/specification/schema/BecknTimeSeries/v1.0/README.md
@@ -46,7 +46,7 @@ human readers.
 ```yaml
 # In the parent attributes.yaml
 telemetry:
-  $ref: "https://schema.nfh.global/BecknTimeSeries/v1.0#/components/schemas/BecknTimeSeries"
+  $ref: "https://schema.nfh.global/BecknTimeSeries/v1.0/attributes.yaml#/components/schemas/BecknTimeSeries"
 ```
 
 **(b) Discovery via `@context` — for polymorphic carriers.** Parent

--- a/specification/schema/BecknTimeSeries/v1.0/attributes.yaml
+++ b/specification/schema/BecknTimeSeries/v1.0/attributes.yaml
@@ -54,7 +54,7 @@ components:
             inline `$ref` from the parent schema.
 
         intervalPeriod:
-          $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/intervalPeriod"
+          $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/intervalPeriod"
           description: >
             Default temporal bounds of the series — ISO 8601 `start` and
             `duration`. An individual interval may override these.
@@ -73,13 +73,13 @@ components:
             — for telemetry/meter readings). The objectType field is the discriminator.
           items:
             oneOf:
-              - $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/eventPayloadDescriptor"
-              - $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/reportPayloadDescriptor"
+              - $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/eventPayloadDescriptor"
+              - $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/reportPayloadDescriptor"
             discriminator:
               propertyName: objectType
               mapping:
-                EVENT_PAYLOAD_DESCRIPTOR: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/eventPayloadDescriptor"
-                REPORT_PAYLOAD_DESCRIPTOR: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/reportPayloadDescriptor"
+                EVENT_PAYLOAD_DESCRIPTOR: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/eventPayloadDescriptor"
+                REPORT_PAYLOAD_DESCRIPTOR: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/reportPayloadDescriptor"
 
         intervals:
           type: array
@@ -89,7 +89,7 @@ components:
             typed `payloads` (valuesMap). Per-row `intervalPeriod` is
             optional and overrides the default.
           items:
-            $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/interval"
+            $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/interval"
 
         resourceName:
           type: string

--- a/specification/schema/CustomerDetails/v1.0/attributes.yaml
+++ b/specification/schema/CustomerDetails/v1.0/attributes.yaml
@@ -29,7 +29,7 @@ components:
   schemas:
 
     CustomerDetails:
-      $id: https://schema.nfh.global/CustomerDetails/v1.0#/components/schemas/CustomerDetails
+      $id: https://schema.nfh.global/CustomerDetails/v1.0/attributes.yaml#/components/schemas/CustomerDetails
       type: object
       description: >
         PII identity and address details for a utility customer.

--- a/specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexBuyOffer/v2.0/attributes.yaml
@@ -94,7 +94,7 @@ components:
                 / units / cardinality table (USAGE, POWER, SOC_END,
                 GPS_LAT, GPS_LON, …).
               oneOf:
-                - $ref: "https://schema.nfh.global/BecknReportDescriptors/v1.0#/components/schemas/BecknReportDescriptors"
+                - $ref: "https://schema.nfh.global/BecknReportDescriptors/v1.0/attributes.yaml#/components/schemas/BecknReportDescriptors"
                 - type: "null"
 
             participatingMetersRef:
@@ -105,7 +105,7 @@ components:
                 fetched body as the authoritative meter list once the
                 receiver has verified `contentHash` and `count` against
                 the body's canonicalized form.
-              $ref: "https://schema.nfh.global/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+              $ref: "https://schema.nfh.global/BecknResourceRef/v1.0/attributes.yaml#/components/schemas/BecknResourceRef"
 
             energyResources:
               type: array
@@ -121,7 +121,7 @@ components:
                 chargers, batteries, solar PV, smart HVAC, etc. —
                 shared with P2P-trading and any future DEG domain.
               items:
-                $ref: "https://schema.nfh.global/EnergyResource/v2.0#/components/schemas/EnergyResource"
+                $ref: "https://schema.nfh.global/EnergyResource/v2.0/attributes.yaml#/components/schemas/EnergyResource"
 
             energyResourcesRef:
               description: >
@@ -129,7 +129,7 @@ components:
                 cohort when it's too large to inline. Mutually
                 exclusive with `energyResources`. Same verification
                 rules as `participatingMetersRef`.
-              $ref: "https://schema.nfh.global/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+              $ref: "https://schema.nfh.global/BecknResourceRef/v1.0/attributes.yaml#/components/schemas/BecknResourceRef"
 
             participatingMetersDigest:
               type: object

--- a/specification/schema/DemandFlexNeed/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexNeed/v2.0/attributes.yaml
@@ -78,7 +78,7 @@ components:
             "@id": location
 
         intervalPeriod:
-          $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/intervalPeriod"
+          $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/intervalPeriod"
           description: >
             Default temporal bounds of the schedule — ISO 8601 `start` and
             `duration` (e.g. PT30M). Interval `id` 0..n-1 index sequential
@@ -99,7 +99,7 @@ components:
             CAPACITY_OFFERED (seller, on commitmentAttributes) and BASELINE /
             USAGE (meter telemetry).
           items:
-            $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/eventPayloadDescriptor"
+            $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/eventPayloadDescriptor"
           x-jsonld:
             "@id": payloadDescriptors
 
@@ -110,6 +110,6 @@ components:
             One row per tranche. Each row carries integer `id` and typed
             `payloads` — CAPACITY_REQUESTED, PRICE, SHORTFALL_PENALTY.
           items:
-            $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/interval"
+            $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/interval"
           x-jsonld:
             "@id": intervals

--- a/specification/schema/DemandFlexPerformance/v2.0/attributes.yaml
+++ b/specification/schema/DemandFlexPerformance/v2.0/attributes.yaml
@@ -63,7 +63,7 @@ components:
                 description: Meter identifier.
                 example: "der://meter/001"
               telemetry:
-                $ref: "https://schema.nfh.global/BecknTimeSeries/v1.0#/components/schemas/BecknTimeSeries"
+                $ref: "https://schema.nfh.global/BecknTimeSeries/v1.0/attributes.yaml#/components/schemas/BecknTimeSeries"
                 description: >
                   BecknTimeSeries carrying BASELINE (always) and — once the
                   event has completed — USAGE payloads, aligned to the same
@@ -82,7 +82,7 @@ components:
             entirely when the whole cohort fits in one message —
             absence of `pageInfo` is the signal that this message is
             self-contained.
-          $ref: "https://schema.nfh.global/BecknPageInfo/v1.0#/components/schemas/BecknPageInfo"
+          $ref: "https://schema.nfh.global/BecknPageInfo/v1.0/attributes.yaml#/components/schemas/BecknPageInfo"
 
         metersRef:
           description: >
@@ -93,4 +93,4 @@ components:
             entire collection. Receivers fetch `uri`, verify against
             `contentHash` and `count`, then run settlement against the
             fetched body.
-          $ref: "https://schema.nfh.global/BecknResourceRef/v1.0#/components/schemas/BecknResourceRef"
+          $ref: "https://schema.nfh.global/BecknResourceRef/v1.0/attributes.yaml#/components/schemas/BecknResourceRef"

--- a/specification/schema/ElectricityCredential/v1.0/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.0/attributes.yaml
@@ -72,7 +72,7 @@ components:
               x-jsonld:
                 "@id": deg:customerProfile
             customerDetails:
-              $ref: "https://schema.nfh.global/CustomerDetails/v1.0#/components/schemas/CustomerDetails"
+              $ref: "https://schema.nfh.global/CustomerDetails/v1.0/attributes.yaml#/components/schemas/CustomerDetails"
               description: >
                 PII section — fullName, installationAddress (beckn Location/2.0),
                 serviceConnectionDate. Defined in CustomerDetails/v1.0.
@@ -89,7 +89,7 @@ components:
               type: array
               minItems: 1
               items:
-                $ref: "https://schema.nfh.global/ConsumptionProfileCredential/v2.0#/components/schemas/ConsumptionProfileCredential/properties/credentialSubject"
+                $ref: "https://schema.nfh.global/ConsumptionProfileCredential/v2.0/attributes.yaml#/components/schemas/ConsumptionProfileCredential/properties/credentialSubject"
             generationProfiles:
               description: >
                 DER generation assets. Each entry conforms to the credentialSubject
@@ -101,7 +101,7 @@ components:
               type: array
               minItems: 1
               items:
-                $ref: "https://schema.nfh.global/GenerationProfileCredential/v2.0#/components/schemas/GenerationProfileCredential/properties/credentialSubject"
+                $ref: "https://schema.nfh.global/GenerationProfileCredential/v2.0/attributes.yaml#/components/schemas/GenerationProfileCredential/properties/credentialSubject"
             storageProfiles:
               description: >
                 Energy storage assets. Each entry conforms to the credentialSubject
@@ -112,4 +112,4 @@ components:
               type: array
               minItems: 1
               items:
-                $ref: "https://schema.nfh.global/StorageProfileCredential/v2.0#/components/schemas/StorageProfileCredential/properties/credentialSubject"
+                $ref: "https://schema.nfh.global/StorageProfileCredential/v2.0/attributes.yaml#/components/schemas/StorageProfileCredential/properties/credentialSubject"

--- a/specification/schema/ElectricityCredential/v1.1/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.1/attributes.yaml
@@ -104,7 +104,7 @@ components:
           x-jsonld:
             "@id": deg:customerNumber
         idRef:
-          $ref: "https://schema.nfh.global/IdRef/v1.0#/components/schemas/IdRef"
+          $ref: "https://schema.nfh.global/IdRef/v1.0/attributes.yaml#/components/schemas/IdRef"
           description: External identity reference for the customer. Defined in IdRef/v1.0.
           x-jsonld:
             "@id": deg:idRef
@@ -124,7 +124,7 @@ components:
           x-jsonld:
             "@id": deg:energyResources
           items:
-            $ref: "https://schema.nfh.global/EnergyResource/v2.0#/components/schemas/EnergyResource"
+            $ref: "https://schema.nfh.global/EnergyResource/v2.0/attributes.yaml#/components/schemas/EnergyResource"
         consumptionProfiles:
           type: array
           minItems: 1
@@ -139,14 +139,14 @@ components:
             $ref: "#/components/schemas/ConsumptionProfile"
 
     ConsumptionProfile:
-      $ref: "https://schema.nfh.global/MeterServiceProfile/v1.0#/components/schemas/MeterServiceProfile"
+      $ref: "https://schema.nfh.global/MeterServiceProfile/v1.0/attributes.yaml#/components/schemas/MeterServiceProfile"
       description: >
         Tariff and regulatory load profile for one meter connection.
         meterId links to a METER entry in customerProfile.energyResources[].
         Alias for MeterServiceProfile/v1.0 — kept for backward compatibility.
 
     CustomerDetails:
-      $ref: "https://schema.nfh.global/CustomerDetails/v1.0#/components/schemas/CustomerDetails"
+      $ref: "https://schema.nfh.global/CustomerDetails/v1.0/attributes.yaml#/components/schemas/CustomerDetails"
       description: >
         PII section — fullName, installationAddress, serviceConnectionDate.
         fullName appears ONLY here — never in customerProfile or resource entries.

--- a/specification/schema/ElectricityCredential/v1.2/attributes.yaml
+++ b/specification/schema/ElectricityCredential/v1.2/attributes.yaml
@@ -124,25 +124,25 @@ components:
             $ref: "#/components/schemas/ConsumptionProfile"
 
     IdRef:
-      $ref: "https://schema.nfh.global/IdRef/v1.0#/components/schemas/IdRef"
+      $ref: "https://schema.nfh.global/IdRef/v1.0/attributes.yaml#/components/schemas/IdRef"
       description: External identity reference for the customer. Defined in IdRef/v1.0.
 
     ConsumptionProfile:
-      $ref: "https://schema.nfh.global/MeterServiceProfile/v1.1#/components/schemas/MeterServiceProfile"
+      $ref: "https://schema.nfh.global/MeterServiceProfile/v1.1/attributes.yaml#/components/schemas/MeterServiceProfile"
       description: >
         Tariff and regulatory load profile for one meter connection.
         meterId links to a METER entry in customerProfile.energyResources[].
         Uses MeterServiceProfile/v1.1 (sanctionedLoad, contractMaxDemand as QuantitativeValue).
 
     CustomerDetails:
-      $ref: "https://schema.nfh.global/CustomerDetails/v1.0#/components/schemas/CustomerDetails"
+      $ref: "https://schema.nfh.global/CustomerDetails/v1.0/attributes.yaml#/components/schemas/CustomerDetails"
       description: >
         PII section — fullName, installationAddress, serviceConnectionDate.
         fullName appears ONLY here — never in customerProfile or resource entries.
         Defined in CustomerDetails/v1.0.
 
     EnergyResource:
-      $ref: "https://schema.nfh.global/EnergyResource/v2.1#/components/schemas/EnergyResource"
+      $ref: "https://schema.nfh.global/EnergyResource/v2.1/attributes.yaml#/components/schemas/EnergyResource"
       description: >
         Discriminated union of all seven typed EnergyResource kinds, each
         inheriting id, type, subResources, parentResources, and attributes

--- a/specification/schema/EnergyCustomerProfile/v1.0/attributes.yaml
+++ b/specification/schema/EnergyCustomerProfile/v1.0/attributes.yaml
@@ -44,6 +44,6 @@ components:
             - Other
           description: Type of electricity meter installed.
         idRef:
-          $ref: "https://schema.nfh.global/IdRef/v1.0#/components/schemas/IdRef"
+          $ref: "https://schema.nfh.global/IdRef/v1.0/attributes.yaml#/components/schemas/IdRef"
           description: External identity reference for the customer. Defined in IdRef/v1.0.
       additionalProperties: false

--- a/specification/schema/EnergyResource/v2.0/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.0/attributes.yaml
@@ -38,25 +38,25 @@ components:
     # directly by the kind schemas — not re-aliased here.
 
     EnergyResourceMeter:
-      $ref: "https://schema.nfh.global/EnergyResourceMeter/v1.0#/components/schemas/EnergyResourceMeter"
+      $ref: "https://schema.nfh.global/EnergyResourceMeter/v1.0/attributes.yaml#/components/schemas/EnergyResourceMeter"
 
     EnergyResourceGenerator:
-      $ref: "https://schema.nfh.global/EnergyResourceGenerator/v1.0#/components/schemas/EnergyResourceGenerator"
+      $ref: "https://schema.nfh.global/EnergyResourceGenerator/v1.0/attributes.yaml#/components/schemas/EnergyResourceGenerator"
 
     EnergyResourceStorage:
-      $ref: "https://schema.nfh.global/EnergyResourceStorage/v1.0#/components/schemas/EnergyResourceStorage"
+      $ref: "https://schema.nfh.global/EnergyResourceStorage/v1.0/attributes.yaml#/components/schemas/EnergyResourceStorage"
 
     EnergyResourceEVCharger:
-      $ref: "https://schema.nfh.global/EnergyResourceEVCharger/v1.0#/components/schemas/EnergyResourceEVCharger"
+      $ref: "https://schema.nfh.global/EnergyResourceEVCharger/v1.0/attributes.yaml#/components/schemas/EnergyResourceEVCharger"
 
     EnergyResourceInverter:
-      $ref: "https://schema.nfh.global/EnergyResourceInverter/v1.0#/components/schemas/EnergyResourceInverter"
+      $ref: "https://schema.nfh.global/EnergyResourceInverter/v1.0/attributes.yaml#/components/schemas/EnergyResourceInverter"
 
     EnergyResourceLoad:
-      $ref: "https://schema.nfh.global/EnergyResourceLoad/v1.0#/components/schemas/EnergyResourceLoad"
+      $ref: "https://schema.nfh.global/EnergyResourceLoad/v1.0/attributes.yaml#/components/schemas/EnergyResourceLoad"
 
     EnergyResourceNetwork:
-      $ref: "https://schema.nfh.global/EnergyResourceNetwork/v1.0#/components/schemas/EnergyResourceNetwork"
+      $ref: "https://schema.nfh.global/EnergyResourceNetwork/v1.0/attributes.yaml#/components/schemas/EnergyResourceNetwork"
 
     # ── Union entry point ─────────────────────────────────────────────────
 

--- a/specification/schema/EnergyResource/v2.1/attributes.yaml
+++ b/specification/schema/EnergyResource/v2.1/attributes.yaml
@@ -25,25 +25,25 @@ components:
   schemas:
 
     EnergyResourceMeter:
-      $ref: "https://schema.nfh.global/EnergyResourceMeter/v1.1#/components/schemas/EnergyResourceMeter"
+      $ref: "https://schema.nfh.global/EnergyResourceMeter/v1.1/attributes.yaml#/components/schemas/EnergyResourceMeter"
 
     EnergyResourceGenerator:
-      $ref: "https://schema.nfh.global/EnergyResourceGenerator/v1.1#/components/schemas/EnergyResourceGenerator"
+      $ref: "https://schema.nfh.global/EnergyResourceGenerator/v1.1/attributes.yaml#/components/schemas/EnergyResourceGenerator"
 
     EnergyResourceStorage:
-      $ref: "https://schema.nfh.global/EnergyResourceStorage/v1.1#/components/schemas/EnergyResourceStorage"
+      $ref: "https://schema.nfh.global/EnergyResourceStorage/v1.1/attributes.yaml#/components/schemas/EnergyResourceStorage"
 
     EnergyResourceEVCharger:
-      $ref: "https://schema.nfh.global/EnergyResourceEVCharger/v1.1#/components/schemas/EnergyResourceEVCharger"
+      $ref: "https://schema.nfh.global/EnergyResourceEVCharger/v1.1/attributes.yaml#/components/schemas/EnergyResourceEVCharger"
 
     EnergyResourceInverter:
-      $ref: "https://schema.nfh.global/EnergyResourceInverter/v1.1#/components/schemas/EnergyResourceInverter"
+      $ref: "https://schema.nfh.global/EnergyResourceInverter/v1.1/attributes.yaml#/components/schemas/EnergyResourceInverter"
 
     EnergyResourceLoad:
-      $ref: "https://schema.nfh.global/EnergyResourceLoad/v1.1#/components/schemas/EnergyResourceLoad"
+      $ref: "https://schema.nfh.global/EnergyResourceLoad/v1.1/attributes.yaml#/components/schemas/EnergyResourceLoad"
 
     EnergyResourceNetwork:
-      $ref: "https://schema.nfh.global/EnergyResourceNetwork/v1.1#/components/schemas/EnergyResourceNetwork"
+      $ref: "https://schema.nfh.global/EnergyResourceNetwork/v1.1/attributes.yaml#/components/schemas/EnergyResourceNetwork"
 
     EnergyResource:
       description: >

--- a/specification/schema/EnergyResourceCommon/v1.0/README.md
+++ b/specification/schema/EnergyResourceCommon/v1.0/README.md
@@ -44,7 +44,7 @@ The attribute bag base inherited inside every kind's `<Kind>Attributes` object v
 ```yaml
 EnergyResourceMeter:
   allOf:
-    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
     - type: object
       properties:
         type:
@@ -58,7 +58,7 @@ EnergyResourceMeter:
 ```yaml
 EnergyResourceMeterAttributes:
   allOf:
-    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
     - type: object
       additionalProperties: true
       properties:

--- a/specification/schema/EnergyResourceCommon/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceCommon/v1.0/attributes.yaml
@@ -31,7 +31,7 @@ components:
     # ── Attribute bag base — inherited by every kind's attributes object ──
 
     EnergyResourceCommonAttributes:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes
       type: object
       additionalProperties: true
       description: >
@@ -111,7 +111,7 @@ components:
     # ── Structural envelope — inherited by every kind schema ─────────────
 
     EnergyResourceCommon:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon
       type: object
       additionalProperties: true
       description: >
@@ -149,7 +149,7 @@ components:
             oneOf:
               - type: string
                 description: id of a sibling EnergyResource.
-              - $ref: "https://schema.nfh.global/EnergyResource/v2.0#/components/schemas/EnergyResource"
+              - $ref: "https://schema.nfh.global/EnergyResource/v2.0/attributes.yaml#/components/schemas/EnergyResource"
                 description: Inline-nested EnergyResource.
           x-jsonld:
             "@id": deg:subResources

--- a/specification/schema/EnergyResourceCommon/v1.0/schema.json
+++ b/specification/schema/EnergyResourceCommon/v1.0/schema.json
@@ -41,7 +41,7 @@
           "items": {
             "oneOf": [
               { "type": "string", "minLength": 1 },
-              { "$ref": "https://schema.nfh.global/EnergyResource/v2.0#/components/schemas/EnergyResource" }
+              { "$ref": "https://schema.nfh.global/EnergyResource/v2.0/attributes.yaml#/components/schemas/EnergyResource" }
             ]
           }
         },

--- a/specification/schema/EnergyResourceCommon/v1.1/README.md
+++ b/specification/schema/EnergyResourceCommon/v1.1/README.md
@@ -69,7 +69,7 @@ The attribute bag base inherited inside every kind's `<Kind>Attributes` object v
 ```yaml
 EnergyResourceMeter:
   allOf:
-    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
     - type: object
       properties:
         type:
@@ -83,7 +83,7 @@ EnergyResourceMeter:
 ```yaml
 EnergyResourceMeterAttributes:
   allOf:
-    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+    - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
     - type: object
       additionalProperties: true
       properties:

--- a/specification/schema/EnergyResourceCommon/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceCommon/v1.1/attributes.yaml
@@ -37,7 +37,7 @@ components:
   schemas:
 
     QuantitativeValue:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QuantitativeValue
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QuantitativeValue
       type: object
       description: >
         A dimensioned quantity. value is the numeric magnitude; unit is a QUDT
@@ -58,7 +58,7 @@ components:
             V, kV (voltage). Mapped to QUDT IRIs via JSON-LD context.
 
     QVPower:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVPower
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVPower
       type: object
       description: >
         Active-power quantity {value, unit}. unit is a QUDT power alias
@@ -73,7 +73,7 @@ components:
           enum: [W, kW, MW]
 
     QVEnergy:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVEnergy
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVEnergy
       type: object
       description: >
         Energy quantity {value, unit}. unit is a QUDT energy alias
@@ -89,7 +89,7 @@ components:
           enum: [kWh, MWh]
 
     QVApparentPower:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVApparentPower
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVApparentPower
       type: object
       description: >
         Apparent-power quantity {value, unit}. unit is a QUDT apparent-power
@@ -105,7 +105,7 @@ components:
           enum: [kVA, MVA]
 
     QVReactivePower:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVReactivePower
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVReactivePower
       type: object
       description: >
         Reactive-power quantity {value, unit}. unit is a QUDT reactive-power
@@ -121,7 +121,7 @@ components:
           enum: [kVAR, MVAR]
 
     QVVoltage:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVVoltage
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVVoltage
       type: object
       description: >
         Voltage quantity {value, unit}. unit is a QUDT voltage alias
@@ -137,7 +137,7 @@ components:
           enum: [V, kV]
 
     EnergyResourceCommonAttributes:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes
       type: object
       additionalProperties: true
       description: >
@@ -278,7 +278,7 @@ components:
             "@id": deg:aggregator
 
     EnergyResourceCommon:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon
       type: object
       additionalProperties: true
       description: >
@@ -314,7 +314,7 @@ components:
           items:
             oneOf:
               - type: string
-              - $ref: "https://schema.nfh.global/EnergyResource/v2.1#/components/schemas/EnergyResource"
+              - $ref: "https://schema.nfh.global/EnergyResource/v2.1/attributes.yaml#/components/schemas/EnergyResource"
           x-jsonld:
             "@id": deg:subResources
 

--- a/specification/schema/EnergyResourceCommon/v1.1/schema.json
+++ b/specification/schema/EnergyResourceCommon/v1.1/schema.json
@@ -111,7 +111,7 @@
           "items": {
             "oneOf": [
               { "type": "string", "minLength": 1 },
-              { "$ref": "https://schema.nfh.global/EnergyResource/v2.1#/components/schemas/EnergyResource" }
+              { "$ref": "https://schema.nfh.global/EnergyResource/v2.1/attributes.yaml#/components/schemas/EnergyResource" }
             ]
           }
         },

--- a/specification/schema/EnergyResourceEVCharger/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceEVCharger/v1.0/attributes.yaml
@@ -39,7 +39,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceEVCharger
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -65,7 +65,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceEVCharger/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceEVCharger/v1.1/attributes.yaml
@@ -21,7 +21,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceEVCharger
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -44,7 +44,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceGenerator/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceGenerator/v1.0/attributes.yaml
@@ -38,7 +38,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceGenerator
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -73,7 +73,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceGenerator/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceGenerator/v1.1/attributes.yaml
@@ -27,7 +27,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceGenerator
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -48,13 +48,13 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:
 
             nominalPower:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVPower"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVPower"
               description: >
                 Nominal (nameplate) power output. Use when distinct from
                 maxExport (peak).
@@ -73,7 +73,7 @@ components:
                 "@id": erDeg:efficiency
 
             dcArrayCapacity:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVPower"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVPower"
               description: >
                 DC-side nameplate capacity of a photovoltaic array at Standard
                 Test Conditions (industry term: "kWp"). For PV systems this is

--- a/specification/schema/EnergyResourceInverter/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceInverter/v1.0/attributes.yaml
@@ -41,7 +41,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceInverter
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -66,7 +66,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceInverter/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceInverter/v1.1/attributes.yaml
@@ -24,7 +24,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceInverter
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -47,13 +47,13 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:
 
             ratedApparentPower:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVApparentPower"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVApparentPower"
               description: >
                 Rated apparent power. Replaces ratedApparentPowerKva from v1.0.
               x-standard: "SunSpec DER Model 702 (maxVA); CIM (IEC 61970-302 PowerElectronicsConnection.ratedS)"
@@ -61,7 +61,7 @@ components:
                 "@id": erDeg:ratedApparentPower
 
             maxReactivePower:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVReactivePower"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVReactivePower"
               description: >
                 Maximum reactive power injection (leading / over-excited).
                 Replaces maxReactivePowerKvar from v1.0.
@@ -70,7 +70,7 @@ components:
                 "@id": erDeg:maxReactivePower
 
             minReactivePower:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVReactivePower"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVReactivePower"
               description: >
                 Maximum reactive power absorption (lagging / under-excited).
                 Value is typically negative. Replaces minReactivePowerKvar from v1.0.

--- a/specification/schema/EnergyResourceLoad/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceLoad/v1.0/attributes.yaml
@@ -37,7 +37,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceLoad
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -65,7 +65,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceLoad/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceLoad/v1.1/attributes.yaml
@@ -20,7 +20,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceLoad
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -42,7 +42,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceMeter/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceMeter/v1.0/attributes.yaml
@@ -32,7 +32,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceMeter
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -57,7 +57,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceMeter/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceMeter/v1.1/attributes.yaml
@@ -20,7 +20,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceMeter
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -41,7 +41,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceNetwork/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceNetwork/v1.0/attributes.yaml
@@ -38,7 +38,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceNetwork
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -68,7 +68,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceNetwork/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceNetwork/v1.1/attributes.yaml
@@ -22,7 +22,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceNetwork
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -46,13 +46,13 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:
 
             nominalVoltage:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVVoltage"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVVoltage"
               description: >
                 Nominal operating voltage. Replaces nominalVoltageKv from v1.0.
               x-standard: "CIM (IEC 61970-301 BaseVoltage.nominalVoltage)"

--- a/specification/schema/EnergyResourceStorage/v1.0/attributes.yaml
+++ b/specification/schema/EnergyResourceStorage/v1.0/attributes.yaml
@@ -38,7 +38,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceStorage
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -67,7 +67,7 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.0/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:

--- a/specification/schema/EnergyResourceStorage/v1.1/attributes.yaml
+++ b/specification/schema/EnergyResourceStorage/v1.1/attributes.yaml
@@ -27,7 +27,7 @@ components:
         "@context": ./context.jsonld
         "@type": EnergyResourceStorage
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommon"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommon"
         - type: object
           required: [id, type]
           properties:
@@ -51,13 +51,13 @@ components:
       x-jsonld:
         "@id": erDeg:attributes
       allOf:
-        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/EnergyResourceCommonAttributes"
+        - $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/EnergyResourceCommonAttributes"
         - type: object
           additionalProperties: true
           properties:
 
             storageCapacity:
-              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVEnergy"
+              $ref: "https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVEnergy"
               description: >
                 Rated stored-energy capacity. Replaces storageCapacityKwh from v1.0.
               x-standard: "CIM (IEC 61970-302 BatteryUnit.ratedE)"

--- a/specification/schema/MeterServiceProfile/v1.0/attributes.yaml
+++ b/specification/schema/MeterServiceProfile/v1.0/attributes.yaml
@@ -24,7 +24,7 @@ components:
   schemas:
 
     MeterServiceProfile:
-      $id: https://schema.nfh.global/MeterServiceProfile/v1.0#/components/schemas/MeterServiceProfile
+      $id: https://schema.nfh.global/MeterServiceProfile/v1.0/attributes.yaml#/components/schemas/MeterServiceProfile
       type: object
       description: >
         Tariff and regulatory load profile for one meter connection point.

--- a/specification/schema/MeterServiceProfile/v1.1/attributes.yaml
+++ b/specification/schema/MeterServiceProfile/v1.1/attributes.yaml
@@ -30,7 +30,7 @@ components:
   schemas:
 
     QVPower:
-      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1#/components/schemas/QVPower
+      $id: https://schema.nfh.global/EnergyResourceCommon/v1.1/attributes.yaml#/components/schemas/QVPower
       type: object
       description: >
         Active-power quantity {value, unit}. unit is a QUDT power alias
@@ -45,7 +45,7 @@ components:
           enum: [W, kW, MW]
 
     MeterServiceProfile:
-      $id: https://schema.nfh.global/MeterServiceProfile/v1.1#/components/schemas/MeterServiceProfile
+      $id: https://schema.nfh.global/MeterServiceProfile/v1.1/attributes.yaml#/components/schemas/MeterServiceProfile
       type: object
       description: >
         Tariff and regulatory load profile for one meter connection point.

--- a/specification/schema/openadr/v3.1.0/README.md
+++ b/specification/schema/openadr/v3.1.0/README.md
@@ -40,7 +40,7 @@ DEG schemas reference these types via the canonical `schema.nfh.global` URL:
 
 ```yaml
 intervalPeriod:
-  $ref: "https://schema.nfh.global/openadr/v3.1.0#/components/schemas/intervalPeriod"
+  $ref: "https://schema.nfh.global/openadr/v3.1.0/attributes.yaml#/components/schemas/intervalPeriod"
 ```
 
 `BecknTimeSeries` uses `interval`, `intervalPeriod`, `eventPayloadDescriptor`,


### PR DESCRIPTION
## Summary
105 \`\$ref\`s across 38 \`attributes.yaml\` files pointed fragment references (\`#/components/schemas/X\`) at a bare version-folder URL instead of the \`attributes.yaml\` file that actually holds \`components.schemas\` — e.g. \`.../BecknResourceRef/v1.0#/components/schemas/BecknResourceRef\` instead of \`.../BecknResourceRef/v1.0/attributes.yaml#/components/schemas/BecknResourceRef\`. Includes the vendored \`openadr/v3.1.0\` (3-part version) refs too.

The old \`schema.beckn.io\` app apparently auto-resolved a bare version-folder URL to \`attributes.yaml\`'s content, but the static replacement (\`schema-aggregator\`, served on GitHub Pages) has no such behavior — hitting the bare URL now returns schema-browser's HTML documentation page instead of YAML.

## Test plan
- [x] Automated before/after scan: bug-pattern occurrences 105 → 0
- [x] Diff audit: every changed line only gains \`attributes.yaml\` — no unrelated content touched
- [x] JSON/YAML syntax validation passes on all 38 changed files
- [x] Live-verified: \`schema.nfh.global/openadr/v3.1.0\` returns \`text/html\`; \`schema.nfh.global/openadr/v3.1.0/attributes.yaml\` returns \`text/yaml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)